### PR TITLE
feat(envelopes): sender can cancel sent envelopes

### DIFF
--- a/apps/api/db/migrations/0006_event_type_cancel.sql
+++ b/apps/api/db/migrations/0006_event_type_cancel.sql
@@ -1,0 +1,6 @@
+-- 0006_event_type_cancel.sql
+-- Add 'session_invalidated_by_cancel' to the envelope event_type enum so the
+-- sender-initiated /envelopes/:id/cancel flow can append per-signer audit
+-- events that mirror the /sign/:id/decline path's session_invalidated_by_decline.
+
+alter type event_type add value if not exists 'session_invalidated_by_cancel';

--- a/apps/api/db/schema.ts
+++ b/apps/api/db/schema.ts
@@ -49,6 +49,7 @@ export type EventTypeDb =
   | 'canceled'
   | 'reminder_sent'
   | 'session_invalidated_by_decline'
+  | 'session_invalidated_by_cancel'
   | 'job_failed'
   | 'retention_deleted';
 export type JobKindDb = 'seal' | 'audit_only';

--- a/apps/api/src/envelopes/envelopes.controller.ts
+++ b/apps/api/src/envelopes/envelopes.controller.ts
@@ -135,6 +135,24 @@ export class EnvelopesController {
     );
   }
 
+  /**
+   * Sender-initiated cancel ("withdraw") of a sent envelope. Allowed only
+   * on `awaiting_others` and `sealing` — terminal statuses surface as 409.
+   * On success the envelope flips to `canceled`, pending access tokens are
+   * revoked, and withdrawal emails fan out to every still-relevant signer.
+   */
+  @Post(':id/cancel')
+  cancel(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Req() req: Request,
+  ): Promise<{ status: 'canceled'; envelope_status: 'canceled' }> {
+    return this.svc.cancel(user.id, id, {
+      ip: extractClientIp(req),
+      user_agent: req.headers['user-agent'] ?? null,
+    });
+  }
+
   @Post(':id/signers/:signer_id/remind')
   @HttpCode(202)
   async remindSigner(

--- a/apps/api/src/envelopes/envelopes.repository.pg.ts
+++ b/apps/api/src/envelopes/envelopes.repository.pg.ts
@@ -826,6 +826,74 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
     });
   }
 
+  async cancelEnvelope(
+    envelope_id: string,
+    owner_id: string,
+  ): Promise<{
+    readonly envelope: Envelope;
+    readonly notifiedSignerIds: ReadonlyArray<string>;
+    readonly alreadySignedSignerIds: ReadonlyArray<string>;
+  } | null> {
+    return this.db.transaction().execute(async (trx) => {
+      // Lock the envelope row first so a concurrent /decline or /submit
+      // can't race the status flip mid-transaction. pg-mem ignores FOR
+      // UPDATE but real Postgres respects it; the row-conditional UPDATE
+      // below is the actual safety net for either backend.
+      const env = await trx
+        .selectFrom('envelopes')
+        .selectAll()
+        .where('id', '=', envelope_id)
+        .forUpdate()
+        .executeTakeFirst();
+      if (!env) return null;
+      if (env.owner_id !== owner_id) return null;
+      if (env.status !== 'awaiting_others' && env.status !== 'sealing') return null;
+
+      const now = new Date().toISOString();
+      const updated = await trx
+        .updateTable('envelopes')
+        .set({ status: 'canceled', updated_at: now })
+        .where('id', '=', envelope_id)
+        .where('owner_id', '=', owner_id)
+        .where('status', 'in', ['awaiting_others', 'sealing'])
+        .executeTakeFirst();
+      if ((updated?.numUpdatedRows ?? 0n) === 0n) return null;
+
+      // Revoke pending access tokens. Signers who've already signed or
+      // declined keep their token history intact for the audit PDF.
+      await trx
+        .updateTable('envelope_signers')
+        .set({ access_token_hash: null })
+        .where('envelope_id', '=', envelope_id)
+        .where('signed_at', 'is', null)
+        .where('declined_at', 'is', null)
+        .execute();
+
+      const signerRows = await trx
+        .selectFrom('envelope_signers')
+        .select(['id', 'signed_at', 'declined_at'])
+        .where('envelope_id', '=', envelope_id)
+        .execute();
+      const notifiedSignerIds: string[] = [];
+      const alreadySignedSignerIds: string[] = [];
+      for (const s of signerRows) {
+        if (s.signed_at !== null) {
+          alreadySignedSignerIds.push(s.id);
+        } else if (s.declined_at === null) {
+          // Pending (not signed, not declined) — they need the
+          // "withdrawn_to_signer" notification.
+          notifiedSignerIds.push(s.id);
+        }
+        // Already-declined signers get nothing — the decline flow already
+        // notified them via session_invalidated_by_decline.
+      }
+
+      const envelope = await this.findByIdWithAllTrx(trx, envelope_id);
+      if (!envelope) return null;
+      return { envelope, notifiedSignerIds, alreadySignedSignerIds };
+    });
+  }
+
   async expireEnvelopes(now: Date, limit: number): Promise<ReadonlyArray<string>> {
     // pg-mem does not support UPDATE ... LIMIT, so we select-then-update.
     // On real Postgres this is also safe: the SELECT lists candidates and

--- a/apps/api/src/envelopes/envelopes.repository.ts
+++ b/apps/api/src/envelopes/envelopes.repository.ts
@@ -166,6 +166,7 @@ export interface EventInput {
     | 'canceled'
     | 'reminder_sent'
     | 'session_invalidated_by_decline'
+    | 'session_invalidated_by_cancel'
     | 'job_failed'
     | 'retention_deleted';
   readonly ip?: string | null;
@@ -260,6 +261,30 @@ export abstract class EnvelopesRepository {
     ip: string | null,
     user_agent: string | null,
   ): Promise<Envelope | null>;
+
+  /**
+   * Sender-initiated cancel. Atomically flips an envelope from
+   * `awaiting_others` or `sealing` → `canceled` and revokes any pending
+   * signer access tokens (NULLs `access_token_hash` so a previously-sent
+   * `/sign/start` request returns 401). Returns null when the row is
+   * missing, owner mismatch, or status was not in the cancelable set —
+   * the service re-reads to disambiguate 404 vs 409.
+   *
+   * Returned signer-id splits drive the email fan-out:
+   *   - `notifiedSignerIds` — signers who hadn't signed yet → enqueue
+   *      `withdrawn_to_signer` (link is dead, no action needed).
+   *   - `alreadySignedSignerIds` — signers who completed before cancel
+   *      → enqueue `withdrawn_after_sign` (their copy + audit retained).
+   */
+  abstract cancelEnvelope(
+    envelope_id: string,
+    owner_id: string,
+  ): Promise<{
+    readonly envelope: Envelope;
+    readonly notifiedSignerIds: ReadonlyArray<string>;
+    readonly alreadySignedSignerIds: ReadonlyArray<string>;
+  } | null>;
+
   abstract expireEnvelopes(now: Date, limit: number): Promise<ReadonlyArray<string>>;
 
   // Audit

--- a/apps/api/src/envelopes/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/envelopes.service.spec.ts
@@ -329,6 +329,28 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
   async declineSigner(): Promise<Envelope | null> {
     throw new Error('not_implemented_in_fake');
   }
+  async cancelEnvelope(
+    envelope_id: string,
+    owner_id: string,
+  ): Promise<{
+    readonly envelope: Envelope;
+    readonly notifiedSignerIds: readonly string[];
+    readonly alreadySignedSignerIds: readonly string[];
+  } | null> {
+    const env = this.envelopes.get(envelope_id);
+    if (!env) return null;
+    if (env.owner_id !== owner_id) return null;
+    if (env.status !== 'awaiting_others' && env.status !== 'sealing') return null;
+    const notifiedSignerIds: string[] = [];
+    const alreadySignedSignerIds: string[] = [];
+    for (const s of env.signers) {
+      if (s.signed_at !== null) alreadySignedSignerIds.push(s.id);
+      else if (s.declined_at === null) notifiedSignerIds.push(s.id);
+    }
+    const next: Envelope = { ...env, status: 'canceled', updated_at: new Date().toISOString() };
+    this.envelopes.set(envelope_id, next);
+    return { envelope: next, notifiedSignerIds, alreadySignedSignerIds };
+  }
   async expireEnvelopes(): Promise<readonly string[]> {
     throw new Error('not_implemented_in_fake');
   }
@@ -349,8 +371,10 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
     return event;
   }
 
-  async enqueueJob(): Promise<string> {
-    throw new Error('not_implemented_in_fake');
+  jobs: Array<{ readonly envelope_id: string; readonly kind: 'seal' | 'audit_only' }> = [];
+  async enqueueJob(envelope_id: string, kind: 'seal' | 'audit_only'): Promise<string> {
+    this.jobs.push({ envelope_id, kind });
+    return `job_${this.jobs.length}`;
   }
   async claimNextJob(): Promise<never> {
     throw new Error('not_implemented_in_fake');
@@ -388,6 +412,7 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
 const TEST_ENV = {
   TC_VERSION: '2026-04-24',
   PRIVACY_VERSION: '2026-04-24',
+  APP_PUBLIC_URL: 'http://localhost:5173',
 } as unknown as AppEnv;
 
 /** Minimal in-memory outbox for service tests. */
@@ -748,6 +773,145 @@ describe('EnvelopesService', () => {
     it('404 on cross-owner', async () => {
       const e = await svc.createDraft(OWNER, { title: 'X' });
       await expect(svc.listEvents(OTHER, e.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('cancel', () => {
+    /**
+     * Stamp a sent envelope with the given per-signer state and force the
+     * status flip — we exercise `cancel` directly here without going
+     * through the full draft → upload → addSigner → send pipeline (those
+     * are covered by the e2e specs).
+     */
+    function setupSentEnvelope(args: {
+      readonly status?: 'awaiting_others' | 'sealing' | 'completed' | 'canceled';
+      readonly signers: ReadonlyArray<{
+        readonly id: string;
+        readonly name: string;
+        readonly email: string;
+        readonly signed_at?: string | null;
+        readonly declined_at?: string | null;
+      }>;
+    }): { readonly id: string } {
+      const id = `env_${repo.envelopes.size + 1}`;
+      const now = new Date().toISOString();
+      const env: Envelope = {
+        id,
+        owner_id: OWNER,
+        title: 'Sent envelope',
+        short_code: 'AAAA-BBBB-CCC',
+        status: args.status ?? 'awaiting_others',
+        delivery_mode: 'parallel',
+        original_pages: 1,
+        original_sha256: 'a'.repeat(64),
+        sealed_sha256: null,
+        sender_email: 'sender@example.com',
+        sender_name: 'Sender Name',
+        sent_at: now,
+        completed_at: null,
+        expires_at: new Date(Date.now() + 30 * 86_400_000).toISOString(),
+        tc_version: '2026-04-24',
+        privacy_version: '2026-04-24',
+        signers: args.signers.map((s) => ({
+          id: s.id,
+          email: s.email,
+          name: s.name,
+          color: '#112233',
+          role: 'signatory',
+          signing_order: 1,
+          status:
+            s.signed_at != null ? 'completed' : s.declined_at != null ? 'declined' : 'awaiting',
+          viewed_at: null,
+          tc_accepted_at: null,
+          signed_at: s.signed_at ?? null,
+          declined_at: s.declined_at ?? null,
+        })),
+        fields: [],
+        created_at: now,
+        updated_at: now,
+      };
+      repo.envelopes.set(id, env);
+      return { id };
+    }
+
+    it('flips awaiting_others → canceled, records canceled event, fans out withdrawn_to_signer + audit_only job', async () => {
+      const { id } = setupSentEnvelope({
+        signers: [
+          { id: 's1', name: 'Ada', email: 'ada@x.com' },
+          { id: 's2', name: 'Bea', email: 'bea@x.com' },
+        ],
+      });
+
+      const res = await svc.cancel(OWNER, id);
+
+      expect(res).toEqual({ status: 'canceled', envelope_status: 'canceled' });
+      expect(repo.envelopes.get(id)?.status).toBe('canceled');
+
+      const types = repo.events.filter((e) => e.envelope_id === id).map((e) => e.event_type);
+      expect(types).toContain('canceled');
+      expect(types.filter((t) => t === 'session_invalidated_by_cancel')).toHaveLength(2);
+
+      const queued = outbound.rows.filter((r) => r.envelope_id === id);
+      expect(queued).toHaveLength(2);
+      expect(queued.every((r) => r.kind === 'withdrawn_to_signer')).toBe(true);
+      expect(queued.map((r) => r.to_email).sort()).toEqual(['ada@x.com', 'bea@x.com']);
+      expect(queued[0]!.payload).toMatchObject({
+        envelope_title: 'Sent envelope',
+        sender_name: 'Sender Name',
+      });
+
+      expect(repo.jobs).toEqual([{ envelope_id: id, kind: 'audit_only' }]);
+    });
+
+    it('routes already-signed signers to withdrawn_after_sign and pending signers to withdrawn_to_signer', async () => {
+      const signedAt = new Date().toISOString();
+      const { id } = setupSentEnvelope({
+        status: 'sealing',
+        signers: [
+          { id: 's1', name: 'Ada', email: 'ada@x.com', signed_at: signedAt },
+          { id: 's2', name: 'Bea', email: 'bea@x.com' },
+        ],
+      });
+
+      await svc.cancel(OWNER, id);
+
+      const queued = outbound.rows.filter((r) => r.envelope_id === id);
+      const byEmail = new Map(queued.map((r) => [r.to_email, r]));
+      expect(byEmail.get('ada@x.com')?.kind).toBe('withdrawn_after_sign');
+      expect(byEmail.get('bea@x.com')?.kind).toBe('withdrawn_to_signer');
+      expect(byEmail.get('ada@x.com')?.payload).toMatchObject({
+        signed_at_readable: expect.stringMatching(/UTC$/),
+      });
+      const sessionInvals = repo.events.filter(
+        (e) => e.event_type === 'session_invalidated_by_cancel',
+      );
+      expect(sessionInvals).toHaveLength(1);
+      expect(sessionInvals[0]?.signer_id).toBe('s2');
+    });
+
+    it('404 envelope_not_found when caller is not the owner', async () => {
+      const { id } = setupSentEnvelope({
+        signers: [{ id: 's1', name: 'Ada', email: 'ada@x.com' }],
+      });
+      await expect(svc.cancel(OTHER, id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('409 envelope_terminal when the envelope is already completed', async () => {
+      const { id } = setupSentEnvelope({
+        status: 'completed',
+        signers: [
+          { id: 's1', name: 'Ada', email: 'ada@x.com', signed_at: new Date().toISOString() },
+        ],
+      });
+      await expect(svc.cancel(OWNER, id)).rejects.toBeInstanceOf(ConflictException);
+    });
+
+    it('409 envelope_terminal when the envelope is already canceled (idempotency guard)', async () => {
+      const { id } = setupSentEnvelope({
+        status: 'canceled',
+        signers: [{ id: 's1', name: 'Ada', email: 'ada@x.com' }],
+      });
+      await expect(svc.cancel(OWNER, id)).rejects.toBeInstanceOf(ConflictException);
     });
   });
 });

--- a/apps/api/src/envelopes/envelopes.service.ts
+++ b/apps/api/src/envelopes/envelopes.service.ts
@@ -20,7 +20,11 @@ import {
   DuplicateOutboundEmailError,
   OutboundEmailsRepository,
 } from '../email/outbound-emails.repository';
-import { buildSignerListHtmlFromSigners } from '../email/template-fragments';
+import {
+  buildSignerListHtmlFromSigners,
+  buildTimelineHtml,
+  type TimelineEventFragment,
+} from '../email/template-fragments';
 import { SigningTokenService } from '../signing/signing-token.service';
 import { StorageService } from '../storage/storage.service';
 import type {
@@ -474,6 +478,148 @@ export class EnvelopesService {
   }
 
   /**
+   * Sender-initiated cancel ("withdraw") of a sent envelope. Mirrors
+   * SigningService.decline on the sender side: atomically flip the
+   * envelope to `canceled`, revoke pending access tokens, fan out the
+   * pre-staged `withdrawn_to_signer` / `withdrawn_after_sign` emails,
+   * and enqueue an `audit_only` job so the timeline + audit PDF reflect
+   * the terminal state.
+   *
+   * Allowed transitions: `awaiting_others` | `sealing` → `canceled`.
+   * `draft` keeps the existing `deleteDraft` flow (no email side-effects)
+   * and any terminal status (`completed` / `declined` / `expired` /
+   * `canceled`) is rejected with 409.
+   */
+  async cancel(
+    owner_id: string,
+    envelope_id: string,
+    audit: { ip: string | null; user_agent: string | null } = { ip: null, user_agent: null },
+  ): Promise<{ readonly status: 'canceled'; readonly envelope_status: 'canceled' }> {
+    const result = await this.repo.cancelEnvelope(envelope_id, owner_id);
+    if (!result) {
+      // Disambiguate: not the owner's row → 404; otherwise terminal → 409.
+      const fresh = await this.repo.findByIdForOwner(owner_id, envelope_id);
+      if (!fresh) throw new NotFoundException('envelope_not_found');
+      throw new ConflictException('envelope_terminal');
+    }
+
+    const { envelope, notifiedSignerIds, alreadySignedSignerIds } = result;
+    const publicUrl = this.env.APP_PUBLIC_URL.replace(/\/$/, '');
+    const verifyUrl = `${publicUrl}/verify/${envelope.short_code}`;
+    const senderDisplay = envelope.sender_name ?? envelope.sender_email ?? 'The document sender';
+
+    // Sender's own audit event for the cancel action.
+    const canceledEvent = await this.repo.appendEvent({
+      envelope_id,
+      actor_kind: 'sender',
+      event_type: 'canceled',
+      ip: audit.ip,
+      user_agent: audit.user_agent,
+      metadata: {
+        notified_signer_count: notifiedSignerIds.length,
+        already_signed_signer_count: alreadySignedSignerIds.length,
+      },
+    });
+
+    // Pre-render a single timeline for the `withdrawn_after_sign` kind:
+    // (sent → each who signed → withdrawn pending). One render even if
+    // multiple recipients share it.
+    const withdrawnTimelineHtml = ((): string => {
+      const events: TimelineEventFragment[] = [];
+      if (envelope.sent_at !== null) {
+        events.push({
+          label: `Envelope sent by ${senderDisplay}`,
+          at: formatUtc(envelope.sent_at),
+        });
+      }
+      for (const s of envelope.signers) {
+        if (s.signed_at !== null) {
+          events.push({ label: `${s.name} signed`, at: formatUtc(s.signed_at) });
+        }
+      }
+      events.push({
+        label: `Envelope withdrawn by ${senderDisplay}`,
+        at: formatUtc(new Date().toISOString()),
+        pending: true,
+      });
+      return buildTimelineHtml(events);
+    })();
+
+    // Pending signers — withdrawn_to_signer + session_invalidated_by_cancel.
+    for (const signerId of notifiedSignerIds) {
+      const signer = envelope.signers.find((s) => s.id === signerId);
+      if (!signer) continue;
+
+      await this.repo.appendEvent({
+        envelope_id,
+        signer_id: signerId,
+        actor_kind: 'system',
+        event_type: 'session_invalidated_by_cancel',
+        metadata: {},
+      });
+
+      try {
+        await this.outboundEmails.insert({
+          envelope_id,
+          signer_id: signerId,
+          kind: 'withdrawn_to_signer',
+          to_email: signer.email,
+          to_name: signer.name,
+          source_event_id: canceledEvent.id,
+          payload: {
+            sender_name: senderDisplay,
+            envelope_title: envelope.title,
+            short_code: envelope.short_code,
+            verify_url: verifyUrl,
+            public_url: publicUrl,
+          },
+        });
+      } catch (err) {
+        if (err instanceof DuplicateOutboundEmailError) continue;
+        throw err;
+      }
+    }
+
+    // Signers who'd already completed before cancel — withdrawn_after_sign.
+    // They keep their copy + the audit retains their submission as legal
+    // evidence; no session-invalidation event because their session was
+    // already terminal (`signed_at` was set).
+    for (const signerId of alreadySignedSignerIds) {
+      const signer = envelope.signers.find((s) => s.id === signerId);
+      if (!signer || signer.signed_at === null) continue;
+      try {
+        await this.outboundEmails.insert({
+          envelope_id,
+          signer_id: signerId,
+          kind: 'withdrawn_after_sign',
+          to_email: signer.email,
+          to_name: signer.name,
+          source_event_id: canceledEvent.id,
+          payload: {
+            sender_name: senderDisplay,
+            envelope_title: envelope.title,
+            signed_at_readable: formatUtc(signer.signed_at),
+            short_code: envelope.short_code,
+            verify_url: verifyUrl,
+            public_url: publicUrl,
+            timeline_html: withdrawnTimelineHtml,
+          },
+        });
+      } catch (err) {
+        if (err instanceof DuplicateOutboundEmailError) continue;
+        throw err;
+      }
+    }
+
+    // Audit-only seal job — produces the audit PDF for the canceled
+    // envelope. Mirrors the decline path so the artifact set is consistent
+    // across terminal statuses.
+    await this.repo.enqueueJob(envelope_id, 'audit_only');
+
+    return { status: 'canceled', envelope_status: 'canceled' };
+  }
+
+  /**
    * Manually re-send the signing invite to a single signer. Rotates the
    * signer's access_token_hash so the new email carries a fresh token —
    * any prior link is dead the moment this succeeds. Throttled to at most
@@ -566,6 +712,17 @@ export class EnvelopesService {
       },
     });
   }
+}
+
+/** ISO timestamp → "2026-04-24 13:05 UTC" for human-readable email copy. */
+function formatUtc(iso: string): string {
+  const d = new Date(iso);
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mi = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi} UTC`;
 }
 
 function formatExpiresAt(iso: string): string {

--- a/apps/api/test/cancel-envelope.e2e-spec.ts
+++ b/apps/api/test/cancel-envelope.e2e-spec.ts
@@ -1,0 +1,237 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { PDFDocument } from 'pdf-lib';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { JWKS_RESOLVER } from '../src/auth/jwks.provider';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { APP_ENV } from '../src/config/config.module';
+import type { AppEnv } from '../src/config/env.schema';
+import { ContactsRepository } from '../src/contacts/contacts.repository';
+import { OutboundEmailsRepository } from '../src/email/outbound-emails.repository';
+import { EnvelopesRepository } from '../src/envelopes/envelopes.repository';
+import { StorageService } from '../src/storage/storage.service';
+import { InMemoryContactsRepository } from './in-memory-contacts-repository';
+import { InMemoryEnvelopesRepository } from './in-memory-envelopes-repository';
+import { InMemoryOutboundEmailsRepository } from './in-memory-outbound-emails-repository';
+import { InMemoryStorageService } from './in-memory-storage';
+import { buildTestJwks } from './test-jwks';
+
+const TEST_ENV: AppEnv = {
+  NODE_ENV: 'test',
+  PORT: 0,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_JWT_AUDIENCE: 'authenticated',
+  CORS_ORIGIN: 'http://localhost:5173',
+  APP_PUBLIC_URL: 'http://localhost:5173',
+  DATABASE_URL: 'postgres://u:p@127.0.0.1:5432/db?sslmode=disable',
+  STORAGE_BUCKET: 'envelopes',
+  TC_VERSION: '2026-04-24',
+  PRIVACY_VERSION: '2026-04-24',
+  SIGNER_SESSION_SECRET: 'x'.repeat(64),
+  EMAIL_PROVIDER: 'logging',
+  EMAIL_FROM_ADDRESS: 'onboarding@resend.dev',
+  EMAIL_FROM_NAME: 'Seald',
+  PDF_SIGNING_PROVIDER: 'local',
+  PDF_SIGNING_TSA_URL: 'https://freetsa.org/tsr',
+  ENVELOPE_RETENTION_YEARS: 7,
+  WORKER_ENABLED: false,
+};
+
+const USER_A = '00000000-0000-0000-0000-00000000000a';
+const USER_B = '00000000-0000-0000-0000-00000000000b';
+const ISSUER = `${TEST_ENV.SUPABASE_URL}/auth/v1`;
+
+/**
+ * Sender-initiated cancel ("withdraw") of a sent envelope.
+ *
+ * Verifies the full pipeline end-to-end:
+ *   1. POST /envelopes/:id/cancel flips an awaiting_others envelope to
+ *      `canceled` and emits a `canceled` event in the audit timeline.
+ *   2. The pending signer's previously-issued plaintext token can no
+ *      longer exchange via /sign/start (401 invalid_token) — i.e. the
+ *      access_token_hash was actually revoked.
+ *   3. Re-issuing /cancel on the same envelope returns 409 (idempotency
+ *      guard via envelope_terminal).
+ *   4. Cross-owner cancel returns 404.
+ */
+describe('Envelopes — sender cancel (e2e)', () => {
+  let app: INestApplication;
+  let envelopesRepo: InMemoryEnvelopesRepository;
+  let contactsRepo: InMemoryContactsRepository;
+  let storage: InMemoryStorageService;
+  let outbound: InMemoryOutboundEmailsRepository;
+  let tk: Awaited<ReturnType<typeof buildTestJwks>>;
+  let tokenA: string;
+  let tokenB: string;
+  let tinyPdf: Buffer;
+
+  beforeAll(async () => {
+    tk = await buildTestJwks();
+    envelopesRepo = new InMemoryEnvelopesRepository();
+    contactsRepo = new InMemoryContactsRepository();
+    storage = new InMemoryStorageService();
+    outbound = new InMemoryOutboundEmailsRepository();
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(APP_ENV)
+      .useValue(TEST_ENV)
+      .overrideProvider(JWKS_RESOLVER)
+      .useValue(tk.resolver)
+      .overrideProvider(EnvelopesRepository)
+      .useValue(envelopesRepo)
+      .overrideProvider(ContactsRepository)
+      .useValue(contactsRepo)
+      .overrideProvider(StorageService)
+      .useValue(storage)
+      .overrideProvider(OutboundEmailsRepository)
+      .useValue(outbound)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    const signOpts = { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE };
+    tokenA = await tk.sign({ sub: USER_A, email: 'sender-a@example.com' }, signOpts);
+    tokenB = await tk.sign({ sub: USER_B, email: 'sender-b@example.com' }, signOpts);
+
+    const doc = await PDFDocument.create();
+    doc.addPage([300, 200]);
+    tinyPdf = Buffer.from(await doc.save());
+  });
+
+  beforeEach(() => {
+    envelopesRepo.reset();
+    contactsRepo.reset();
+    storage.reset();
+    outbound.reset();
+  });
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const auth = (t: string) => ({ Authorization: `Bearer ${t}` });
+
+  /** Drive a full draft → upload → addSigner → fields → send pipeline so
+   *  the cancel test starts from a real `awaiting_others` envelope with a
+   *  hashed access token. Returns the plaintext token threaded into the
+   *  invite email so we can later assert that `/sign/start` 401s after
+   *  cancel revokes the hash. */
+  async function buildSentEnvelope(): Promise<{
+    envId: string;
+    signerId: string;
+    plaintextToken: string;
+  }> {
+    const contact = await contactsRepo.create({
+      owner_id: USER_A,
+      name: 'Ada',
+      email: 'ada@example.com',
+      color: '#112233',
+    });
+    const env = await request(app.getHttpServer())
+      .post('/envelopes')
+      .set(auth(tokenA))
+      .send({ title: 'Cancel me' });
+    await request(app.getHttpServer())
+      .post(`/envelopes/${env.body.id}/upload`)
+      .set(auth(tokenA))
+      .attach('file', tinyPdf, { filename: 't.pdf', contentType: 'application/pdf' });
+    const signer = await request(app.getHttpServer())
+      .post(`/envelopes/${env.body.id}/signers`)
+      .set(auth(tokenA))
+      .send({ contact_id: contact.id });
+    await request(app.getHttpServer())
+      .put(`/envelopes/${env.body.id}/fields`)
+      .set(auth(tokenA))
+      .send({
+        fields: [
+          { signer_id: signer.body.id, kind: 'signature', page: 1, x: 0.1, y: 0.1, required: true },
+        ],
+      });
+    await request(app.getHttpServer()).post(`/envelopes/${env.body.id}/send`).set(auth(tokenA));
+
+    const invite = outbound.rows.find((r) => r.kind === 'invite');
+    if (!invite) throw new Error('expected invite to be enqueued');
+    const match = /\?t=([A-Za-z0-9_-]{43})/.exec(String(invite.payload.sign_url));
+    if (!match) throw new Error('could not parse plaintext token from sign_url');
+    return { envId: env.body.id, signerId: signer.body.id, plaintextToken: match[1]! };
+  }
+
+  it('POST /envelopes/:id/cancel flips status, revokes pending tokens, fans out withdrawn_to_signer email, records canceled event', async () => {
+    const { envId, signerId, plaintextToken } = await buildSentEnvelope();
+
+    const cancel = await request(app.getHttpServer())
+      .post(`/envelopes/${envId}/cancel`)
+      .set(auth(tokenA));
+    expect(cancel.status).toBe(201);
+    expect(cancel.body).toEqual({ status: 'canceled', envelope_status: 'canceled' });
+
+    // Status is observably canceled on the next read.
+    const fresh = await request(app.getHttpServer()).get(`/envelopes/${envId}`).set(auth(tokenA));
+    expect(fresh.status).toBe(200);
+    expect(fresh.body.status).toBe('canceled');
+
+    // The signer's plaintext token is dead — /sign/start should 401, not
+    // surface the (now-invalid) session.
+    const start = await request(app.getHttpServer())
+      .post('/sign/start')
+      .send({ envelope_id: envId, token: plaintextToken });
+    expect(start.status).toBe(401);
+    expect(start.body).toEqual({ error: 'invalid_token' });
+
+    // Audit timeline carries the `canceled` + `session_invalidated_by_cancel` events.
+    const events = await request(app.getHttpServer())
+      .get(`/envelopes/${envId}/events`)
+      .set(auth(tokenA));
+    expect(events.status).toBe(200);
+    const types = events.body.events.map((e: { event_type: string }) => e.event_type);
+    expect(types).toContain('canceled');
+    expect(types).toContain('session_invalidated_by_cancel');
+
+    // The pending signer received a `withdrawn_to_signer` email.
+    const withdrawn = outbound.rows.filter(
+      (r) => r.envelope_id === envId && r.kind === 'withdrawn_to_signer',
+    );
+    expect(withdrawn).toHaveLength(1);
+    expect(withdrawn[0]!.signer_id).toBe(signerId);
+    expect(withdrawn[0]!.to_email).toBe('ada@example.com');
+  });
+
+  it('returns 409 envelope_terminal on a second cancel', async () => {
+    const { envId } = await buildSentEnvelope();
+    await request(app.getHttpServer()).post(`/envelopes/${envId}/cancel`).set(auth(tokenA));
+
+    const second = await request(app.getHttpServer())
+      .post(`/envelopes/${envId}/cancel`)
+      .set(auth(tokenA));
+    expect(second.status).toBe(409);
+    expect(second.body).toEqual({ error: 'envelope_terminal' });
+  });
+
+  it('returns 404 envelope_not_found when caller is not the owner', async () => {
+    const { envId } = await buildSentEnvelope();
+    const res = await request(app.getHttpServer())
+      .post(`/envelopes/${envId}/cancel`)
+      .set(auth(tokenB));
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'envelope_not_found' });
+  });
+
+  it('returns 409 envelope_terminal when called on a draft envelope', async () => {
+    // A draft envelope hasn't been sent — the proper way to remove it is
+    // DELETE /envelopes/:id. /cancel is reserved for sent envelopes.
+    const draft = await request(app.getHttpServer())
+      .post('/envelopes')
+      .set(auth(tokenA))
+      .send({ title: 'Still a draft' });
+    const res = await request(app.getHttpServer())
+      .post(`/envelopes/${draft.body.id}/cancel`)
+      .set(auth(tokenA));
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ error: 'envelope_terminal' });
+  });
+});

--- a/apps/api/test/in-memory-envelopes-repository.ts
+++ b/apps/api/test/in-memory-envelopes-repository.ts
@@ -518,6 +518,35 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
   getDeclineReason(signer_id: string): string | null | undefined {
     return this.declineReasons.get(signer_id);
   }
+  async cancelEnvelope(
+    envelope_id: string,
+    owner_id: string,
+  ): Promise<{
+    readonly envelope: Envelope;
+    readonly notifiedSignerIds: readonly string[];
+    readonly alreadySignedSignerIds: readonly string[];
+  } | null> {
+    const env = this.envelopes.get(envelope_id);
+    if (!env) return null;
+    if (env.owner_id !== owner_id) return null;
+    if (env.status !== 'awaiting_others' && env.status !== 'sealing') return null;
+    const now = new Date().toISOString();
+    const notifiedSignerIds: string[] = [];
+    const alreadySignedSignerIds: string[] = [];
+    for (const s of env.signers) {
+      if (s.signed_at !== null) {
+        alreadySignedSignerIds.push(s.id);
+      } else if (s.declined_at === null) {
+        notifiedSignerIds.push(s.id);
+        // Revoke pending token so /sign/start with the old hash 401s.
+        this.signerTokenHashes.delete(s.id);
+      }
+    }
+    const next: Envelope = { ...env, status: 'canceled', updated_at: now };
+    this.envelopes.set(envelope_id, next);
+    return { envelope: next, notifiedSignerIds, alreadySignedSignerIds };
+  }
+
   async expireEnvelopes(now: Date, limit: number): Promise<readonly string[]> {
     const transitioned: string[] = [];
     const iso = new Date().toISOString();

--- a/apps/api/test/pg-mem-db.ts
+++ b/apps/api/test/pg-mem-db.ts
@@ -123,6 +123,19 @@ export function createPgMemDb(): PgMemHandle {
   const migration0005Path = resolve(__dirname, '../db/migrations/0005_signer_initials.sql');
   mem.public.none(readFileSync(migration0005Path, 'utf8'));
 
+  // 0006 adds 'session_invalidated_by_cancel' to the event_type enum.
+  // pg-mem treats enums as plain text columns once the create-type runs, so
+  // ALTER TYPE ... ADD VALUE is a no-op against the in-memory schema; we
+  // load it for parity with real Postgres + so any future enum-aware
+  // pg-mem release picks the new value up automatically.
+  const migration0006Path = resolve(__dirname, '../db/migrations/0006_event_type_cancel.sql');
+  try {
+    mem.public.none(readFileSync(migration0006Path, 'utf8'));
+  } catch {
+    // pg-mem may not implement ALTER TYPE ADD VALUE — safe to ignore;
+    // its enum check is text-based so the inserts still work.
+  }
+
   const { Pool } = mem.adapters.createPg();
   const pool = new Pool();
   const db = new Kysely<Database>({ dialect: new PostgresDialect({ pool }) });

--- a/apps/web/src/features/envelopes/envelopesApi.ts
+++ b/apps/web/src/features/envelopes/envelopesApi.ts
@@ -125,6 +125,7 @@ export type EnvelopeEventType =
   | 'canceled'
   | 'reminder_sent'
   | 'session_invalidated_by_decline'
+  | 'session_invalidated_by_cancel'
   | 'job_failed'
   | 'retention_deleted';
 
@@ -275,4 +276,26 @@ export async function sendEnvelope(id: string, signal?: AbortSignal): Promise<En
 
 export async function deleteEnvelope(id: string, signal?: AbortSignal): Promise<void> {
   await apiClient.delete(`/envelopes/${id}`, configWithSignal(signal));
+}
+
+export interface CancelEnvelopeResponse {
+  readonly status: 'canceled';
+  readonly envelope_status: 'canceled';
+}
+
+/**
+ * Sender-initiated cancel ("withdraw") of a sent envelope. Allowed only on
+ * `awaiting_others` / `sealing`; terminal statuses surface as 409. Use the
+ * delete-draft flow for `draft` envelopes.
+ */
+export async function cancelEnvelope(
+  id: string,
+  signal?: AbortSignal,
+): Promise<CancelEnvelopeResponse> {
+  const { data } = await apiClient.post<CancelEnvelopeResponse>(
+    `/envelopes/${id}/cancel`,
+    undefined,
+    configWithSignal(signal),
+  );
+  return data;
 }

--- a/apps/web/src/features/envelopes/index.ts
+++ b/apps/web/src/features/envelopes/index.ts
@@ -12,6 +12,7 @@ export {
   usePlaceEnvelopeFieldsMutation,
   useSendEnvelopeMutation,
   useDeleteEnvelopeMutation,
+  useCancelEnvelopeMutation,
 } from './useEnvelopes';
 export type {
   UploadFileArgs,
@@ -32,8 +33,10 @@ export {
   placeEnvelopeFields,
   sendEnvelope,
   deleteEnvelope,
+  cancelEnvelope,
 } from './envelopesApi';
 export type {
+  CancelEnvelopeResponse,
   Envelope,
   EnvelopeDownloadKind,
   EnvelopeDownloadUrl,

--- a/apps/web/src/features/envelopes/useEnvelopes.ts
+++ b/apps/web/src/features/envelopes/useEnvelopes.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { EnvelopeListItem } from 'shared';
 import type {
+  CancelEnvelopeResponse,
   Envelope,
   EnvelopeEventsResponse,
   EnvelopeField,
@@ -11,6 +12,7 @@ import type {
 } from './envelopesApi';
 import {
   addEnvelopeSigner,
+  cancelEnvelope,
   createEnvelope,
   deleteEnvelope,
   getEnvelope,
@@ -148,6 +150,28 @@ export function useDeleteEnvelopeMutation() {
     mutationFn: (id) => deleteEnvelope(id),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
+    },
+  });
+}
+
+/**
+ * Sender-initiated cancel ("withdraw") of a sent envelope. Mirrors
+ * `useDeleteEnvelopeMutation` but targets the `/cancel` endpoint —
+ * use this for `awaiting_others` / `sealing` envelopes; the delete-draft
+ * mutation handles `draft`.
+ */
+export function useCancelEnvelopeMutation() {
+  const qc = useQueryClient();
+  return useMutation<CancelEnvelopeResponse, Error, string>({
+    mutationFn: (id) => cancelEnvelope(id),
+    onSuccess: (_res, id) => {
+      // Invalidate both the list and the detail query so the UI re-pulls
+      // the canonical `canceled` status. Don't optimistically setQueryData
+      // — the API also recomputes signers.access_token_hash side-effects
+      // and we want the next read to round-trip.
+      qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
+      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(id) });
+      qc.invalidateQueries({ queryKey: ENVELOPE_EVENTS_KEY(id) });
     },
   });
 }

--- a/apps/web/src/features/verify/model/types.ts
+++ b/apps/web/src/features/verify/model/types.ts
@@ -44,6 +44,7 @@ export type VerifyEventType =
   | 'canceled'
   | 'reminder_sent'
   | 'session_invalidated_by_decline'
+  | 'session_invalidated_by_cancel'
   | 'job_failed'
   | 'retention_deleted';
 

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.test.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { render, screen, type RenderResult } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import type { ReactElement, ReactNode } from 'react';
@@ -21,6 +22,7 @@ import { apiClient } from '../../lib/api/apiClient';
 import { EnvelopeDetailPage } from './EnvelopeDetailPage';
 
 const get = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+const post = apiClient.post as unknown as ReturnType<typeof vi.fn>;
 
 function renderAt(id: string): RenderResult {
   const qc = new QueryClient({
@@ -45,7 +47,54 @@ function renderAt(id: string): RenderResult {
 
 beforeEach(() => {
   get.mockReset();
+  post.mockReset();
 });
+
+interface EnvelopeMockOverrides {
+  readonly status?: string;
+  readonly signers?: ReadonlyArray<Record<string, unknown>>;
+}
+
+function mockEnvelope(overrides: EnvelopeMockOverrides = {}): void {
+  const defaultSigner = {
+    id: 's1',
+    email: 'maya@example.com',
+    name: 'Maya Raskin',
+    color: '#10B981',
+    role: 'signatory',
+    signing_order: 1,
+    status: 'awaiting',
+    viewed_at: null,
+    tc_accepted_at: null,
+    signed_at: null,
+    declined_at: null,
+  };
+  get.mockImplementation((url: string) => {
+    if (url.endsWith('/events')) {
+      return Promise.resolve({ data: { events: [] }, status: 200 });
+    }
+    return Promise.resolve({
+      data: {
+        id: 'env-1',
+        owner_id: 'u',
+        title: 'Master Services Agreement',
+        short_code: 'MSA-ABCD-1234',
+        status: overrides.status ?? 'awaiting_others',
+        original_pages: 4,
+        expires_at: '2030-01-01T00:00:00Z',
+        tc_version: '1',
+        privacy_version: '1',
+        sent_at: '2026-04-01T00:00:00Z',
+        completed_at: null,
+        signers: overrides.signers ?? [defaultSigner],
+        fields: [],
+        created_at: '2026-04-01T00:00:00Z',
+        updated_at: '2026-04-01T00:00:00Z',
+      },
+      status: 200,
+    });
+  });
+}
 
 describe('EnvelopeDetailPage', () => {
   it('renders envelope title, short code, and signer list on success', async () => {
@@ -118,5 +167,61 @@ describe('EnvelopeDetailPage', () => {
     get.mockImplementationOnce(() => new Promise(() => {}));
     const { container } = renderAt('env-pending');
     expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+
+  it('shows the Withdraw button on awaiting_others envelopes and calls cancel on confirm', async () => {
+    mockEnvelope({ status: 'awaiting_others' });
+    post.mockResolvedValue({
+      data: { status: 'canceled', envelope_status: 'canceled' },
+      status: 201,
+    });
+
+    renderAt('env-1');
+    const user = userEvent.setup();
+
+    const withdraw = await screen.findByRole('button', { name: /withdraw/i });
+    await user.click(withdraw);
+
+    // Dialog opens with sent-mode copy. The dialog's confirm action also
+    // reads "Withdraw" — disambiguate by waiting for the dialog title.
+    expect(
+      await screen.findByRole('heading', { name: /withdraw this envelope\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/will be notified that the request is canceled/i)).toBeInTheDocument();
+
+    const confirmButtons = screen.getAllByRole('button', { name: /^withdraw$/i });
+    // The dialog confirm is the last "Withdraw" button rendered (header
+    // button is first); click that one to fire the mutation.
+    const dialogConfirm = confirmButtons[confirmButtons.length - 1];
+    expect(dialogConfirm).toBeDefined();
+    await user.click(dialogConfirm!);
+
+    expect(post).toHaveBeenCalledWith('/envelopes/env-1/cancel', undefined, expect.anything());
+  });
+
+  it('hides the Withdraw button on completed envelopes', async () => {
+    mockEnvelope({
+      status: 'completed',
+      signers: [
+        {
+          id: 's1',
+          email: 'maya@example.com',
+          name: 'Maya Raskin',
+          color: '#10B981',
+          role: 'signatory',
+          signing_order: 1,
+          status: 'completed',
+          viewed_at: '2026-04-01T00:00:00Z',
+          tc_accepted_at: '2026-04-01T00:00:00Z',
+          signed_at: '2026-04-01T00:01:00Z',
+          declined_at: null,
+        },
+      ],
+    });
+
+    renderAt('env-1');
+
+    expect(await screen.findByText(/master services agreement/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /withdraw/i })).toBeNull();
   });
 });

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
@@ -38,7 +38,10 @@ import {
   useEnvelopeEventsQuery,
   useEnvelopeQuery,
 } from '@/features/envelopes';
-import { useDeleteEnvelopeMutation } from '@/features/envelopes/useEnvelopes';
+import {
+  useCancelEnvelopeMutation,
+  useDeleteEnvelopeMutation,
+} from '@/features/envelopes/useEnvelopes';
 import type { Envelope, EnvelopeEvent, EnvelopeStatus, SignerUiStatus } from '@/features/envelopes';
 import {
   Actions,
@@ -301,9 +304,13 @@ interface ActionToast {
  *   - Send reminder — fans out `POST /envelopes/:id/signers/:sid/remind`
  *     across every signer still waiting. 429s (1/hour throttle) aggregate
  *     into the toast; a partial-success is reported.
- *   - Withdraw — for DRAFT envelopes only (the backend currently supports
- *     `deleteDraft` but has no sent-envelope cancel). Hidden for other
- *     statuses so the control doesn't bait a click that can't complete.
+ *   - Withdraw — visible on `draft`, `awaiting_others`, and `sealing`
+ *     envelopes. Drafts route through `deleteDraft` (no email side-effects);
+ *     sent envelopes hit `POST /envelopes/:id/cancel`, which flips the
+ *     status to `canceled`, revokes pending access tokens, and fans out
+ *     `withdrawn_to_signer` / `withdrawn_after_sign` notifications.
+ *     Terminal envelopes (completed / declined / expired / canceled) hide
+ *     the control so the user doesn't bait a click that can't complete.
  *   - Breadcrumb Documents — navigates to `/documents`.
  *   - View audit trail — opens `/verify/:short_code` in a new tab,
  *     the public verify page sealed into every outbound email.
@@ -315,6 +322,7 @@ export function EnvelopeDetailPage() {
   const q = useEnvelopeQuery(id ?? '', Boolean(id));
   const ev = useEnvelopeEventsQuery(id ?? '', Boolean(id));
   const deleteEnvelope = useDeleteEnvelopeMutation();
+  const cancelEnvelope = useCancelEnvelopeMutation();
 
   const [toast, setToast] = useState<ActionToast | null>(null);
   const [withdrawOpen, setWithdrawOpen] = useState(false);
@@ -495,10 +503,30 @@ export function EnvelopeDetailPage() {
   const handleConfirmWithdraw = useCallback(() => {
     if (!envelope) return;
     setWithdrawOpen(false);
-    deleteEnvelope.mutate(envelope.id, {
+    // Drafts: hard-delete (no signers were ever notified). Sent envelopes
+    // (awaiting_others / sealing): the cancel mutation flips the status to
+    // `canceled` server-side and fans out the withdrawal emails. Terminal
+    // statuses don't even render the button so we don't branch for them.
+    if (envelope.status === 'draft') {
+      deleteEnvelope.mutate(envelope.id, {
+        onSuccess: () => {
+          qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
+          navigate('/documents');
+        },
+        onError: (err) => {
+          setToast({
+            kind: 'danger',
+            text: err instanceof Error ? err.message : 'Could not withdraw this envelope.',
+          });
+        },
+      });
+      return;
+    }
+    cancelEnvelope.mutate(envelope.id, {
       onSuccess: () => {
-        qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
-        navigate('/documents');
+        // Stay on the page so the user sees the timeline pick up the
+        // `canceled` event + signer status updates.
+        setToast({ kind: 'success', text: 'Envelope withdrawn. Signers were notified.' });
       },
       onError: (err) => {
         setToast({
@@ -507,7 +535,7 @@ export function EnvelopeDetailPage() {
         });
       },
     });
-  }, [envelope, deleteEnvelope, qc, navigate]);
+  }, [envelope, deleteEnvelope, cancelEnvelope, qc, navigate]);
 
   if (q.isPending) {
     return (
@@ -640,12 +668,14 @@ export function EnvelopeDetailPage() {
             >
               Send reminder
             </Button>
-            {envelope.status === 'draft' ? (
+            {envelope.status === 'draft' ||
+            envelope.status === 'awaiting_others' ||
+            envelope.status === 'sealing' ? (
               <Button
                 variant="secondary"
                 iconLeft={X}
                 onClick={() => setWithdrawOpen(true)}
-                loading={deleteEnvelope.isPending}
+                loading={deleteEnvelope.isPending || cancelEnvelope.isPending}
               >
                 Withdraw
               </Button>
@@ -753,9 +783,13 @@ export function EnvelopeDetailPage() {
       <ExitConfirmDialog
         open={withdrawOpen}
         title="Withdraw this envelope?"
-        description="This draft will be permanently removed. The action cannot be undone."
+        description={
+          envelope.status === 'draft'
+            ? 'This draft will be permanently removed. The action cannot be undone.'
+            : `Your signer${envelope.signers.length === 1 ? '' : 's'} will be notified that the request is canceled. This cannot be undone.`
+        }
         confirmLabel="Withdraw"
-        cancelLabel="Keep draft"
+        cancelLabel={envelope.status === 'draft' ? 'Keep draft' : 'Keep envelope'}
         onConfirm={handleConfirmWithdraw}
         onCancel={() => setWithdrawOpen(false)}
       />

--- a/apps/web/src/pages/VerifyPage/VerifyPage.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.tsx
@@ -163,6 +163,7 @@ const EVENT_LABEL: Record<VerifyEvent['event_type'], string> = {
   canceled: 'Envelope canceled',
   reminder_sent: 'Reminder sent',
   session_invalidated_by_decline: 'Session invalidated',
+  session_invalidated_by_cancel: 'Session invalidated (cancel)',
   job_failed: 'Sealing job failed',
   retention_deleted: 'Document retention expired',
 };

--- a/packages/shared/src/envelope-contract.ts
+++ b/packages/shared/src/envelope-contract.ts
@@ -47,6 +47,7 @@ export const EVENT_TYPES = [
   'canceled',
   'reminder_sent',
   'session_invalidated_by_decline',
+  'session_invalidated_by_cancel',
   'job_failed',
   'retention_deleted',
 ] as const;


### PR DESCRIPTION
## Summary
- POST /envelopes/:id/cancel — owner-only, only on awaiting_others / sealing.
- Atomically flips status, NULLs pending access_token_hash so old links 401, fans out the pre-staged withdrawn_to_signer / withdrawn_after_sign emails, appends canceled + session_invalidated_by_cancel events.
- EnvelopeDetailPage Withdraw button now visible on non-draft non-terminal envelopes; reuses the existing WithdrawDialog with sent-mode copy.
- New canonical EVENT_TYPES entry session_invalidated_by_cancel; FE VerifyEventType + EVENT_LABEL synced. DB migration 0005 widens the event_type enum.

## Test plan
- [x] pnpm --filter api test (290 passed)
- [x] pnpm --filter api test:e2e (115 passed, including new cancel-envelope.e2e-spec.ts)
- [x] pnpm --filter web test (624 passed)
- [x] pnpm -r typecheck (all green)
- [x] pnpm -r lint (all green)
- [ ] Manual: send envelope, click Withdraw, confirm; verify signer email arrives, /sign/start with old token returns 401, audit timeline shows canceled event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)