### PR TITLE
chore(web): upgrade Storybook 8.3.5 → 9.1.20 for Vite 6 compatibility

### DIFF
--- a/apps/web/.storybook/main.ts
+++ b/apps/web/.storybook/main.ts
@@ -2,10 +2,12 @@ import type { StorybookConfig } from '@storybook/react-vite';
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
-  addons: ['@storybook/addon-essentials', '@storybook/addon-a11y', '@storybook/addon-themes'],
+
+  addons: ['@storybook/addon-a11y', '@storybook/addon-themes', '@storybook/addon-docs'],
+
   framework: { name: '@storybook/react-vite', options: {} },
-  docs: { autodocs: 'tag' },
   typescript: { reactDocgen: 'react-docgen-typescript' },
+
   // Storybook spawns its own Vite build that ignores apps/web/vite.config.ts.
   // Mirror the `target: 'esnext'` workaround for vite 5.4.21's esbuild bug
   // (CJS-wrapped destructuring incorrectly flagged for the default target).

--- a/apps/web/.storybook/preview.tsx
+++ b/apps/web/.storybook/preview.tsx
@@ -1,4 +1,4 @@
-import type { Preview, Decorator } from '@storybook/react';
+import type { Preview, Decorator } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { withThemeFromJSXProvider } from '@storybook/addon-themes';
 import { SealdThemeProvider } from '../src/providers/SealdThemeProvider';
@@ -19,18 +19,30 @@ const withSealdTheme: Decorator = withThemeFromJSXProvider({
 
 const preview: Preview = {
   decorators: [withSealdTheme],
+
   parameters: {
     controls: { expanded: true },
     backgrounds: {
-      default: 'app',
-      values: [
-        { name: 'app', value: '#F8FAFC' }, // --bg-app / --ink-50
-        { name: 'paper', value: '#FFFFFF' }, // --paper
-        { name: 'sunken', value: '#F3F6FA' }, // --bg-sunken / --ink-100
-      ],
+      options: {
+        // --bg-app / --ink-50
+        app: { name: 'app', value: '#F8FAFC' },
+
+        // --paper
+        paper: { name: 'paper', value: '#FFFFFF' },
+
+        // --bg-sunken / --ink-100
+        sunken: { name: 'sunken', value: '#F3F6FA' },
+      },
     },
     a11y: { disable: false },
   },
+
   tags: ['autodocs'],
+
+  initialGlobals: {
+    backgrounds: {
+      value: 'app',
+    },
+  },
 };
 export default preview;

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,3 +1,6 @@
+// For more info, see https://github.com/storybookjs/eslint-plugin-storybook#configuration-flat-config-format
+import storybook from "eslint-plugin-storybook";
+
 // Flat ESLint config (ESLint 9). Replaces .eslintrc.cjs and migrates off the
 // dormant `airbnb` preset. We intentionally roll our own preset stack (instead
 // of @vercel/style-guide) because @vercel/style-guide@6 declares
@@ -37,319 +40,295 @@ import jsxA11yPlugin from 'eslint-plugin-jsx-a11y';
 import importPlugin from 'eslint-plugin-import';
 import globals from 'globals';
 
-export default tseslint.config(
-  // Ignores (was apps/web/.eslintignore). The flat config file itself is
-  // ignored from the type-aware parser path because it is intentionally not
-  // included in tsconfig.{json,node.json}. Linting it would otherwise emit
-  // `Parsing error: parserOptions.project has been provided ... but was not
-  // found in any of the provided project(s)`.
-  {
-    ignores: [
-      'node_modules/**',
-      'dist/**',
-      'dist-ssr/**',
-      'storybook-static/**',
-      'coverage/**',
-      '.vite/**',
-      'eslint.config.js',
-      // Playwright e2e + config — not part of any tsconfig project, so the
-      // typescript-eslint parser would fail with "file was not found in any
-      // of the provided project(s)". Linting these files isn't critical;
-      // the spec already runs through Playwright's own type-aware runtime.
-      'e2e/**',
-      'playwright.config.ts',
-      'playwright-report/**',
-      'test-results/**',
+export default tseslint.config(// Ignores (was apps/web/.eslintignore). The flat config file itself is
+// ignored from the type-aware parser path because it is intentionally not
+// included in tsconfig.{json,node.json}. Linting it would otherwise emit
+// `Parsing error: parserOptions.project has been provided ... but was not
+// found in any of the provided project(s)`.
+{
+  ignores: [
+    'node_modules/**',
+    'dist/**',
+    'dist-ssr/**',
+    'storybook-static/**',
+    'coverage/**',
+    '.vite/**',
+    'eslint.config.js',
+    // Playwright e2e + config — not part of any tsconfig project, so the
+    // typescript-eslint parser would fail with "file was not found in any
+    // of the provided project(s)". Linting these files isn't critical;
+    // the spec already runs through Playwright's own type-aware runtime.
+    'e2e/**',
+    'playwright.config.ts',
+    'playwright-report/**',
+    'test-results/**',
+  ],
+}, // Project-wide linterOptions. Many `// eslint-disable-next-line ...`
+// directives in the source target rules that came from the legacy `airbnb`
+// preset (e.g. `react/no-array-index-key`, `no-param-reassign`,
+// `import/first`, `no-alert`, `consistent-return`, `max-classes-per-file`,
+// `class-methods-use-this`, `no-await-in-loop`). Airbnb is now removed
+// (it was already dormant) so those rules are off and the directives are
+// flagged as "unused". Turning the report off keeps this migration
+// zero-source-churn; a future cleanup pass can sweep the directives out.
+{
+  linterOptions: {
+    reportUnusedDisableDirectives: 'off',
+  },
+}, // Base JS recommended rules.
+js.configs.recommended, // typescript-eslint recommended (non type-checked baseline; type-checked
+// rules layered on below for app source only).
+...tseslint.configs.recommended, // Plugin recommended configs (flat-config exports).
+reactPlugin.configs.flat.recommended, reactPlugin.configs.flat['jsx-runtime'], jsxA11yPlugin.flatConfigs.recommended, importPlugin.flatConfigs.recommended, importPlugin.flatConfigs.typescript, // Project-wide settings + custom rules (applies to all TS/TSX/JS/JSX files).
+{
+  files: ['**/*.{ts,tsx,js,jsx,cjs,mjs}'],
+  languageOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    parserOptions: {
+      ecmaFeatures: { jsx: true },
+      project: ['./tsconfig.json', './tsconfig.node.json'],
+      tsconfigRootDir: import.meta.dirname,
+    },
+    globals: {
+      ...globals.browser,
+      ...globals.node,
+      ...globals.es2022,
+    },
+  },
+  plugins: {
+    'react-hooks': reactHooksPlugin,
+  },
+  settings: {
+    react: { version: 'detect' },
+    // Teach eslint-plugin-import about the TS path-alias `@/*` declared in
+    // tsconfig.json so `import { ... } from '@/components/Button'` resolves
+    // for `import/no-unresolved` and `import/extensions`.
+    'import/resolver': {
+      typescript: {
+        project: ['./tsconfig.json', './tsconfig.node.json'],
+      },
+      node: true,
+    },
+  },
+  rules: {
+    // react-hooks recommended — applied manually because the plugin's
+    // `recommended` flat config export shape varies by version.
+    ...reactHooksPlugin.configs.recommended.rules,
+
+    'import/prefer-default-export': 'off',
+    'import/no-default-export': 'error',
+    // Matches the previous behavior under the airbnb chain. Several files
+    // do `import styled from 'styled-components'` (legitimate default
+    // import that happens to share a name with a named export), and a few
+    // controlled accessibility-aware places use `autoFocus`. The legacy
+    // .eslintrc.cjs produced 0 warnings/errors with these effectively
+    // disabled; we preserve that.
+    'import/no-named-as-default': 'off',
+    'import/no-named-as-default-member': 'off',
+    'jsx-a11y/no-autofocus': 'off',
+    'react/require-default-props': 'off',
+    'react/jsx-props-no-spreading': 'off',
+    'react/function-component-definition': [
+      'error',
+      { namedComponents: 'function-declaration', unnamedComponents: 'arrow-function' },
+    ],
+    '@typescript-eslint/consistent-type-imports': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+    // Layer boundary enforcement (Phase-1 component library).
+    // Layers: L0 styles < L1 primitives < L2 domain < L3 widgets < L4 providers.
+    // A component in Ln must NOT import from any layer above it. Same layer and
+    // utilities (src/lib, src/types, src/test) are always allowed.
+    'import/no-restricted-paths': [
+      'error',
+      {
+        zones: [
+          // L0 (styles) must not import from any component layer.
+          {
+            target: './src/styles',
+            from: './src/components',
+            message: 'Layer boundary: L0 (styles) must not import from components.',
+          },
+          // L1 (primitives) must not import from L2/L3.
+          {
+            target: [
+              './src/components/Badge',
+              './src/components/Button',
+              './src/components/Avatar',
+              './src/components/Icon',
+              './src/components/TextField',
+              './src/components/DocThumb',
+              './src/components/EmptyState',
+              './src/components/SignatureMark',
+              './src/components/StatCard',
+            ],
+            from: [
+              './src/components/AddSignerDropdown',
+              './src/components/EmailMasthead',
+              './src/components/FieldsPlacedList',
+              './src/components/FilterTabs',
+              './src/components/PageHeader',
+              './src/components/PageThumbStrip',
+              './src/components/PageToolbar',
+              './src/components/PlacedField',
+              './src/components/SendPanelFooter',
+              './src/components/StatusBadge',
+              './src/components/SignatureField',
+              './src/components/SignerRow',
+              './src/components/CollapsibleRail',
+              './src/components/DocumentCanvas',
+              './src/components/EmailCard',
+              './src/components/FieldPalette',
+              './src/components/FieldsBar',
+              './src/components/NavBar',
+              './src/components/PlaceOnPagesPopover',
+              './src/components/SelectSignersPopover',
+              './src/components/SideBar',
+              './src/components/SignaturePad',
+              './src/components/SignersPanel',
+            ],
+            message: 'Layer boundary: L1 primitives must not import from L2/L3 components.',
+          },
+          // L2 (domain) must not import from L3.
+          {
+            target: [
+              './src/components/AddSignerDropdown',
+              './src/components/EmailMasthead',
+              './src/components/FieldsPlacedList',
+              './src/components/FilterTabs',
+              './src/components/PageHeader',
+              './src/components/PageThumbStrip',
+              './src/components/PageToolbar',
+              './src/components/PlacedField',
+              './src/components/SendPanelFooter',
+              './src/components/StatusBadge',
+              './src/components/SignatureField',
+              './src/components/SignerRow',
+            ],
+            from: [
+              './src/components/CollapsibleRail',
+              './src/components/DocumentCanvas',
+              './src/components/EmailCard',
+              './src/components/FieldPalette',
+              './src/components/FieldsBar',
+              './src/components/NavBar',
+              './src/components/PlaceOnPagesPopover',
+              './src/components/SelectSignersPopover',
+              './src/components/SideBar',
+              './src/components/SignaturePad',
+              './src/components/SignersPanel',
+            ],
+            message: 'Layer boundary: L2 domain components must not import from L3 widgets.',
+          },
+          // Signer surface isolation — the public /sign/* flow must not
+          // import any Supabase-aware code or the authenticated apiClient.
+          // This makes a future split into a dedicated `apps/sign` package
+          // purely mechanical, and prevents the recipient bundle from
+          // accidentally pulling sender auth code.
+          {
+            target: [
+              './src/features/signing',
+              './src/pages/SigningEntryPage',
+              './src/pages/SigningPrepPage',
+              './src/pages/SigningFillPage',
+              './src/pages/SigningReviewPage',
+              './src/pages/SigningDonePage',
+              './src/pages/SigningDeclinedPage',
+              './src/components/RecipientHeader',
+              './src/components/DocumentPageCanvas',
+              './src/components/SignerField',
+              './src/components/SignatureCapture',
+              './src/components/FieldInputDrawer',
+              './src/components/ReviewList',
+              './src/components/ProgressBar',
+            ],
+            from: [
+              './src/lib/supabase',
+              './src/providers/AuthProvider',
+              './src/providers/AppStateProvider',
+              './src/features/contacts',
+              './src/lib/api/apiClient',
+            ],
+            message:
+              'Signer-surface code must not depend on sender/Supabase modules — use signApiClient + features/signing only.',
+          },
+          // L0-L3 (styles + components) must not import from L4 pages.
+          {
+            target: ['./src/styles', './src/components'],
+            from: './src/pages',
+            message: 'Layer boundary: components and styles must not import from L4 pages.',
+          },
+        ],
+      },
+    ],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector:
+          "TSTypeReference[typeName.type='Identifier'][typeName.name=/^(FC|VFC|FunctionComponent)$/]",
+        message: 'Do not use FC/VFC/FunctionComponent type — declare props explicitly.',
+      },
+      {
+        selector:
+          "TSTypeReference[typeName.type='TSQualifiedName'][typeName.left.name='React'][typeName.right.name=/^(FC|VFC|FunctionComponent)$/]",
+        message:
+          'Do not use React.FC/React.VFC/React.FunctionComponent — declare props explicitly.',
+      },
+    ],
+    // Lock in rule 1.6 — once an import has to climb two or more levels
+    // it should use the `@/*` alias instead. Same-dir (`./Foo`) and
+    // parent-dir (`../sibling`) imports remain idiomatic and are allowed.
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: ['../../*', '../../../*', '../../../../*'],
+            message: 'Use @/* path alias instead of deep relative imports (rule 1.6).',
+          },
+        ],
+      },
     ],
   },
-
-  // Project-wide linterOptions. Many `// eslint-disable-next-line ...`
-  // directives in the source target rules that came from the legacy `airbnb`
-  // preset (e.g. `react/no-array-index-key`, `no-param-reassign`,
-  // `import/first`, `no-alert`, `consistent-return`, `max-classes-per-file`,
-  // `class-methods-use-this`, `no-await-in-loop`). Airbnb is now removed
-  // (it was already dormant) so those rules are off and the directives are
-  // flagged as "unused". Turning the report off keeps this migration
-  // zero-source-churn; a future cleanup pass can sweep the directives out.
-  {
-    linterOptions: {
-      reportUnusedDisableDirectives: 'off',
-    },
-  },
-
-  // Base JS recommended rules.
-  js.configs.recommended,
-
-  // typescript-eslint recommended (non type-checked baseline; type-checked
-  // rules layered on below for app source only).
-  ...tseslint.configs.recommended,
-
-  // Plugin recommended configs (flat-config exports).
-  reactPlugin.configs.flat.recommended,
-  reactPlugin.configs.flat['jsx-runtime'],
-  jsxA11yPlugin.flatConfigs.recommended,
-  importPlugin.flatConfigs.recommended,
-  importPlugin.flatConfigs.typescript,
-
-  // Project-wide settings + custom rules (applies to all TS/TSX/JS/JSX files).
-  {
-    files: ['**/*.{ts,tsx,js,jsx,cjs,mjs}'],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      sourceType: 'module',
-      parserOptions: {
-        ecmaFeatures: { jsx: true },
-        project: ['./tsconfig.json', './tsconfig.node.json'],
-        tsconfigRootDir: import.meta.dirname,
+}, // Override: hex literals banned in component styles.
+{
+  files: ['src/components/**/*.styles.ts'],
+  rules: {
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'Literal[value=/^#[0-9A-Fa-f]{3,8}$/]',
+        message: 'Hex literals are banned in component styles — read from theme.*',
       },
-      globals: {
-        ...globals.browser,
-        ...globals.node,
-        ...globals.es2022,
+      {
+        selector: 'TemplateElement[value.raw=/#[0-9A-Fa-f]{3,8}/]',
+        message: 'Hex literals are banned in component styles — read from theme.*',
       },
-    },
-    plugins: {
-      'react-hooks': reactHooksPlugin,
-    },
-    settings: {
-      react: { version: 'detect' },
-      // Teach eslint-plugin-import about the TS path-alias `@/*` declared in
-      // tsconfig.json so `import { ... } from '@/components/Button'` resolves
-      // for `import/no-unresolved` and `import/extensions`.
-      'import/resolver': {
-        typescript: {
-          project: ['./tsconfig.json', './tsconfig.node.json'],
-        },
-        node: true,
-      },
-    },
-    rules: {
-      // react-hooks recommended — applied manually because the plugin's
-      // `recommended` flat config export shape varies by version.
-      ...reactHooksPlugin.configs.recommended.rules,
-
-      'import/prefer-default-export': 'off',
-      'import/no-default-export': 'error',
-      // Matches the previous behavior under the airbnb chain. Several files
-      // do `import styled from 'styled-components'` (legitimate default
-      // import that happens to share a name with a named export), and a few
-      // controlled accessibility-aware places use `autoFocus`. The legacy
-      // .eslintrc.cjs produced 0 warnings/errors with these effectively
-      // disabled; we preserve that.
-      'import/no-named-as-default': 'off',
-      'import/no-named-as-default-member': 'off',
-      'jsx-a11y/no-autofocus': 'off',
-      'react/require-default-props': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'react/function-component-definition': [
-        'error',
-        { namedComponents: 'function-declaration', unnamedComponents: 'arrow-function' },
-      ],
-      '@typescript-eslint/consistent-type-imports': 'error',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-      // Layer boundary enforcement (Phase-1 component library).
-      // Layers: L0 styles < L1 primitives < L2 domain < L3 widgets < L4 providers.
-      // A component in Ln must NOT import from any layer above it. Same layer and
-      // utilities (src/lib, src/types, src/test) are always allowed.
-      'import/no-restricted-paths': [
-        'error',
-        {
-          zones: [
-            // L0 (styles) must not import from any component layer.
-            {
-              target: './src/styles',
-              from: './src/components',
-              message: 'Layer boundary: L0 (styles) must not import from components.',
-            },
-            // L1 (primitives) must not import from L2/L3.
-            {
-              target: [
-                './src/components/Badge',
-                './src/components/Button',
-                './src/components/Avatar',
-                './src/components/Icon',
-                './src/components/TextField',
-                './src/components/DocThumb',
-                './src/components/EmptyState',
-                './src/components/SignatureMark',
-                './src/components/StatCard',
-              ],
-              from: [
-                './src/components/AddSignerDropdown',
-                './src/components/EmailMasthead',
-                './src/components/FieldsPlacedList',
-                './src/components/FilterTabs',
-                './src/components/PageHeader',
-                './src/components/PageThumbStrip',
-                './src/components/PageToolbar',
-                './src/components/PlacedField',
-                './src/components/SendPanelFooter',
-                './src/components/StatusBadge',
-                './src/components/SignatureField',
-                './src/components/SignerRow',
-                './src/components/CollapsibleRail',
-                './src/components/DocumentCanvas',
-                './src/components/EmailCard',
-                './src/components/FieldPalette',
-                './src/components/FieldsBar',
-                './src/components/NavBar',
-                './src/components/PlaceOnPagesPopover',
-                './src/components/SelectSignersPopover',
-                './src/components/SideBar',
-                './src/components/SignaturePad',
-                './src/components/SignersPanel',
-              ],
-              message: 'Layer boundary: L1 primitives must not import from L2/L3 components.',
-            },
-            // L2 (domain) must not import from L3.
-            {
-              target: [
-                './src/components/AddSignerDropdown',
-                './src/components/EmailMasthead',
-                './src/components/FieldsPlacedList',
-                './src/components/FilterTabs',
-                './src/components/PageHeader',
-                './src/components/PageThumbStrip',
-                './src/components/PageToolbar',
-                './src/components/PlacedField',
-                './src/components/SendPanelFooter',
-                './src/components/StatusBadge',
-                './src/components/SignatureField',
-                './src/components/SignerRow',
-              ],
-              from: [
-                './src/components/CollapsibleRail',
-                './src/components/DocumentCanvas',
-                './src/components/EmailCard',
-                './src/components/FieldPalette',
-                './src/components/FieldsBar',
-                './src/components/NavBar',
-                './src/components/PlaceOnPagesPopover',
-                './src/components/SelectSignersPopover',
-                './src/components/SideBar',
-                './src/components/SignaturePad',
-                './src/components/SignersPanel',
-              ],
-              message: 'Layer boundary: L2 domain components must not import from L3 widgets.',
-            },
-            // Signer surface isolation — the public /sign/* flow must not
-            // import any Supabase-aware code or the authenticated apiClient.
-            // This makes a future split into a dedicated `apps/sign` package
-            // purely mechanical, and prevents the recipient bundle from
-            // accidentally pulling sender auth code.
-            {
-              target: [
-                './src/features/signing',
-                './src/pages/SigningEntryPage',
-                './src/pages/SigningPrepPage',
-                './src/pages/SigningFillPage',
-                './src/pages/SigningReviewPage',
-                './src/pages/SigningDonePage',
-                './src/pages/SigningDeclinedPage',
-                './src/components/RecipientHeader',
-                './src/components/DocumentPageCanvas',
-                './src/components/SignerField',
-                './src/components/SignatureCapture',
-                './src/components/FieldInputDrawer',
-                './src/components/ReviewList',
-                './src/components/ProgressBar',
-              ],
-              from: [
-                './src/lib/supabase',
-                './src/providers/AuthProvider',
-                './src/providers/AppStateProvider',
-                './src/features/contacts',
-                './src/lib/api/apiClient',
-              ],
-              message:
-                'Signer-surface code must not depend on sender/Supabase modules — use signApiClient + features/signing only.',
-            },
-            // L0-L3 (styles + components) must not import from L4 pages.
-            {
-              target: ['./src/styles', './src/components'],
-              from: './src/pages',
-              message: 'Layer boundary: components and styles must not import from L4 pages.',
-            },
-          ],
-        },
-      ],
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector:
-            "TSTypeReference[typeName.type='Identifier'][typeName.name=/^(FC|VFC|FunctionComponent)$/]",
-          message: 'Do not use FC/VFC/FunctionComponent type — declare props explicitly.',
-        },
-        {
-          selector:
-            "TSTypeReference[typeName.type='TSQualifiedName'][typeName.left.name='React'][typeName.right.name=/^(FC|VFC|FunctionComponent)$/]",
-          message:
-            'Do not use React.FC/React.VFC/React.FunctionComponent — declare props explicitly.',
-        },
-      ],
-      // Lock in rule 1.6 — once an import has to climb two or more levels
-      // it should use the `@/*` alias instead. Same-dir (`./Foo`) and
-      // parent-dir (`../sibling`) imports remain idiomatic and are allowed.
-      'no-restricted-imports': [
-        'error',
-        {
-          patterns: [
-            {
-              group: ['../../*', '../../../*', '../../../../*'],
-              message: 'Use @/* path alias instead of deep relative imports (rule 1.6).',
-            },
-          ],
-        },
-      ],
-    },
+    ],
   },
-
-  // Override: hex literals banned in component styles.
-  {
-    files: ['src/components/**/*.styles.ts'],
-    rules: {
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: 'Literal[value=/^#[0-9A-Fa-f]{3,8}$/]',
-          message: 'Hex literals are banned in component styles — read from theme.*',
-        },
-        {
-          selector: 'TemplateElement[value.raw=/#[0-9A-Fa-f]{3,8}/]',
-          message: 'Hex literals are banned in component styles — read from theme.*',
-        },
-      ],
-    },
+}, // Override: tests, stories, .storybook, src/test.
+{
+  files: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', '.storybook/**/*', 'src/test/**/*'],
+  rules: {
+    'import/no-extraneous-dependencies': 'off',
+    'react/jsx-props-no-spreading': 'off',
+    'import/no-default-export': 'off',
+    // Tests + stories migrate to `@/*` in a separate worktree — disable
+    // the deep-relative guard here so this commit doesn't churn them.
+    'no-restricted-imports': 'off',
   },
-
-  // Override: tests, stories, .storybook, src/test.
-  {
-    files: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', '.storybook/**/*', 'src/test/**/*'],
-    rules: {
-      'import/no-extraneous-dependencies': 'off',
-      'react/jsx-props-no-spreading': 'off',
-      'import/no-default-export': 'off',
-      // Tests + stories migrate to `@/*` in a separate worktree — disable
-      // the deep-relative guard here so this commit doesn't churn them.
-      'no-restricted-imports': 'off',
-    },
+}, // Override: build/dev configs that legitimately default-export.
+{
+  files: ['vite.config.ts', '.storybook/main.ts'],
+  rules: {
+    'import/no-default-export': 'off',
+    'import/no-extraneous-dependencies': 'off',
   },
-
-  // Override: build/dev configs that legitimately default-export.
-  {
-    files: ['vite.config.ts', '.storybook/main.ts'],
-    rules: {
-      'import/no-default-export': 'off',
-      'import/no-extraneous-dependencies': 'off',
-    },
+}, // Override: ambient declarations.
+{
+  files: ['src/**/*.d.ts'],
+  rules: {
+    '@typescript-eslint/no-empty-object-type': 'off',
+    '@typescript-eslint/no-unused-vars': 'off',
   },
-
-  // Override: ambient declarations.
-  {
-    files: ['src/**/*.d.ts'],
-    rules: {
-      '@typescript-eslint/no-empty-object-type': 'off',
-      '@typescript-eslint/no-unused-vars': 'off',
-    },
-  },
-);
+}, storybook.configs["flat/recommended"]);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -40,13 +40,9 @@
   "devDependencies": {
     "@eslint/js": "^9",
     "@playwright/test": "^1",
-    "@storybook/addon-a11y": "8.3.5",
-    "@storybook/addon-essentials": "8.3.5",
-    "@storybook/addon-themes": "8.3.5",
-    "@storybook/blocks": "8.3.5",
-    "@storybook/react": "8.3.5",
-    "@storybook/react-vite": "8.3.5",
-    "@storybook/test": "8.3.5",
+    "@storybook/addon-a11y": "9.1.20",
+    "@storybook/addon-themes": "9.1.20",
+    "@storybook/react-vite": "9.1.20",
     "@testing-library/jest-dom": "6.5.0",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.5.2",
@@ -66,11 +62,13 @@
     "jsdom": "25.0.1",
     "playwright-bdd": "^8",
     "rollup-plugin-visualizer": "^7.0.1",
-    "storybook": "8.3.5",
+    "storybook": "9.1.20",
     "typescript": "5.6.3",
     "typescript-eslint": "^8",
     "vite": "6.4.2",
     "vitest": "4.1.5",
-    "vitest-axe": "0.1.0"
+    "vitest-axe": "0.1.0",
+    "eslint-plugin-storybook": "9.1.20",
+    "@storybook/addon-docs": "9.1.20"
   }
 }

--- a/apps/web/src/components/ActivityTimeline/ActivityTimeline.stories.tsx
+++ b/apps/web/src/components/ActivityTimeline/ActivityTimeline.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   Eye,
   FilePlus,

--- a/apps/web/src/components/AddSignerDropdown/AddSignerDropdown.stories.tsx
+++ b/apps/web/src/components/AddSignerDropdown/AddSignerDropdown.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { AddSignerDropdown } from './AddSignerDropdown';

--- a/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.stories.tsx
+++ b/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { AuthBrandPanel } from './AuthBrandPanel';
 
 const meta: Meta<typeof AuthBrandPanel> = {

--- a/apps/web/src/components/AuthForm/AuthForm.stories.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { AuthForm } from './AuthForm';
 import { AuthShell } from '../AuthShell';

--- a/apps/web/src/components/AuthShell/AuthShell.stories.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { AuthShell } from './AuthShell';
 
 const meta: Meta<typeof AuthShell> = {

--- a/apps/web/src/components/Avatar/Avatar.stories.tsx
+++ b/apps/web/src/components/Avatar/Avatar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Avatar } from './Avatar';
 
 const meta: Meta<typeof Avatar> = {

--- a/apps/web/src/components/Badge/Badge.stories.tsx
+++ b/apps/web/src/components/Badge/Badge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Badge } from './Badge';
 
 const meta: Meta<typeof Badge> = {

--- a/apps/web/src/components/Button/Button.stories.tsx
+++ b/apps/web/src/components/Button/Button.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Send, ArrowRight } from 'lucide-react';
 import { Button } from './Button';
 

--- a/apps/web/src/components/Card/Card.stories.tsx
+++ b/apps/web/src/components/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Card } from './Card';
 
 const meta: Meta<typeof Card> = {

--- a/apps/web/src/components/CollapsibleRail/CollapsibleRail.stories.tsx
+++ b/apps/web/src/components/CollapsibleRail/CollapsibleRail.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { CollapsibleRail } from './CollapsibleRail';

--- a/apps/web/src/components/CreateSignatureRequestDialog/CreateSignatureRequestDialog.stories.tsx
+++ b/apps/web/src/components/CreateSignatureRequestDialog/CreateSignatureRequestDialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { CreateSignatureRequestDialog } from './CreateSignatureRequestDialog';

--- a/apps/web/src/components/Divider/Divider.stories.tsx
+++ b/apps/web/src/components/Divider/Divider.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Divider } from './Divider';
 
 const meta: Meta<typeof Divider> = {

--- a/apps/web/src/components/DocThumb/DocThumb.stories.tsx
+++ b/apps/web/src/components/DocThumb/DocThumb.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DocThumb } from './DocThumb';
 
 const meta: Meta<typeof DocThumb> = {

--- a/apps/web/src/components/DocumentCanvas/DocumentCanvas.stories.tsx
+++ b/apps/web/src/components/DocumentCanvas/DocumentCanvas.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DocumentCanvas } from './DocumentCanvas';
 
 const meta: Meta<typeof DocumentCanvas> = {

--- a/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.stories.tsx
+++ b/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { DocumentPageCanvas } from './DocumentPageCanvas';
 
 const meta: Meta<typeof DocumentPageCanvas> = {

--- a/apps/web/src/components/DownloadMenu/DownloadMenu.stories.tsx
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { FileCheck2, FileText, Package, ShieldCheck } from 'lucide-react';
 import { DownloadMenu } from './DownloadMenu';
 import type { DownloadMenuItem } from './DownloadMenu.types';

--- a/apps/web/src/components/EmailCard/EmailCard.stories.tsx
+++ b/apps/web/src/components/EmailCard/EmailCard.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EmailCard } from './EmailCard';
 import { EmailMasthead } from '../EmailMasthead';
 

--- a/apps/web/src/components/EmailMasthead/EmailMasthead.stories.tsx
+++ b/apps/web/src/components/EmailMasthead/EmailMasthead.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EmailMasthead } from './EmailMasthead';
 
 const meta: Meta<typeof EmailMasthead> = {

--- a/apps/web/src/components/EmptyState/EmptyState.stories.tsx
+++ b/apps/web/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { EmptyState } from './EmptyState';
 
 const meta: Meta<typeof EmptyState> = {

--- a/apps/web/src/components/ExitConfirmDialog/ExitConfirmDialog.stories.tsx
+++ b/apps/web/src/components/ExitConfirmDialog/ExitConfirmDialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { ExitConfirmDialog } from './ExitConfirmDialog';
 

--- a/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.stories.tsx
+++ b/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { FieldInputDrawer } from './FieldInputDrawer';
 import type { FieldInputKind } from './FieldInputDrawer.types';

--- a/apps/web/src/components/FieldPalette/FieldPalette.stories.tsx
+++ b/apps/web/src/components/FieldPalette/FieldPalette.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { CollapsibleRail } from '../CollapsibleRail';
 import { FieldPalette } from './FieldPalette';

--- a/apps/web/src/components/FieldsBar/FieldsBar.stories.tsx
+++ b/apps/web/src/components/FieldsBar/FieldsBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { FieldsBar } from './FieldsBar';
 import type { FieldsBarSigner } from './FieldsBar.types';

--- a/apps/web/src/components/FieldsPlacedList/FieldsPlacedList.stories.tsx
+++ b/apps/web/src/components/FieldsPlacedList/FieldsPlacedList.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { FieldsPlacedList } from './FieldsPlacedList';

--- a/apps/web/src/components/FilterTabs/FilterTabs.stories.tsx
+++ b/apps/web/src/components/FilterTabs/FilterTabs.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { FilterTabs } from './FilterTabs';
 

--- a/apps/web/src/components/GoogleButton/GoogleButton.stories.tsx
+++ b/apps/web/src/components/GoogleButton/GoogleButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { GoogleButton } from './GoogleButton';
 
 const meta: Meta<typeof GoogleButton> = {

--- a/apps/web/src/components/GuestBadge/GuestBadge.stories.tsx
+++ b/apps/web/src/components/GuestBadge/GuestBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { GuestBadge } from './GuestBadge';
 
 const meta: Meta<typeof GuestBadge> = {

--- a/apps/web/src/components/Icon/Icon.stories.tsx
+++ b/apps/web/src/components/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PenTool, FileSignature, Send, ShieldCheck } from 'lucide-react';
 import { Icon } from './Icon';
 

--- a/apps/web/src/components/NavBar/NavBar.stories.tsx
+++ b/apps/web/src/components/NavBar/NavBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { NavBar } from './NavBar';
 import type { NavItem } from './NavBar.types';

--- a/apps/web/src/components/PageHeader/PageHeader.stories.tsx
+++ b/apps/web/src/components/PageHeader/PageHeader.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PageHeader } from './PageHeader';
 
 const meta: Meta<typeof PageHeader> = {

--- a/apps/web/src/components/PageThumbRail/PageThumbRail.stories.tsx
+++ b/apps/web/src/components/PageThumbRail/PageThumbRail.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { PageThumbRail } from './PageThumbRail';
 

--- a/apps/web/src/components/PageThumbStrip/PageThumbStrip.stories.tsx
+++ b/apps/web/src/components/PageThumbStrip/PageThumbStrip.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { PageThumbStrip } from './PageThumbStrip';
 

--- a/apps/web/src/components/PageToolbar/PageToolbar.stories.tsx
+++ b/apps/web/src/components/PageToolbar/PageToolbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { PageToolbar } from './PageToolbar';
 

--- a/apps/web/src/components/PasswordField/PasswordField.stories.tsx
+++ b/apps/web/src/components/PasswordField/PasswordField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PasswordField } from './PasswordField';
 
 const meta: Meta<typeof PasswordField> = {

--- a/apps/web/src/components/PasswordStrengthMeter/PasswordStrengthMeter.stories.tsx
+++ b/apps/web/src/components/PasswordStrengthMeter/PasswordStrengthMeter.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PasswordStrengthMeter } from './PasswordStrengthMeter';
 
 const meta: Meta<typeof PasswordStrengthMeter> = {

--- a/apps/web/src/components/PdfPageView/PdfPageView.stories.tsx
+++ b/apps/web/src/components/PdfPageView/PdfPageView.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PdfPageView } from './PdfPageView';
 import type { PDFDocumentProxy } from '../../lib/pdf';
 

--- a/apps/web/src/components/PlaceOnPagesPopover/PlaceOnPagesPopover.stories.tsx
+++ b/apps/web/src/components/PlaceOnPagesPopover/PlaceOnPagesPopover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { PlaceOnPagesPopover } from './PlaceOnPagesPopover';

--- a/apps/web/src/components/PlacedField/PlacedField.stories.tsx
+++ b/apps/web/src/components/PlacedField/PlacedField.stories.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { PlacedField } from './PlacedField';
 import type { PlacedFieldSigner, PlacedFieldValue } from './PlacedField.types';
 

--- a/apps/web/src/components/ProgressBar/ProgressBar.stories.tsx
+++ b/apps/web/src/components/ProgressBar/ProgressBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { ProgressBar } from './ProgressBar';
 
 const meta: Meta<typeof ProgressBar> = {

--- a/apps/web/src/components/RecipientHeader/RecipientHeader.stories.tsx
+++ b/apps/web/src/components/RecipientHeader/RecipientHeader.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { RecipientHeader } from './RecipientHeader';
 
 const meta: Meta<typeof RecipientHeader> = {

--- a/apps/web/src/components/RemoveLinkedCopiesDialog/RemoveLinkedCopiesDialog.stories.tsx
+++ b/apps/web/src/components/RemoveLinkedCopiesDialog/RemoveLinkedCopiesDialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { RemoveLinkedCopiesDialog } from './RemoveLinkedCopiesDialog';
 import type { RemoveLinkedScope } from './RemoveLinkedCopiesDialog.types';

--- a/apps/web/src/components/ReviewList/ReviewList.stories.tsx
+++ b/apps/web/src/components/ReviewList/ReviewList.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignatureMark } from '../SignatureMark';
 import { ReviewList } from './ReviewList';
 import type { ReviewItem } from './ReviewList.types';

--- a/apps/web/src/components/SelectSignersPopover/SelectSignersPopover.stories.tsx
+++ b/apps/web/src/components/SelectSignersPopover/SelectSignersPopover.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import type { JSX } from 'react';
 import { SelectSignersPopover } from './SelectSignersPopover';

--- a/apps/web/src/components/SendPanelFooter/SendPanelFooter.stories.tsx
+++ b/apps/web/src/components/SendPanelFooter/SendPanelFooter.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SendPanelFooter } from './SendPanelFooter';
 
 const meta: Meta<typeof SendPanelFooter> = {

--- a/apps/web/src/components/SendingOverlay/SendingOverlay.stories.tsx
+++ b/apps/web/src/components/SendingOverlay/SendingOverlay.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SendingOverlay } from './SendingOverlay';
 import type { SendingOverlaySigner } from './SendingOverlay.types';
 

--- a/apps/web/src/components/SideBar/SideBar.stories.tsx
+++ b/apps/web/src/components/SideBar/SideBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Briefcase, Mail, Star } from 'lucide-react';
 import { SideBar } from './SideBar';

--- a/apps/web/src/components/SignatureCapture/SignatureCapture.stories.tsx
+++ b/apps/web/src/components/SignatureCapture/SignatureCapture.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SignatureCapture } from './SignatureCapture';
 

--- a/apps/web/src/components/SignatureField/SignatureField.stories.tsx
+++ b/apps/web/src/components/SignatureField/SignatureField.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignatureField } from './SignatureField';
 import { FIELD_KINDS } from '../../types/sealdTypes';
 

--- a/apps/web/src/components/SignatureMark/SignatureMark.stories.tsx
+++ b/apps/web/src/components/SignatureMark/SignatureMark.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignatureMark } from './SignatureMark';
 
 const meta: Meta<typeof SignatureMark> = {

--- a/apps/web/src/components/SignaturePad/SignaturePad.stories.tsx
+++ b/apps/web/src/components/SignaturePad/SignaturePad.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SignaturePad } from './SignaturePad';
 import type { SignaturePadMode, SignaturePadProps } from './SignaturePad.types';

--- a/apps/web/src/components/SignerField/SignerField.stories.tsx
+++ b/apps/web/src/components/SignerField/SignerField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignerField } from './SignerField';
 import type { SignerFieldKind } from './SignerField.types';
 

--- a/apps/web/src/components/SignerProgressBar/SignerProgressBar.stories.tsx
+++ b/apps/web/src/components/SignerProgressBar/SignerProgressBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignerProgressBar } from './SignerProgressBar';
 
 const meta: Meta<typeof SignerProgressBar> = {

--- a/apps/web/src/components/SignerRow/SignerRow.stories.tsx
+++ b/apps/web/src/components/SignerRow/SignerRow.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SignerRow } from './SignerRow';
 import { SIGNER_STATUSES } from '../../types/sealdTypes';

--- a/apps/web/src/components/SignerStack/SignerStack.stories.tsx
+++ b/apps/web/src/components/SignerStack/SignerStack.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignerStack } from './SignerStack';
 
 const meta: Meta<typeof SignerStack> = {

--- a/apps/web/src/components/SignersPanel/SignersPanel.stories.tsx
+++ b/apps/web/src/components/SignersPanel/SignersPanel.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SignersPanel } from './SignersPanel';
 import type { SignersPanelSigner } from './SignersPanel.types';
 

--- a/apps/web/src/components/Skeleton/Skeleton.stories.tsx
+++ b/apps/web/src/components/Skeleton/Skeleton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Skeleton } from './Skeleton';
 
 const meta: Meta<typeof Skeleton> = {

--- a/apps/web/src/components/StatCard/StatCard.stories.tsx
+++ b/apps/web/src/components/StatCard/StatCard.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StatCard } from './StatCard';
 
 const meta: Meta<typeof StatCard> = {

--- a/apps/web/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/apps/web/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { StatusBadge } from './StatusBadge';
 import { SIGNER_STATUSES } from '../../types/sealdTypes';
 

--- a/apps/web/src/components/TextField/TextField.stories.tsx
+++ b/apps/web/src/components/TextField/TextField.stories.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { Mail } from 'lucide-react';
 import { TextField } from './TextField';
 

--- a/apps/web/src/components/UserMenu/UserMenu.stories.tsx
+++ b/apps/web/src/components/UserMenu/UserMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { UserMenu } from './UserMenu';
 
 function onSignOut(): void {

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthContext } from '../../providers/AuthProvider';

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../../providers/AuthProvider';

--- a/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/DebugAuthPage/DebugAuthPage.stories.tsx
+++ b/apps/web/src/pages/DebugAuthPage/DebugAuthPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MemoryRouter } from 'react-router-dom';
 import { DebugAuthPage } from './DebugAuthPage';
 

--- a/apps/web/src/pages/DocumentPage/DocumentPage.stories.tsx
+++ b/apps/web/src/pages/DocumentPage/DocumentPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { DocumentPage } from './DocumentPage';
 import type { DocumentPageSigner } from './DocumentPage.types';

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.stories.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../../providers/AuthProvider';

--- a/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
+++ b/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../../providers/AuthProvider';

--- a/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { AuthContext } from '../../providers/AuthProvider';

--- a/apps/web/src/pages/SigningDeclinedPage/SigningDeclinedPage.stories.tsx
+++ b/apps/web/src/pages/SigningDeclinedPage/SigningDeclinedPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { writeDoneSnapshot } from '../../features/signing';

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.stories.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { writeDoneSnapshot } from '../../features/signing';

--- a/apps/web/src/pages/SigningEntryPage/SigningEntryPage.stories.tsx
+++ b/apps/web/src/pages/SigningEntryPage/SigningEntryPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { SigningEntryPage } from './SigningEntryPage';
 

--- a/apps/web/src/pages/SigningFillPage/SigningFillPage.stories.tsx
+++ b/apps/web/src/pages/SigningFillPage/SigningFillPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/SigningPrepPage/SigningPrepPage.stories.tsx
+++ b/apps/web/src/pages/SigningPrepPage/SigningPrepPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/SigningReviewPage/SigningReviewPage.stories.tsx
+++ b/apps/web/src/pages/SigningReviewPage/SigningReviewPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';

--- a/apps/web/src/pages/UploadPage/UploadPage.stories.tsx
+++ b/apps/web/src/pages/UploadPage/UploadPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { UploadPage } from './UploadPage';
 

--- a/apps/web/src/pages/VerifyPage/VerifyPage.stories.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { VerifyPage } from './VerifyPage';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,26 +297,17 @@ importers:
         specifier: ^1
         version: 1.59.1
       '@storybook/addon-a11y':
-        specifier: 8.3.5
-        version: 8.3.5(storybook@8.3.5)
-      '@storybook/addon-essentials':
-        specifier: 8.3.5
-        version: 8.3.5(storybook@8.3.5)
+        specifier: 9.1.20
+        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
+      '@storybook/addon-docs':
+        specifier: 9.1.20
+        version: 9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
       '@storybook/addon-themes':
-        specifier: 8.3.5
-        version: 8.3.5(storybook@8.3.5)
-      '@storybook/blocks':
-        specifier: 8.3.5
-        version: 8.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)
-      '@storybook/react':
-        specifier: 8.3.5
-        version: 8.3.5(@storybook/test@8.3.5(storybook@8.3.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)(typescript@5.6.3)
+        specifier: 9.1.20
+        version: 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
       '@storybook/react-vite':
-        specifier: 8.3.5
-        version: 8.3.5(@storybook/test@8.3.5(storybook@8.3.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.3.5)(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
-      '@storybook/test':
-        specifier: 8.3.5
-        version: 8.3.5(storybook@8.3.5)
+        specifier: 9.1.20
+        version: 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       '@testing-library/jest-dom':
         specifier: 6.5.0
         version: 6.5.0
@@ -362,6 +353,9 @@ importers:
       eslint-plugin-react-hooks:
         specifier: 5.2.0
         version: 5.2.0(eslint@9.39.4)
+      eslint-plugin-storybook:
+        specifier: 9.1.20
+        version: 9.1.20(eslint@9.39.4)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3)
       globals:
         specifier: ^15
         version: 15.15.0
@@ -375,8 +369,8 @@ importers:
         specifier: ^7.0.1
         version: 7.0.1(rollup@4.60.2)
       storybook:
-        specifier: 8.3.5
-        version: 8.3.5
+        specifier: 9.1.20
+        version: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       typescript:
         specifier: 5.6.3
         version: 5.6.3
@@ -726,9 +720,6 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
-
-  '@base2/pretty-print-object@1.0.1':
-    resolution: {integrity: sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==}
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
@@ -1716,11 +1707,11 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0':
-    resolution: {integrity: sha512-2D6y7fNvFmsLmRt6UCOFJPvFoPMJGT0Uh1Wg0RaigUp7kdQPs6yYn8Dmx6GZkOH/NW0yMTwRz/p0SRMMRo50vA==}
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1':
+    resolution: {integrity: sha512-J4BaTocTOYFkMHIra1JDWrMWpNmBl4EkplIwHEsV8aeUOtdWjwSnln9U7twjMFTAEB7mptNtSKyVi1Y2W9sDJw==}
     peerDependencies:
       typescript: '>= 4.3.x'
-      vite: ^3.0.0 || ^4.0.0 || ^5.0.0
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -2274,109 +2265,31 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@storybook/addon-a11y@8.3.5':
-    resolution: {integrity: sha512-/19UO8IXbyfcYK5K8ejSYF+hC+EK79c0bBPHMNeYSFOHSqQM3KoMo+TLIcLsuhuRClmlM+4Zs+VSIYDwc+d3ig==}
+  '@storybook/addon-a11y@9.1.20':
+    resolution: {integrity: sha512-VFZ34y4ApmFwIzPRs2OJrG6jtYhM5y91eCZLTlR/HMGQciKF4TdOJHjj+5vf91SOER5UDcLizXetpiUowiZSgw==}
     peerDependencies:
-      storybook: ^8.3.5
+      storybook: ^9.1.20
 
-  '@storybook/addon-actions@8.3.5':
-    resolution: {integrity: sha512-t8D5oo+4XfD+F8091wLa2y/CDd/W2lExCeol5Vm1tp5saO+u6f2/d7iykLhTowWV84Uohi3D073uFeyTAlGebg==}
+  '@storybook/addon-docs@9.1.20':
+    resolution: {integrity: sha512-eUIOd4u/p9994Nkv8Avn6r/xmS7D+RNmhmu6KGROefN3myLe3JfhSdimal2wDFe/h/OUNZ/LVVKMZrya9oEfKQ==}
     peerDependencies:
-      storybook: ^8.3.5
+      storybook: ^9.1.20
 
-  '@storybook/addon-backgrounds@8.3.5':
-    resolution: {integrity: sha512-IQGjDujuw8+iSqKREdkL8I5E/5CAHZbfOWd4A75PQK2D6qZ0fu/xRwTOQOH4jP6xn/abvfACOdL6A0d5bU90ag==}
+  '@storybook/addon-themes@9.1.20':
+    resolution: {integrity: sha512-GY9WKJMxbsI24CTj1PToWbjZGuXnwLasahv51wpIQC94Sn/8NxRta8K2BO2Pqb7U3sdtjH6htUasnQnaL0/ZBw==}
     peerDependencies:
-      storybook: ^8.3.5
+      storybook: ^9.1.20
 
-  '@storybook/addon-controls@8.3.5':
-    resolution: {integrity: sha512-2eCVobUUvY1Rq7sp1U8Mx8t44VXwvi0E+hqyrsqOx5TTSC/FUQ+hNAX6GSYUcFIyQQ1ORpKNlUjAAdjxBv1ZHQ==}
+  '@storybook/builder-vite@9.1.20':
+    resolution: {integrity: sha512-cdU3Q2/wEaT8h+mApFToRiF/0hYKH1eAkD0scQn67aODgp7xnkr0YHcdA+8w0Uxd2V7U8crV/cmT/HD0ELVOGw==}
     peerDependencies:
-      storybook: ^8.3.5
+      storybook: ^9.1.20
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/addon-docs@8.3.5':
-    resolution: {integrity: sha512-MOVfo1bY8kXTzbvmWnx3UuSO4WNykFz7Edvb3mxltNyuW7UDRZGuIuSe32ddT/EtLJfurrC9Ja3yBy4KBUGnMA==}
+  '@storybook/csf-plugin@9.1.20':
+    resolution: {integrity: sha512-HHgk50YQhML7mT01Mzf9N7lNMFHWN4HwwRP90kPT9Ct+Jhx7h3LBDbdmWjI96HwujcpY7eoYdTfpB1Sw8Z7nBQ==}
     peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-essentials@8.3.5':
-    resolution: {integrity: sha512-hXTtPuN4/IsXjUrkMPAuz1qKAl8DovdXpjQgjQs7jSAVx3kc4BZaGqJ3gaVenKtO8uDchmA92BoQygpkc8eWhw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-highlight@8.3.5':
-    resolution: {integrity: sha512-ku0epul9aReCR3Gv/emwYnsqg3vgux5OmYMjoDcJC7s+LyfweSzLV/f5t9gSHazikJElh5TehtVkWbC4QfbGSw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-measure@8.3.5':
-    resolution: {integrity: sha512-6GVehgbHhFIFS69xSfRV+12VK0cnuIAtZdp1J3eUCc2ATrcigqVjTM6wzZz6kBuX6O3dcusr7Wg46KtNliqLqg==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-outline@8.3.5':
-    resolution: {integrity: sha512-dwmK6GzjEnQP9Yo0VnBUQtJkXZlXdfjWyskZ/IlUVc+IFdeeCtIiMyA92oMfHo8eXt0k1g21ZqMaIn7ZltOuHw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-themes@8.3.5':
-    resolution: {integrity: sha512-kXHKAZvAtMoOR1XFGTo5/T8anE9x7W8Ddpof2wyi+du5HscFiEW7TesWdvNgBUR7wAaiR21aW2S4jC72a6gTCw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-toolbars@8.3.5':
-    resolution: {integrity: sha512-Ml2gc9q8WbteDvmuAZGgBxt5SqWMXzuTkMjlsA8EB53hlkN1w9esX4s8YtBeNqC3HKoUzcdq8uexSBqU8fDbSA==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/addon-viewport@8.3.5':
-    resolution: {integrity: sha512-FSWydoPiVWFXEittG7O1YgvuaqoU9Vb+qoq9XfP/hvQHHMDcMZvC40JaV8AnJeTXaM7ngIjcn9XDEfGbFfOzXw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/blocks@8.3.5':
-    resolution: {integrity: sha512-8cHTdTywolTHlgwN8I7YH7saWAIjGzV617AwjhJ95AKlC0VtpO1gAFcAgCqr4DU9eMc+LZuvbnaU/RSvA5eCCQ==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.3.5
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@storybook/builder-vite@8.3.5':
-    resolution: {integrity: sha512-paGX8tEmAeAKFU5Cnwkq3RAi3LFCnmjAxMJikT09jUi6jDpNa0VzH8jbLxKdjsPMAsz0Wv3mrLvL2b8hyxLWAw==}
-    peerDependencies:
-      '@preact/preset-vite': '*'
-      storybook: ^8.3.5
-      typescript: '>= 4.3.x'
-      vite: ^4.0.0 || ^5.0.0
-      vite-plugin-glimmerx: '*'
-    peerDependenciesMeta:
-      '@preact/preset-vite':
-        optional: true
-      typescript:
-        optional: true
-      vite-plugin-glimmerx:
-        optional: true
-
-  '@storybook/components@8.6.17':
-    resolution: {integrity: sha512-0b8xkkuPCNbM8LTOzyfxuo2KdJCHIfu3+QxWBFllXap0eYNHwVeSxE5KERQ/bk2GDCiRzaUbwH9PeLorxOzJJQ==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/core@8.3.5':
-    resolution: {integrity: sha512-GOGfTvdioNa/n+Huwg4u/dsyYyBcM+gEcdxi3B7i5x4yJ3I912KoVshumQAOF2myKSRdI8h8aGWdx7nnjd0+5Q==}
-
-  '@storybook/csf-plugin@8.3.5':
-    resolution: {integrity: sha512-ODVqNXwJt90hG7QW8I9w/XUyOGlr0l7XltmIJgXwB/2cYDvaGu3JV5Ybg7O0fxPV8uXk7JlRuUD8ZYv5Low6pA==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/csf@0.1.13':
-    resolution: {integrity: sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==}
+      storybook: ^9.1.20
 
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
@@ -2388,61 +2301,33 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
-  '@storybook/instrumenter@8.3.5':
-    resolution: {integrity: sha512-NLDXai5y2t1ITgHVK9chyL0rMFZbICCOGcnTbyWhkLbiEWZKPJ8FuB8+g+Ba6zwtCve1A1Cnb4O2LOWy7TgWQw==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/manager-api@8.6.17':
-    resolution: {integrity: sha512-sPJytvClNrw5GgKcPletMTxDOAYcTRA8VRt9E+ncKvPSYHtPDqLfGTgWajXmt0hRsiBUN5bOgLS9bmNjNQWhrw==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/preview-api@8.6.17':
-    resolution: {integrity: sha512-vpTCTkw11wXerYnlG5Q0y4SbFqG9O6GhR0hlYgCn3Z9kcHlNjK/xuwd3h4CvwNXxRNWZGT8qYYCLn5gSSrX6fA==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/react-dom-shim@8.3.5':
-    resolution: {integrity: sha512-Hf0UitJ/K0C7ajooooUK/PxOR4ihUWqsC7iCV1Gqth8U37dTeLMbaEO4PBwu0VQ+Ufg0N8BJLWfg7o6G4hrODw==}
+  '@storybook/react-dom-shim@9.1.20':
+    resolution: {integrity: sha512-UYdZavfPwHEqCKMqPssUOlyFVZiJExLxnSHwkICSZBmw3gxXJcp1aXWs7PvoZdWz2K4ztl3IcKErXXHeiY6w+A==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.3.5
+      storybook: ^9.1.20
 
-  '@storybook/react-vite@8.3.5':
-    resolution: {integrity: sha512-1pnN1JB7GrHUoTVn8VGkS240VNGhWkZBOMaaaRQnkgY1dCrFxAQv4YKFVuC250+rQzgp8X33J/pDAukgwzWYFQ==}
-    engines: {node: '>=18.0.0'}
+  '@storybook/react-vite@9.1.20':
+    resolution: {integrity: sha512-buXeNvEJ9kp4FKbGYV7zW4sh/KS01EAjeq8Z6AVxaXOh4W2CIRTKM9maWGz+Rr+YyqQIq/Gl+RqNwxctpxeuHA==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.3.5
-      vite: ^4.0.0 || ^5.0.0
+      storybook: ^9.1.20
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@storybook/react@8.3.5':
-    resolution: {integrity: sha512-kuBPe/wBin10SWr4EWPKxiTRGQ4RD2etGEVWVQLqVpOuJp/J2hVvXQHtCfZXU4TZT5x4PBbPRswbr58+XlF+kQ==}
-    engines: {node: '>=18.0.0'}
+  '@storybook/react@9.1.20':
+    resolution: {integrity: sha512-TJhqzggs7HCvLhTXKfx8HodnVq9YizsB2J31s9v6olU0UCxbCY+FYaCF+XdE8qUCyefGRZgHKzGBIczJ/q9e2g==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@storybook/test': 8.3.5
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.3.5
-      typescript: '>= 4.2.x'
+      storybook: ^9.1.20
+      typescript: '>= 4.9.x'
     peerDependenciesMeta:
-      '@storybook/test':
-        optional: true
       typescript:
         optional: true
-
-  '@storybook/test@8.3.5':
-    resolution: {integrity: sha512-1BXWsUGWk9FiKKelZZ55FDJdeoL8uRBHbjTYBRM2xJLhdNSvGzI4Tb3bkmxPpGn72Ua6AyldhlTxr2BpUFKOHA==}
-    peerDependencies:
-      storybook: ^8.3.5
-
-  '@storybook/theming@8.6.17':
-    resolution: {integrity: sha512-IttFvRqozpuzN5MlQEWGOzUA2rZg86688Dyv1d+bjpYcFHtY1X4XyTCGwv1BPTaTsB959oM8R2yoNYWQkABbBA==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
   '@stryker-mutator/api@8.7.1':
     resolution: {integrity: sha512-56vxcVxIfW0jxJhr7HB9Zx6Xr5/M95RG9MUK1DtbQhlmQesjpfBBsrPLOPzBJaITPH/vOYykuJ69vgSAMccQyw==}
@@ -2606,6 +2491,10 @@ packages:
     resolution: {integrity: sha512-xGGHpBXYSHUUr6XsKBfs85TWlYKpTc37cSBBVrXcib2MkHLboWlkClhWF37JKlDb9KEq3dHs+f2xR7XJEWGBxA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
   '@testing-library/react@16.3.2':
     resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
     engines: {node: '>=18'}
@@ -2623,6 +2512,12 @@ packages:
 
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -2692,17 +2587,11 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  '@types/escodegen@0.0.6':
-    resolution: {integrity: sha512-AjwI4MvWx3HAOaZqYsjKWyEObT9lcVV0Y0V8nXo6cXzN8ZiMxVhf6F3d/UNvXVGKrEzL/Dluc5p+y9GkzlTWig==}
-
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
   '@types/eslint@9.6.1':
     resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
-  '@types/estree@0.0.51':
-    resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2712,12 +2601,6 @@ packages:
 
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
-
-  '@types/find-cache-dir@3.2.1':
-    resolution: {integrity: sha512-frsJrz2t/CeGifcu/6uRo4b+SzAwT4NYCVPu1GN8IB9XTzrpPkGuV0tmh9mN+/L0PklAlsC3u5Fxt0ju00LXIw==}
-
-  '@types/glob@7.2.0':
-    resolution: {integrity: sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -2746,9 +2629,6 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
-
   '@types/long@4.0.2':
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
 
@@ -2763,10 +2643,6 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/minimatch@6.0.0':
-    resolution: {integrity: sha512-zmPitbQ8+6zNutpwgcQuLcsEpn/Cj54Kbn7L5pX0Os5kdWplB7xPgEh/g+SWOB/qmows2gpuCaPyduq8ZZRnxA==}
-    deprecated: This is a stub types definition. minimatch provides its own type definitions, so you do not need this installed.
 
   '@types/mjml-core@5.0.0':
     resolution: {integrity: sha512-E1Rho2ZfVEqZekQoESDuPAw7C3MrzdUvS6YAiEPGdhQQqAchMXfdChXlSi6ly9YhZgUP026ujrRlEGJn9o/zAg==}
@@ -2850,9 +2726,6 @@ packages:
 
   '@types/uuid@3.4.13':
     resolution: {integrity: sha512-pAeZeUbLE4Z9Vi9wsWV2bYPTweEHeJJy0G4pEjOA/FSvy1Ad5U5Km8iDV6TKre1mjBiVNfAdVHKruP8bAh4Q5A==}
-
-  '@types/uuid@9.0.8':
-    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
 
   '@types/validator@13.15.10':
     resolution: {integrity: sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==}
@@ -3098,11 +2971,22 @@ packages:
       '@vitest/browser':
         optional: true
 
-  '@vitest/expect@2.0.5':
-    resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
   '@vitest/expect@4.1.5':
     resolution: {integrity: sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@4.1.5':
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
@@ -3115,11 +2999,8 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@2.0.5':
-    resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
-
-  '@vitest/pretty-format@2.1.9':
-    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
   '@vitest/pretty-format@4.1.5':
     resolution: {integrity: sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==}
@@ -3130,17 +3011,14 @@ packages:
   '@vitest/snapshot@4.1.5':
     resolution: {integrity: sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==}
 
-  '@vitest/spy@2.0.5':
-    resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
   '@vitest/spy@4.1.5':
     resolution: {integrity: sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==}
 
-  '@vitest/utils@2.0.5':
-    resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
-
-  '@vitest/utils@2.1.9':
-    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
@@ -3240,10 +3118,6 @@ packages:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn-walk@7.2.0:
-    resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
-    engines: {node: '>=0.4.0'}
 
   acorn-walk@8.3.5:
     resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
@@ -3563,9 +3437,6 @@ packages:
 
   brotli@1.3.3:
     resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
-
-  browser-assert@1.2.1:
-    resolution: {integrity: sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==}
 
   browserify-zlib@0.2.0:
     resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
@@ -3901,9 +3772,6 @@ packages:
 
   common-ancestor-path@1.0.1:
     resolution: {integrity: sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==}
-
-  commondir@1.0.1:
-    resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
@@ -4564,6 +4432,13 @@ packages:
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
 
+  eslint-plugin-storybook@9.1.20:
+    resolution: {integrity: sha512-T7uqlzZABlOm0n36UQyyP0u7r+6/Bz5CTAvFK5n+FQPkAhba01mGovYVG61gcDeC06I0AlbZCZ0MP7MFxXAEVg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      eslint: '>=8'
+      storybook: ^9.1.20
+
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
     engines: {node: '>=8.0.0'}
@@ -4779,10 +4654,6 @@ packages:
     resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
     engines: {node: '>= 0.8'}
 
-  find-cache-dir@3.3.2:
-    resolution: {integrity: sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==}
-    engines: {node: '>=8'}
-
   find-up-simple@1.0.1:
     resolution: {integrity: sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==}
     engines: {node: '>=18'}
@@ -4794,6 +4665,10 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  find-up@7.0.0:
+    resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
+    engines: {node: '>=18'}
 
   find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
@@ -4861,10 +4736,6 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
-
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
 
   fs-monkey@1.1.0:
     resolution: {integrity: sha512-QMUezzXWII9EV5aTFXW1UBVUO77wYPpjqIF8/AviUCThNeSYZykpoTixUeaNNBwmCev0AMDWMAni+f8Hxb1IFw==}
@@ -4975,12 +4846,6 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
-  glob-promise@4.2.2:
-    resolution: {integrity: sha512-xcUzJ8NWN5bktoTIX7eOclO1Npxd/dyVqUJxlLIDasT4C7KZyqlPIwkdJ0Ypiy3p2ZKahTjK4M9uC3sNSfNMzw==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      glob: ^7.1.6
-
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
@@ -5083,9 +4948,6 @@ packages:
   hast-util-from-parse5@8.0.3:
     resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
 
-  hast-util-heading-rank@3.0.0:
-    resolution: {integrity: sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==}
-
   hast-util-is-element@3.0.0:
     resolution: {integrity: sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==}
 
@@ -5100,9 +4962,6 @@ packages:
 
   hast-util-to-parse5@8.0.1:
     resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
-
-  hast-util-to-string@3.0.1:
-    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -5141,10 +5000,6 @@ packages:
     resolution: {integrity: sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==}
     engines: {node: '>=6'}
     hasBin: true
-
-  html-tags@3.3.1:
-    resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
-    engines: {node: '>=8'}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -5276,10 +5131,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  is-absolute-url@4.0.1:
-    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-arguments@1.2.0:
     resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
@@ -5416,10 +5267,6 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
-
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -5708,10 +5555,6 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
-  jsdoc-type-pratt-parser@4.8.0:
-    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
-    engines: {node: '>=12.0.0'}
-
   jsdom@25.0.1:
     resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
     engines: {node: '>=18'}
@@ -5857,6 +5700,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  locate-path@7.2.0:
+    resolution: {integrity: sha512-gvVijfZvn7R+2qyPX8mAuKcFGDf6Nc61GdvGafQsHL0sBIxfKzA+usWn4GFC/bk+QdwPUD4kWFJLhElipq+0VA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   lodash-es@4.18.1:
     resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
@@ -5936,10 +5783,6 @@ packages:
   magic-string@0.22.5:
     resolution: {integrity: sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==}
 
-  magic-string@0.27.0:
-    resolution: {integrity: sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==}
-    engines: {node: '>=12'}
-
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -5967,20 +5810,8 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
-  map-or-similar@1.5.0:
-    resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
-
-  markdown-to-jsx@7.7.17:
-    resolution: {integrity: sha512-7mG/1feQ0TX5I7YyMZVDgCC/y2I3CiEhIRQIhyov9nGBP5eoVrOXXHuL5ZP8GRfxVZKRiXWJgwXkb9It+nQZfQ==}
-    engines: {node: '>= 10'}
-    peerDependencies:
-      react: '>= 0.14.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -6035,9 +5866,6 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
-
-  memoizerific@1.11.3:
-    resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
 
   mensch@0.3.4:
     resolution: {integrity: sha512-IAeFvcOnV9V0Yk+bFhYR07O3yNina9ANIN5MoXBKYJ/RLYPurd2d0yw14MDhpr9/momp0WofT1bPUh3hkzdi/g==}
@@ -6607,6 +6435,10 @@ packages:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
 
+  p-limit@4.0.0:
+    resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   p-limit@6.2.0:
     resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
     engines: {node: '>=18'}
@@ -6618,6 +6450,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-locate@6.0.0:
+    resolution: {integrity: sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   p-queue@8.1.1:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
@@ -6674,6 +6510,10 @@ packages:
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
+
+  path-exists@5.0.0:
+    resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -6867,10 +6707,6 @@ packages:
     resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
     engines: {node: '>=10.13.0'}
 
-  polished@4.3.1:
-    resolution: {integrity: sha512-OBatVyC/N7SCW/FaDHrSd+vn0o5cS855TOmYi4OkdWUMSJCET/xip//ch8xGUvtr3i44X9LVyWwQlRMTN3pwSA==}
-    engines: {node: '>=10'}
-
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -6951,10 +6787,6 @@ packages:
 
   process-warning@5.0.0:
     resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
-
-  process@0.11.10:
-    resolution: {integrity: sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==}
-    engines: {node: '>= 0.6.0'}
 
   progress@2.0.3:
     resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
@@ -7043,36 +6875,19 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-colorful@5.6.1:
-    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
       typescript: '>= 4.3.x'
 
-  react-docgen@7.1.1:
-    resolution: {integrity: sha512-hlSJDQ2synMPKFZOsKo9Hi8WWZTC7POR8EmWvTSjow+VDgKzkmjQvFm2fk0tmRw+f0vTOIYKlarR0iL4996pdg==}
-    engines: {node: '>=16.14.0'}
-
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
-    peerDependencies:
-      react: ^18.3.1
+  react-docgen@8.0.3:
+    resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
+    engines: {node: ^20.9.0 || >=22}
 
   react-dom@19.2.5:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
-
-  react-element-to-jsx-string@15.0.0:
-    resolution: {integrity: sha512-UDg4lXB6BzlobN60P8fHWVPX3Kyw8ORrTeBtClmIlGdkOOE+GYQSFvmEU5iLLpwp/6v42DINwNcwOhOLfQ//FQ==}
-    peerDependencies:
-      react: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
-      react-dom: ^0.14.8 || ^15.0.1 || ^16.0.0 || ^17.0.1 || ^18.0.0
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7099,10 +6914,6 @@ packages:
     peerDependenciesMeta:
       react-dom:
         optional: true
-
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
@@ -7162,17 +6973,11 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
-  rehype-external-links@3.0.0:
-    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
-
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
-
-  rehype-slug@6.0.0:
-    resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
 
   rehype-stringify@10.0.1:
     resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
@@ -7369,9 +7174,6 @@ packages:
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
-
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   scheduler@0.25.0-rc-603e6108-20241029:
     resolution: {integrity: sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==}
@@ -7582,9 +7384,14 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
-  storybook@8.3.5:
-    resolution: {integrity: sha512-hYQVtP2l+3kO8oKDn4fjXXQYxgTRsj/LaV6lUMJH0zt+OhVmDXKJLxmdUP4ieTm0T8wEbSYosFavgPcQZlxRfw==}
+  storybook@9.1.20:
+    resolution: {integrity: sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==}
     hasBin: true
+    peerDependencies:
+      prettier: ^2 || ^3
+    peerDependenciesMeta:
+      prettier:
+        optional: true
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -7752,9 +7559,6 @@ packages:
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
 
-  telejson@7.2.0:
-    resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
-
   terser-webpack-plugin@5.4.0:
     resolution: {integrity: sha512-Bn5vxm48flOIfkdl5CaD2+1CiUVbonWQ3KQPyP7/EuIl9Gbzq/gQFOzaMFUEgVjB1396tcK0SG8XcNJ/2kDH8g==}
     engines: {node: '>= 10.13.0'}
@@ -7812,16 +7616,16 @@ packages:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
-  tinyrainbow@1.2.0:
-    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
-  tinyspy@3.0.2:
-    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -7988,10 +7792,6 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  type-fest@2.19.0:
-    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
-    engines: {node: '>=12.20'}
-
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -8088,6 +7888,10 @@ packages:
   unicode-trie@2.0.0:
     resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
+  unicorn-magic@0.1.0:
+    resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
+    engines: {node: '>=18'}
+
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
@@ -8152,9 +7956,6 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  util@0.12.5:
-    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
-
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -8170,10 +7971,6 @@ packages:
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -9184,8 +8981,6 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base2/pretty-print-object@1.0.1': {}
-
   '@bcoe/v8-coverage@0.2.3': {}
 
   '@bcoe/v8-coverage@1.0.2': {}
@@ -10141,11 +9936,10 @@ snapshots:
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.3.0(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
     dependencies:
-      glob: 7.2.3
-      glob-promise: 4.2.2(glob@7.2.3)
-      magic-string: 0.27.0
+      glob: 13.0.6
+      magic-string: 0.30.21
       react-docgen-typescript: 2.4.0(typescript@5.6.3)
       vite: 6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)
     optionalDependencies:
@@ -10202,11 +9996,11 @@ snapshots:
       - supports-color
     optional: true
 
-  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@18.3.1)':
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.5)':
     dependencies:
       '@types/mdx': 2.0.13
       '@types/react': 19.2.14
-      react: 18.3.1
+      react: 19.2.5
 
   '@napi-rs/canvas-android-arm64@0.1.99':
     optional: true
@@ -10743,297 +10537,84 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-a11y@8.3.5(storybook@8.3.5)':
+  '@storybook/addon-a11y@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))':
     dependencies:
-      '@storybook/addon-highlight': 8.3.5(storybook@8.3.5)
+      '@storybook/global': 5.0.0
       axe-core: 4.11.3
-      storybook: 8.3.5
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
 
-  '@storybook/addon-actions@8.3.5(storybook@8.3.5)':
+  '@storybook/addon-docs@9.1.20(@types/react@19.2.14)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))':
     dependencies:
-      '@storybook/global': 5.0.0
-      '@types/uuid': 9.0.8
-      dequal: 2.0.3
-      polished: 4.3.1
-      storybook: 8.3.5
-      uuid: 9.0.1
-
-  '@storybook/addon-backgrounds@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      memoizerific: 1.11.3
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-controls@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      dequal: 2.0.3
-      lodash: 4.18.1
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-docs@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@18.3.1)
-      '@storybook/blocks': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)
-      '@storybook/csf-plugin': 8.3.5(storybook@8.3.5)
-      '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)
-      '@types/react': 19.2.14
-      fs-extra: 11.3.4
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      rehype-external-links: 3.0.0
-      rehype-slug: 6.0.0
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-essentials@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/addon-actions': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-backgrounds': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-controls': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-docs': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-highlight': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-measure': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-outline': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-toolbars': 8.3.5(storybook@8.3.5)
-      '@storybook/addon-viewport': 8.3.5(storybook@8.3.5)
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-highlight@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      storybook: 8.3.5
-
-  '@storybook/addon-measure@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      storybook: 8.3.5
-      tiny-invariant: 1.3.3
-
-  '@storybook/addon-outline@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-themes@8.3.5(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-
-  '@storybook/addon-toolbars@8.3.5(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
-
-  '@storybook/addon-viewport@8.3.5(storybook@8.3.5)':
-    dependencies:
-      memoizerific: 1.11.3
-      storybook: 8.3.5
-
-  '@storybook/blocks@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)':
-    dependencies:
-      '@storybook/csf': 0.1.13
-      '@storybook/global': 5.0.0
-      '@storybook/icons': 1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/lodash': 4.17.24
-      color-convert: 2.0.1
-      dequal: 2.0.3
-      lodash: 4.18.1
-      markdown-to-jsx: 7.7.17(react@18.3.1)
-      memoizerific: 1.11.3
-      polished: 4.3.1
-      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.3.5
-      telejson: 7.2.0
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@storybook/blocks@8.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)':
-    dependencies:
-      '@storybook/csf': 0.1.13
-      '@storybook/global': 5.0.0
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.5)
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
       '@storybook/icons': 1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@types/lodash': 4.17.24
-      color-convert: 2.0.1
-      dequal: 2.0.3
-      lodash: 4.18.1
-      markdown-to-jsx: 7.7.17(react@19.2.5)
-      memoizerific: 1.11.3
-      polished: 4.3.1
-      react-colorful: 5.6.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      storybook: 8.3.5
-      telejson: 7.2.0
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    optionalDependencies:
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
 
-  '@storybook/builder-vite@8.3.5(storybook@8.3.5)(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
+  '@storybook/addon-themes@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))':
     dependencies:
-      '@storybook/csf-plugin': 8.3.5(storybook@8.3.5)
-      '@types/find-cache-dir': 3.2.1
-      browser-assert: 1.2.1
-      es-module-lexer: 1.7.0
-      express: 4.22.1
-      find-cache-dir: 3.3.2
-      fs-extra: 11.3.4
-      magic-string: 0.30.21
-      storybook: 8.3.5
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+      ts-dedent: 2.2.0
+
+  '@storybook/builder-vite@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
+    dependencies:
+      '@storybook/csf-plugin': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       ts-dedent: 2.2.0
       vite: 6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - supports-color
 
-  '@storybook/components@8.6.17(storybook@8.3.5)':
+  '@storybook/csf-plugin@9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))':
     dependencies:
-      storybook: 8.3.5
-
-  '@storybook/core@8.3.5':
-    dependencies:
-      '@storybook/csf': 0.1.13
-      '@types/express': 4.17.25
-      better-opn: 3.0.2
-      browser-assert: 1.2.1
-      esbuild: 0.28.0
-      esbuild-register: 3.6.0(esbuild@0.28.0)
-      express: 4.22.1
-      jsdoc-type-pratt-parser: 4.8.0
-      process: 0.11.10
-      recast: 0.23.11
-      semver: 7.7.4
-      util: 0.12.5
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@storybook/csf-plugin@8.3.5(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       unplugin: 1.16.1
 
-  '@storybook/csf@0.1.13':
-    dependencies:
-      type-fest: 2.19.0
-
   '@storybook/global@5.0.0': {}
-
-  '@storybook/icons@1.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/icons@1.6.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@storybook/instrumenter@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/global': 5.0.0
-      '@vitest/utils': 2.1.9
-      storybook: 8.3.5
-      util: 0.12.5
-
-  '@storybook/manager-api@8.6.17(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
-
-  '@storybook/preview-api@8.6.17(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
-
-  '@storybook/react-dom-shim@8.3.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.3.5)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.3.5
-
-  '@storybook/react-dom-shim@8.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)':
+  '@storybook/react-dom-shim@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))':
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      storybook: 8.3.5
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
 
-  '@storybook/react-vite@8.3.5(@storybook/test@8.3.5(storybook@8.3.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@8.3.5)(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
+  '@storybook/react-vite@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.2)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.3.0(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       '@rollup/pluginutils': 5.3.0(rollup@4.60.2)
-      '@storybook/builder-vite': 8.3.5(storybook@8.3.5)(typescript@5.6.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
-      '@storybook/react': 8.3.5(@storybook/test@8.3.5(storybook@8.3.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)(typescript@5.6.3)
-      find-up: 5.0.0
+      '@storybook/builder-vite': 9.1.20(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+      '@storybook/react': 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3)
+      find-up: 7.0.0
       magic-string: 0.30.21
       react: 19.2.5
-      react-docgen: 7.1.1
+      react-docgen: 8.0.3
       react-dom: 19.2.5(react@19.2.5)
       resolve: 1.22.12
-      storybook: 8.3.5
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
       tsconfig-paths: 4.2.0
       vite: 6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)
     transitivePeerDependencies:
-      - '@preact/preset-vite'
-      - '@storybook/test'
       - rollup
       - supports-color
       - typescript
-      - vite-plugin-glimmerx
 
-  '@storybook/react@8.3.5(@storybook/test@8.3.5(storybook@8.3.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)(typescript@5.6.3)':
+  '@storybook/react@9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3)':
     dependencies:
-      '@storybook/components': 8.6.17(storybook@8.3.5)
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.17(storybook@8.3.5)
-      '@storybook/preview-api': 8.6.17(storybook@8.3.5)
-      '@storybook/react-dom-shim': 8.3.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@8.3.5)
-      '@storybook/theming': 8.6.17(storybook@8.3.5)
-      '@types/escodegen': 0.0.6
-      '@types/estree': 0.0.51
-      '@types/node': 22.19.17
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2(acorn@7.4.1)
-      acorn-walk: 7.2.0
-      escodegen: 2.1.0
-      html-tags: 3.3.1
-      prop-types: 15.8.1
+      '@storybook/react-dom-shim': 9.1.20(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-      react-element-to-jsx-string: 15.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      semver: 7.7.4
-      storybook: 8.3.5
-      ts-dedent: 2.2.0
-      type-fest: 2.19.0
-      util-deprecate: 1.0.2
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
     optionalDependencies:
-      '@storybook/test': 8.3.5(storybook@8.3.5)
       typescript: 5.6.3
-
-  '@storybook/test@8.3.5(storybook@8.3.5)':
-    dependencies:
-      '@storybook/csf': 0.1.13
-      '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.3.5(storybook@8.3.5)
-      '@testing-library/dom': 10.4.0
-      '@testing-library/jest-dom': 6.5.0
-      '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
-      '@vitest/expect': 2.0.5
-      '@vitest/spy': 2.0.5
-      storybook: 8.3.5
-      util: 0.12.5
-
-  '@storybook/theming@8.6.17(storybook@8.3.5)':
-    dependencies:
-      storybook: 8.3.5
 
   '@stryker-mutator/api@8.7.1':
     dependencies:
@@ -11237,6 +10818,15 @@ snapshots:
       lodash: 4.18.1
       redent: 3.0.0
 
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
   '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@babel/runtime': 7.29.2
@@ -11248,6 +10838,10 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 
@@ -11326,8 +10920,6 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
-  '@types/escodegen@0.0.6': {}
-
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -11337,8 +10929,6 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       '@types/json-schema': 7.0.15
-
-  '@types/estree@0.0.51': {}
 
   '@types/estree@1.0.8': {}
 
@@ -11355,13 +10945,6 @@ snapshots:
       '@types/express-serve-static-core': 4.19.8
       '@types/qs': 6.15.0
       '@types/serve-static': 1.15.10
-
-  '@types/find-cache-dir@3.2.1': {}
-
-  '@types/glob@7.2.0':
-    dependencies:
-      '@types/minimatch': 6.0.0
-      '@types/node': 20.16.10
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -11392,8 +10975,6 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/lodash@4.17.24': {}
-
   '@types/long@4.0.2': {}
 
   '@types/mdast@4.0.4':
@@ -11405,10 +10986,6 @@ snapshots:
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
-
-  '@types/minimatch@6.0.0':
-    dependencies:
-      minimatch: 10.2.5
 
   '@types/mjml-core@5.0.0': {}
 
@@ -11507,8 +11084,6 @@ snapshots:
   '@types/uuid@10.0.0': {}
 
   '@types/uuid@3.4.13': {}
-
-  '@types/uuid@9.0.8': {}
 
   '@types/validator@13.15.10': {}
 
@@ -11779,12 +11354,13 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@20.16.10)(@vitest/coverage-v8@4.1.5)(jsdom@25.0.1(canvas@2.11.2))(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
 
-  '@vitest/expect@2.0.5':
+  '@vitest/expect@3.2.4':
     dependencies:
-      '@vitest/spy': 2.0.5
-      '@vitest/utils': 2.0.5
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
       chai: 5.3.3
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -11795,6 +11371,14 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
+  '@vitest/mocker@3.2.4(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)
+
   '@vitest/mocker@4.1.5(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.5
@@ -11803,13 +11387,9 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)
 
-  '@vitest/pretty-format@2.0.5':
+  '@vitest/pretty-format@3.2.4':
     dependencies:
-      tinyrainbow: 1.2.0
-
-  '@vitest/pretty-format@2.1.9':
-    dependencies:
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -11827,24 +11407,17 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@2.0.5':
+  '@vitest/spy@3.2.4':
     dependencies:
-      tinyspy: 3.0.2
+      tinyspy: 4.0.4
 
   '@vitest/spy@4.1.5': {}
 
-  '@vitest/utils@2.0.5':
+  '@vitest/utils@3.2.4':
     dependencies:
-      '@vitest/pretty-format': 2.0.5
-      estree-walker: 3.0.3
+      '@vitest/pretty-format': 3.2.4
       loupe: 3.2.1
-      tinyrainbow: 1.2.0
-
-  '@vitest/utils@2.1.9':
-    dependencies:
-      '@vitest/pretty-format': 2.1.9
-      loupe: 3.2.1
-      tinyrainbow: 1.2.0
+      tinyrainbow: 2.0.0
 
   '@vitest/utils@4.1.5':
     dependencies:
@@ -11994,15 +11567,9 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-jsx@5.3.2(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-
-  acorn-walk@7.2.0: {}
 
   acorn-walk@8.3.5:
     dependencies:
@@ -12453,8 +12020,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
 
-  browser-assert@1.2.1: {}
-
   browserify-zlib@0.2.0:
     dependencies:
       pako: 1.0.11
@@ -12767,8 +12332,6 @@ snapshots:
       esprima: 4.0.1
 
   common-ancestor-path@1.0.1: {}
-
-  commondir@1.0.1: {}
 
   component-emitter@1.3.1: {}
 
@@ -13611,6 +13174,15 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
+  eslint-plugin-storybook@9.1.20(eslint@9.39.4)(storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)))(typescript@5.6.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.59.0(eslint@9.39.4)(typescript@5.6.3)
+      eslint: 9.39.4
+      storybook: 9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   eslint-scope@5.1.1:
     dependencies:
       esrecurse: 4.3.0
@@ -13939,12 +13511,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  find-cache-dir@3.3.2:
-    dependencies:
-      commondir: 1.0.1
-      make-dir: 3.1.0
-      pkg-dir: 4.2.0
-
   find-up-simple@1.0.1: {}
 
   find-up@4.1.0:
@@ -13956,6 +13522,12 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  find-up@7.0.0:
+    dependencies:
+      locate-path: 7.2.0
+      path-exists: 5.0.0
+      unicorn-magic: 0.1.0
 
   find-yarn-workspace-root2@1.2.16:
     dependencies:
@@ -14045,12 +13617,6 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.1
-      universalify: 2.0.1
-
-  fs-extra@11.3.4:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
@@ -14170,11 +13736,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob-promise@4.2.2(glob@7.2.3):
-    dependencies:
-      '@types/glob': 7.2.0
-      glob: 7.2.3
 
   glob-to-regexp@0.4.1: {}
 
@@ -14299,10 +13860,6 @@ snapshots:
       vfile-location: 5.0.3
       web-namespaces: 2.0.1
 
-  hast-util-heading-rank@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-
   hast-util-is-element@3.0.0:
     dependencies:
       '@types/hast': 3.0.4
@@ -14351,10 +13908,6 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
-  hast-util-to-string@3.0.1:
-    dependencies:
-      '@types/hast': 3.0.4
-
   hast-util-to-text@4.0.2:
     dependencies:
       '@types/hast': 3.0.4
@@ -14401,8 +13954,6 @@ snapshots:
       param-case: 2.1.1
       relateurl: 0.2.7
       uglify-js: 3.19.3
-
-  html-tags@3.3.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -14560,8 +14111,6 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  is-absolute-url@4.0.1: {}
-
   is-arguments@1.2.0:
     dependencies:
       call-bound: 1.0.4
@@ -14677,8 +14226,6 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@4.1.0: {}
-
-  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -15151,8 +14698,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsdoc-type-pratt-parser@4.8.0: {}
-
   jsdom@25.0.1(canvas@2.11.2):
     dependencies:
       cssstyle: 4.6.0
@@ -15328,6 +14873,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  locate-path@7.2.0:
+    dependencies:
+      p-locate: 6.0.0
+
   lodash-es@4.18.1: {}
 
   lodash.groupby@4.6.0: {}
@@ -15396,10 +14945,6 @@ snapshots:
     dependencies:
       vlq: 0.2.3
 
-  magic-string@0.27.0:
-    dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -15423,6 +14968,7 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
+    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -15434,17 +14980,7 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
-  map-or-similar@1.5.0: {}
-
   markdown-table@3.0.4: {}
-
-  markdown-to-jsx@7.7.17(react@18.3.1):
-    optionalDependencies:
-      react: 18.3.1
-
-  markdown-to-jsx@7.7.17(react@19.2.5):
-    optionalDependencies:
-      react: 19.2.5
 
   math-intrinsics@1.1.0: {}
 
@@ -15575,10 +15111,6 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
-
-  memoizerific@1.11.3:
-    dependencies:
-      map-or-similar: 1.5.0
 
   mensch@0.3.4: {}
 
@@ -16451,6 +15983,10 @@ snapshots:
     dependencies:
       yocto-queue: 0.1.0
 
+  p-limit@4.0.0:
+    dependencies:
+      yocto-queue: 1.2.2
+
   p-limit@6.2.0:
     dependencies:
       yocto-queue: 1.2.2
@@ -16462,6 +15998,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-locate@6.0.0:
+    dependencies:
+      p-limit: 4.0.0
 
   p-queue@8.1.1:
     dependencies:
@@ -16518,6 +16058,8 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
+
+  path-exists@5.0.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -16692,10 +16234,6 @@ snapshots:
 
   pngjs@5.0.0: {}
 
-  polished@4.3.1:
-    dependencies:
-      '@babel/runtime': 7.29.2
-
   possible-typed-array-names@1.1.0: {}
 
   postcss-value-parser@4.2.0: {}
@@ -16768,8 +16306,6 @@ snapshots:
   process-nextick-args@2.0.1: {}
 
   process-warning@5.0.0: {}
-
-  process@0.11.10: {}
 
   progress@2.0.3: {}
 
@@ -16874,21 +16410,11 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  react-colorful@5.6.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-
   react-docgen-typescript@2.4.0(typescript@5.6.3):
     dependencies:
       typescript: 5.6.3
 
-  react-docgen@7.1.1:
+  react-docgen@8.0.3:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/traverse': 7.29.0
@@ -16903,24 +16429,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-dom@18.3.1(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
-
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
-
-  react-element-to-jsx-string@15.0.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
-    dependencies:
-      '@base2/pretty-print-object': 1.0.1
-      is-plain-object: 5.0.0
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      react-is: 18.1.0
 
   react-is@16.13.1: {}
 
@@ -16941,10 +16453,6 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.5(react@19.2.5)
-
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
 
   react@19.2.5: {}
 
@@ -17024,15 +16532,6 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
-  rehype-external-links@3.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@ungap/structured-clone': 1.3.0
-      hast-util-is-element: 3.0.0
-      is-absolute-url: 4.0.1
-      space-separated-tokens: 2.0.2
-      unist-util-visit: 5.1.0
-
   rehype-parse@9.0.1:
     dependencies:
       '@types/hast': 3.0.4
@@ -17044,14 +16543,6 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
-
-  rehype-slug@6.0.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      github-slugger: 2.0.0
-      hast-util-heading-rank: 3.0.0
-      hast-util-to-string: 3.0.1
-      unist-util-visit: 5.1.0
 
   rehype-stringify@10.0.1:
     dependencies:
@@ -17292,10 +16783,6 @@ snapshots:
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
-
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
 
   scheduler@0.25.0-rc-603e6108-20241029: {}
 
@@ -17566,13 +17053,29 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@8.3.5:
+  storybook@9.1.20(@testing-library/dom@10.4.0)(prettier@3.8.3)(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3)):
     dependencies:
-      '@storybook/core': 8.3.5
+      '@storybook/global': 5.0.0
+      '@testing-library/jest-dom': 6.9.1
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@6.4.2(@types/node@20.16.10)(terser@5.46.2)(yaml@2.8.3))
+      '@vitest/spy': 3.2.4
+      better-opn: 3.0.2
+      esbuild: 0.28.0
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+      recast: 0.23.11
+      semver: 7.7.4
+      ws: 8.20.0
+    optionalDependencies:
+      prettier: 3.8.3
     transitivePeerDependencies:
+      - '@testing-library/dom'
       - bufferutil
+      - msw
       - supports-color
       - utf-8-validate
+      - vite
 
   streamsearch@1.1.0: {}
 
@@ -17778,10 +17281,6 @@ snapshots:
     dependencies:
       bintrees: 1.0.2
 
-  telejson@7.2.0:
-    dependencies:
-      memoizerific: 1.11.3
-
   terser-webpack-plugin@5.4.0(@swc/core@1.15.30(@swc/helpers@0.5.21))(webpack@5.97.1(@swc/core@1.15.30(@swc/helpers@0.5.21))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -17833,11 +17332,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinyrainbow@1.2.0: {}
+  tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
 
-  tinyspy@3.0.2: {}
+  tinyspy@4.0.4: {}
 
   tldts-core@6.1.86: {}
 
@@ -17981,8 +17480,6 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  type-fest@2.19.0: {}
-
   type-fest@4.41.0: {}
 
   type-is@1.6.18:
@@ -18095,6 +17592,8 @@ snapshots:
       pako: 0.2.9
       tiny-inflate: 1.0.3
 
+  unicorn-magic@0.1.0: {}
+
   unicorn-magic@0.3.0: {}
 
   unified@11.0.5:
@@ -18196,14 +17695,6 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  util@0.12.5:
-    dependencies:
-      inherits: 2.0.4
-      is-arguments: 1.2.0
-      is-generator-function: 1.1.2
-      is-typed-array: 1.1.15
-      which-typed-array: 1.1.20
-
   utils-merge@1.0.1: {}
 
   uuid@10.0.0: {}
@@ -18211,8 +17702,6 @@ snapshots:
   uuid@11.0.5: {}
 
   uuid@3.4.0: {}
-
-  uuid@9.0.1: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Why

Storybook 8.3.5 declares peer `vite: ^4.0.0 || ^5.0.0` but the repo runs Vite 6.4.2. Symptom in `pnpm --filter web storybook` —

> `[vite] (client) warning: Failed to resolve "\u0000/virtual:/@storybook/builder-vite/storybook-stories.js"`

— caused by Storybook's HMR client trying to register a virtual module URL Vite 6's analysis plugin no longer accepts in that shape.

Storybook 10 requires a one-major-at-a-time path, so this PR lands v9 first; a follow-up can take v9 → v10 once the addon migrations are settled.

## What the codemod did

- Bumped every `@storybook/*` dep to `9.1.20` + the standalone `storybook` 9.1.20 driver.
- Dropped `@storybook/addon-essentials` (split into `@storybook/addon-docs` in v9; controls / actions / interactions / viewport / backgrounds moved into core).
- Dropped `@storybook/blocks` and `@storybook/test` (consolidated upstream).
- Re-pointed every story import from `@storybook/react` → `@storybook/react-vite` (renderer-to-framework migration).
- Pruned legacy keys from `.storybook/main.ts` (`docs.autodocs` deprecation; config simplified).
- Added `eslint-plugin-storybook@9.1.20`.

## Test plan

- [x] `pnpm install` — clean, no peer-dep warnings about Storybook ↔ Vite.
- [x] `pnpm -r typecheck` — green.
- [x] `pnpm -r lint` — green.
- [x] `pnpm --filter web build-storybook` — green; static bundle still under `apps/web/storybook-static/` (Chromatic workflow unchanged).
- [x] `pnpm --filter web test` — 629 tests green.
- [x] Original Vite virtual-module warning is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)