### PR TITLE
refactor(api): NestJS best-practices pass

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,7 @@
 import { Module } from '@nestjs/common';
+import { APP_FILTER } from '@nestjs/core';
 import { AuthModule } from './auth/auth.module';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ConfigModule } from './config/config.module';
 import { ContactsModule } from './contacts/contacts.module';
 import { DbModule } from './db/db.module';
@@ -27,5 +29,6 @@ import { StorageModule } from './storage/storage.module';
     VerifyModule,
     CronModule,
   ],
+  providers: [{ provide: APP_FILTER, useClass: HttpExceptionFilter }],
 })
 export class AppModule {}

--- a/apps/api/src/auth/auth.guard.spec.ts
+++ b/apps/api/src/auth/auth.guard.spec.ts
@@ -1,5 +1,7 @@
 import { ExecutionContext, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
+import { IS_PUBLIC_KEY } from './public.decorator';
 import { SupabaseJwtStrategy } from './supabase-jwt.strategy';
 import type { AuthUser } from './auth-user';
 
@@ -12,12 +14,20 @@ function mockContext(
   const request: RequestStub = { headers, ...req };
   return {
     switchToHttp: () => ({ getRequest: () => request }),
+    getHandler: () => () => undefined,
+    getClass: () => class {},
   } as unknown as ExecutionContext;
 }
 
-function makeGuard(validate: (token: string) => Promise<AuthUser>) {
+function makeGuard(
+  validate: (token: string) => Promise<AuthUser>,
+  isPublic = false,
+): { guard: AuthGuard; strategy: SupabaseJwtStrategy } {
   const strategy = { validate } as unknown as SupabaseJwtStrategy;
-  return { guard: new AuthGuard(strategy), strategy };
+  const reflector = {
+    getAllAndOverride: (key: string) => (key === IS_PUBLIC_KEY ? isPublic : undefined),
+  } as unknown as Reflector;
+  return { guard: new AuthGuard(strategy, reflector), strategy };
 }
 
 describe('AuthGuard', () => {
@@ -50,6 +60,8 @@ describe('AuthGuard', () => {
     });
     const ctx = {
       switchToHttp: () => ({ getRequest: () => req }),
+      getHandler: () => () => undefined,
+      getClass: () => class {},
     } as unknown as ExecutionContext;
     await expect(guard.canActivate(ctx)).resolves.toBe(true);
     expect(req.user).toEqual(user);
@@ -63,5 +75,13 @@ describe('AuthGuard', () => {
     await expect(guard.canActivate(ctx)).rejects.toMatchObject({
       message: 'token_expired',
     });
+  });
+
+  it('bypasses auth when route is marked @Public()', async () => {
+    const { guard } = makeGuard(async () => {
+      throw new Error('strategy should not run for public routes');
+    }, true);
+    const ctx = mockContext({});
+    await expect(guard.canActivate(ctx)).resolves.toBe(true);
   });
 });

--- a/apps/api/src/auth/auth.guard.ts
+++ b/apps/api/src/auth/auth.guard.ts
@@ -1,12 +1,31 @@
 import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { IS_PUBLIC_KEY } from './public.decorator';
 import { SupabaseJwtStrategy } from './supabase-jwt.strategy';
 import type { AuthUser } from './auth-user';
 
+/**
+ * Default-deny user-JWT guard. Registered globally as APP_GUARD in
+ * AuthModule, so every controller route requires a valid Supabase JWT
+ * unless explicitly tagged with `@Public()` (rule 5.1). Unauthenticated
+ * surfaces (health, verify, /sign, /internal/cron) opt out via
+ * `@Public()`; signer-session and cron-secret surfaces still apply their
+ * own guards on top.
+ */
 @Injectable()
 export class AuthGuard implements CanActivate {
-  constructor(private readonly strategy: SupabaseJwtStrategy) {}
+  constructor(
+    private readonly strategy: SupabaseJwtStrategy,
+    private readonly reflector: Reflector,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+
     const req = context.switchToHttp().getRequest<{
       headers: Record<string, string | undefined>;
       user?: AuthUser;

--- a/apps/api/src/auth/auth.module.ts
+++ b/apps/api/src/auth/auth.module.ts
@@ -1,10 +1,24 @@
 import { Module } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { AuthGuard } from './auth.guard';
 import { createJwksProvider } from './jwks.provider';
 import { SupabaseJwtStrategy } from './supabase-jwt.strategy';
 
+/**
+ * `AuthGuard` is registered both as a regular provider (so existing
+ * `@UseGuards(AuthGuard)` decorators that pre-date the global wiring keep
+ * resolving the same instance via DI) AND as the global APP_GUARD
+ * default-deny gate. The redundant per-route `@UseGuards(AuthGuard)` are
+ * being removed in this PR; what remains are routes that compose
+ * AuthGuard with another guard.
+ */
 @Module({
-  providers: [createJwksProvider(), SupabaseJwtStrategy, AuthGuard],
+  providers: [
+    createJwksProvider(),
+    SupabaseJwtStrategy,
+    AuthGuard,
+    { provide: APP_GUARD, useClass: AuthGuard },
+  ],
   exports: [AuthGuard, SupabaseJwtStrategy],
 })
 export class AuthModule {}

--- a/apps/api/src/auth/public.decorator.ts
+++ b/apps/api/src/auth/public.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+/**
+ * Metadata key inspected by `AuthGuard` (registered as APP_GUARD in
+ * AuthModule). Routes/controllers tagged with `@Public()` bypass the
+ * default-deny user-JWT check — the global guard is the security default,
+ * `@Public()` is the explicit opt-out for unauthenticated surfaces (health,
+ * verify, signer-session-protected /sign, cron-secret-protected /internal).
+ */
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = (): MethodDecorator & ClassDecorator => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/contacts/contacts.controller.ts
+++ b/apps/api/src/contacts/contacts.controller.ts
@@ -8,9 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
-  UseGuards,
 } from '@nestjs/common';
-import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import type { AuthUser } from '../auth/auth-user';
 import type { Contact } from './contact.entity';
@@ -18,8 +16,10 @@ import { ContactsService } from './contacts.service';
 import { CreateContactDto } from './dto/create-contact.dto';
 import { UpdateContactDto } from './dto/update-contact.dto';
 
+// AuthGuard is registered globally as APP_GUARD in AuthModule (rule 5.1).
+// No `@UseGuards(AuthGuard)` needed — every route here authenticates by
+// default unless tagged with `@Public()`.
 @Controller('contacts')
-@UseGuards(AuthGuard)
 export class ContactsController {
   constructor(private readonly svc: ContactsService) {}
 

--- a/apps/api/src/cron/cron.controller.ts
+++ b/apps/api/src/cron/cron.controller.ts
@@ -7,6 +7,7 @@ import {
   Post,
   UnauthorizedException,
 } from '@nestjs/common';
+import { Public } from '../auth/public.decorator';
 import { APP_ENV } from '../config/config.module';
 import type { AppEnv } from '../config/env.schema';
 import { EmailDispatcherService, type FlushResult } from '../email/email-dispatcher.service';
@@ -20,6 +21,7 @@ import { EnvelopesRepository } from '../envelopes/envelopes.repository';
  * CRON_SECRET is mandatory in production (env schema enforces >=32 chars).
  * In test it's optional, but if unset the endpoint refuses.
  */
+@Public()
 @Controller('internal/cron')
 export class CronController {
   constructor(

--- a/apps/api/src/envelopes/envelopes.controller.ts
+++ b/apps/api/src/envelopes/envelopes.controller.ts
@@ -13,7 +13,6 @@ import {
   Query,
   Req,
   UploadedFile,
-  UseGuards,
   UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
@@ -21,7 +20,6 @@ import type { Request } from 'express';
 import { ENVELOPE_STATUSES } from 'shared';
 import type { Envelope } from 'shared';
 import type { AuthUser } from '../auth/auth-user';
-import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
 import { extractClientIp } from '../common/extract-client-ip';
 import { AddSignerDto } from './dto/add-signer.dto';
@@ -38,8 +36,9 @@ import { EnvelopesService } from './envelopes.service';
 
 type EnvelopeStatus = Envelope['status'];
 
+// AuthGuard is registered globally as APP_GUARD in AuthModule (rule 5.1).
+// Every route here authenticates by default unless tagged with `@Public()`.
 @Controller('envelopes')
-@UseGuards(AuthGuard)
 export class EnvelopesController {
   constructor(private readonly svc: EnvelopesService) {}
 

--- a/apps/api/src/health/health.controller.ts
+++ b/apps/api/src/health/health.controller.ts
@@ -1,15 +1,19 @@
 import { Controller, Get, UseGuards } from '@nestjs/common';
 import { AuthGuard } from '../auth/auth.guard';
 import { CurrentUser } from '../auth/current-user.decorator';
+import { Public } from '../auth/public.decorator';
 import type { AuthUser } from '../auth/auth-user';
 
 @Controller()
 export class HealthController {
+  @Public()
   @Get('health')
   health(): { status: 'ok' } {
     return { status: 'ok' };
   }
 
+  // /me explicitly authenticates against the global AuthGuard (no @Public()).
+  // The redundant @UseGuards keeps the local intent visible for readers.
   @UseGuards(AuthGuard)
   @Get('me')
   me(@CurrentUser() user: AuthUser): AuthUser {

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -5,7 +5,6 @@ import { Logger, ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { APP_ENV } from './config/config.module';
 import type { AppEnv } from './config/env.schema';
-import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 
 /** HTTP keep-alive must be shorter than headers timeout (Node ≥18.5 invariant). */
 const KEEP_ALIVE_TIMEOUT_MS = 5_000;
@@ -56,7 +55,8 @@ async function bootstrap() {
   app.useGlobalPipes(
     new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
   );
-  app.useGlobalFilters(new HttpExceptionFilter());
+  // HttpExceptionFilter is registered via APP_FILTER in AppModule (rule 6.2)
+  // so it can inject Logger / ConfigService cleanly.
 
   // SIGTERM (orchestrator stop) + SIGINT (Ctrl-C) → graceful shutdown via
   // OnApplicationShutdown lifecycle hooks (rule 12.1, 12.4). DbModule already

--- a/apps/api/src/sealing/sealing.service.ts
+++ b/apps/api/src/sealing/sealing.service.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import { APP_ENV } from '../config/config.module';
 import type { AppEnv } from '../config/env.schema';
@@ -52,7 +52,7 @@ export class SealingService {
 
   async processSealJob(envelope_id: string): Promise<void> {
     const envelope = await this.repo.findByIdWithAll(envelope_id);
-    if (!envelope) throw new Error(`envelope_not_found:${envelope_id}`);
+    if (!envelope) throw new NotFoundException('envelope_not_found');
     if (envelope.status !== 'sealing') {
       // Envelope raced into a non-sealing state (declined, expired). Bail
       // quietly — the worker will mark the job done and no harm done.
@@ -169,7 +169,7 @@ export class SealingService {
 
   async processAuditOnlyJob(envelope_id: string): Promise<void> {
     const envelope = await this.repo.findByIdWithAll(envelope_id);
-    if (!envelope) throw new Error(`envelope_not_found:${envelope_id}`);
+    if (!envelope) throw new NotFoundException('envelope_not_found');
 
     const [events, signerDetails] = await Promise.all([
       this.repo.listEventsForEnvelope(envelope_id),

--- a/apps/api/src/signing/signing.controller.ts
+++ b/apps/api/src/signing/signing.controller.ts
@@ -17,6 +17,7 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { serialize as serializeCookie } from 'cookie';
 import type { Request, Response } from 'express';
+import { Public } from '../auth/public.decorator';
 import { extractClientIp } from '../common/extract-client-ip';
 import { APP_ENV } from '../config/config.module';
 import type { AppEnv } from '../config/env.schema';
@@ -40,6 +41,7 @@ import { SigningService, type SignMeResponse } from './signing.service';
  * web app) against `api.seald.nromomentum.com` — main.ts's enableCors already
  * honors `CORS_ORIGIN`, no per-route config needed.
  */
+@Public()
 @Controller('sign')
 export class SigningController {
   constructor(

--- a/apps/api/src/verify/verify.controller.ts
+++ b/apps/api/src/verify/verify.controller.ts
@@ -1,4 +1,5 @@
 import { Controller, Get, NotFoundException, Param } from '@nestjs/common';
+import { Public } from '../auth/public.decorator';
 import type { EnvelopeEvent } from '../envelopes/envelope.entity';
 import { EnvelopesRepository } from '../envelopes/envelopes.repository';
 import { StorageService } from '../storage/storage.service';
@@ -24,6 +25,7 @@ import { StorageService } from '../storage/storage.service';
  *   - signer decline_reason free-text (only presence flag)
  *   - signature image paths / tokens / anything internal
  */
+@Public()
 @Controller('verify')
 export class VerifyController {
   constructor(


### PR DESCRIPTION
refactor(api): NestJS best-practices pass

Applies the nestjs-best-practices skill across apps/api/. Refactors only
— no feature changes, no migrations.

## Changes (by rule)

### P0
- **Rule 6.1** — sealing.service.ts: replaced `throw new Error('envelope_not_found:...')`
  with `NotFoundException('envelope_not_found')` so the existing
  HttpExceptionFilter maps it to a clean 404 instead of leaking through
  as an unhandled-exception 500.
- **Rule 6.2** — moved HttpExceptionFilter from
  `app.useGlobalFilters(new HttpExceptionFilter())` to an APP_FILTER
  provider in AppModule. The filter now participates in DI (Logger
  injection works correctly) instead of being instantiated by hand.

### P1
- **Rule 5.1** — registered AuthGuard as APP_GUARD in AuthModule
  (default-deny). Created `auth/public.decorator.ts` for opting routes
  out via @Public(). AuthGuard now reads `IS_PUBLIC_KEY` metadata via
  Reflector and bypasses on match.
  Routes marked @Public(): all health endpoints, all verify endpoints,
  all signing endpoints (signer surface uses its own SignerSessionGuard),
  all cron endpoints (gated by CRON_SECRET header).
  Removed redundant `@UseGuards(AuthGuard)` from contacts and envelopes
  controllers — the global handles it.

### P2 — deferred
- Rule 2.4 (URI versioning): would change every public URL. Defer to a
  dedicated PR with FE coordination.
- Rule 11.4 (StreamableFile for PDFs), Rule 4.2 (multi-write transactions),
  Rule 2.6 (@ApiProperty Swagger annotations), Rule 3.2 (service splits),
  Rule 11.2 (CacheInterceptor on /verify) — separate follow-up PRs.

## Test plan
- pnpm -r typecheck — green
- pnpm -r lint — green
- pnpm --filter api test — 309/309 passed (incl. updated AuthGuard tests)
- pnpm --filter api test:e2e — 115/115 passed
- pnpm --filter web test — 629/629 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
