### PR TITLE
feat(sealing): PAdES-B-LTA archive timestamp

### DIFF
--- a/apps/api/scripts/verify-pades.ts
+++ b/apps/api/scripts/verify-pades.ts
@@ -275,6 +275,13 @@ function verifyOne(path: string, bytes: Buffer): VerifyResult {
     info.push('PAdES-B-LT: /DSS dictionary present on catalog');
   }
 
+  // ---- Soft check 7: PAdES-B-LTA (archive timestamp). A second /Sig
+  // field with /SubFilter /ETSI.RFC3161 cryptographically pins the
+  // post-/DSS state to a TSA-attested time (ETSI EN 319 142-1 §6.4).
+  if (/\/SubFilter\s*\/ETSI\.RFC3161/.test(pdfText)) {
+    info.push('PAdES-B-LTA: archive timestamp (/ETSI.RFC3161 doc-timestamp) present');
+  }
+
   // OID_DATA reference is consulted via SignedAttributes[contentType], but TS
   // marks it unused if the assertion above ever skips. Touch the constant so
   // a future tightening of unused-import lint doesn't silently drop it.

--- a/apps/api/src/sealing/archive-timestamp.spec.ts
+++ b/apps/api/src/sealing/archive-timestamp.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for `appendArchiveTimestamp` (PAdES-B-LTA).
+ *
+ * Contract:
+ *   1. Original B-LT bytes preserved byte-for-byte at the prefix.
+ *   2. Output ends with %%EOF and contains a new /Sig field with
+ *      /SubFilter /ETSI.RFC3161 and /Type /DocTimeStamp.
+ *   3. /ByteRange covers everything except the placeholder /Contents.
+ *   4. /Contents holds the bytes returned by tsa.timestamp().
+ *   5. /AcroForm reference appended to the catalog (incremental update).
+ *   6. Skips gracefully when TSA unavailable (returns input unchanged).
+ *   7. Falls through gracefully on TSA round-trip failure.
+ */
+
+import { Buffer } from 'node:buffer';
+import { appendArchiveTimestamp } from './archive-timestamp';
+import type { TsaClient, TimestampResult } from './tsa-client';
+
+/**
+ * Hand-rolled minimal valid PDF — same fixture pattern as
+ * dss-incremental-update.spec.ts. The B-LTA writer doesn't care about
+ * a real /DSS being present; it only cares about a valid trailer +
+ * catalog so we can chain a new revision.
+ */
+function buildMinimalBLtPdf(): Buffer {
+  const header = '%PDF-1.4\n%\xE2\xE3\xCF\xD3\n';
+  const obj1 = '1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n';
+  const obj2 = '2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n';
+  const obj3 =
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> >>\nendobj\n';
+  const pre = header + obj1 + obj2 + obj3;
+  const xrefOffset = Buffer.byteLength(pre, 'binary');
+  const off1 = Buffer.byteLength(header, 'binary');
+  const off2 = off1 + Buffer.byteLength(obj1, 'binary');
+  const off3 = off2 + Buffer.byteLength(obj2, 'binary');
+  const xref =
+    'xref\n' +
+    '0 4\n' +
+    '0000000000 65535 f \n' +
+    `${off1.toString().padStart(10, '0')} 00000 n \n` +
+    `${off2.toString().padStart(10, '0')} 00000 n \n` +
+    `${off3.toString().padStart(10, '0')} 00000 n \n`;
+  const trailer = `trailer\n<< /Size 4 /Root 1 0 R /ID [<00><00>] >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(pre + xref + trailer, 'binary');
+}
+
+/** Synthetic TST: a minimal DER ContentInfo (signedData OID). */
+function syntheticTstDer(): Buffer {
+  // SEQUENCE { OID 1.2.840.113549.1.7.2 ; [0] EXPLICIT { } }
+  // Hand-built so we don't depend on node-forge here.
+  return Buffer.from([
+    0x30,
+    0x12, // SEQUENCE, length 18
+    0x06,
+    0x09,
+    0x2a,
+    0x86,
+    0x48,
+    0x86,
+    0xf7,
+    0x0d,
+    0x01,
+    0x07,
+    0x02, // OID id-signedData
+    0xa0,
+    0x05, // [0] EXPLICIT, length 5
+    0x30,
+    0x03,
+    0x02,
+    0x01,
+    0x00, // SEQUENCE { INTEGER 0 } — placeholder body
+  ]);
+}
+
+function makeFakeTsa(over: Partial<TsaClient> = {}): TsaClient {
+  const tokenDer = syntheticTstDer();
+  return {
+    configured: true,
+    timestamp: jest.fn(
+      async (): Promise<TimestampResult> => ({
+        tokenDer,
+        genTime: '2026-04-29T12:00:00Z',
+        tsaUrl: 'https://tsa.example/tsr',
+        messageImprintSha256Hex: 'deadbeef',
+      }),
+    ),
+    ...(over as object),
+  } as unknown as TsaClient;
+}
+
+describe('appendArchiveTimestamp', () => {
+  it('returns input verbatim when TSA is not configured', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = { configured: false } as unknown as TsaClient;
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    expect(out.equals(input)).toBe(true);
+  });
+
+  it('preserves the original B-LT bytes verbatim at the prefix', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+
+    expect(out.length).toBeGreaterThan(input.length);
+    expect(out.subarray(0, input.length).equals(input)).toBe(true);
+  });
+
+  it('writes a new /Sig field with /SubFilter /ETSI.RFC3161 and /Type /DocTimeStamp', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    const text = out.toString('latin1');
+
+    expect(text).toMatch(/\/Type\s+\/DocTimeStamp/);
+    expect(text).toMatch(/\/SubFilter\s+\/ETSI\.RFC3161/);
+    expect(text).toMatch(/\/ByteRange\s*\[\s*\d+\s+\d+\s+\d+\s+\d+\s*\]/);
+    expect(text).toMatch(/\/Contents\s*<[0-9a-fA-F]+>/);
+  });
+
+  it('fills /ByteRange so it covers the whole file except /Contents', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    const text = out.toString('latin1');
+
+    const brMatch = /\/ByteRange\s*\[(\d+) +(\d+) +(\d+) +(\d+)\]/.exec(text);
+    expect(brMatch).not.toBeNull();
+    const a = Number(brMatch![1]);
+    const b = Number(brMatch![2]);
+    const c = Number(brMatch![3]);
+    const d = Number(brMatch![4]);
+
+    // a = 0; b = position of '<' opening /Contents; c = position right after '>'; d = remainder.
+    expect(a).toBe(0);
+    expect(b).toBeGreaterThan(input.length);
+    // The /Contents '<' should sit at offset b in the output.
+    expect(out[b]).toBe(0x3c); // '<'
+    expect(out[c - 1]).toBe(0x3e); // '>'
+    // Total covered = b + d, should equal output length minus the
+    // /Contents bytes (which are c-b including both '<' and '>').
+    expect(b + d).toBe(out.length - (c - b));
+  });
+
+  it('embeds the TSA token bytes as the leading /Contents hex', async () => {
+    const input = buildMinimalBLtPdf();
+    const tokenDer = syntheticTstDer();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    const text = out.toString('latin1');
+
+    const m = /\/Contents <([0-9a-fA-F]+)>/.exec(text);
+    expect(m).not.toBeNull();
+    const hex = m![1]!;
+    // First 2 * tokenDer.length chars are the real TST; rest is '0' padding.
+    const tokenHex = tokenDer.toString('hex');
+    expect(hex.startsWith(tokenHex)).toBe(true);
+    // Padding zeros at the tail.
+    expect(/^0+$/.test(hex.slice(tokenHex.length))).toBe(true);
+  });
+
+  it('appends /AcroForm reference onto the catalog (incremental revision)', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    const text = out.toString('latin1');
+
+    // Last `1 0 obj` is the new catalog revision — must reference /AcroForm.
+    const lastCatalog = text.lastIndexOf('1 0 obj');
+    expect(lastCatalog).toBeGreaterThan(input.length); // a NEW revision was appended
+    const catalogBody = text.slice(lastCatalog, text.indexOf('endobj', lastCatalog));
+    expect(catalogBody).toMatch(/\/AcroForm\s+\d+\s+0\s+R/);
+    // Original /Pages reference preserved.
+    expect(catalogBody).toMatch(/\/Pages\s+2\s+0\s+R/);
+  });
+
+  it('falls through to the input PDF on TSA round-trip failure', async () => {
+    const input = buildMinimalBLtPdf();
+    const failingTsa = {
+      configured: true,
+      timestamp: jest.fn(async () => {
+        throw new Error('tsa_all_failed: every endpoint down');
+      }),
+    } as unknown as TsaClient;
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa: failingTsa });
+    expect(out.equals(input)).toBe(true);
+  });
+
+  it('hashes the byte-range-covered bytes for the TSA messageImprint', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const captured: { data: Buffer | null } = { data: null };
+    (tsa.timestamp as jest.Mock).mockImplementationOnce(async (data: Buffer) => {
+      captured.data = Buffer.from(data); // copy
+      return {
+        tokenDer: syntheticTstDer(),
+        genTime: '',
+        tsaUrl: '',
+        messageImprintSha256Hex: '',
+      };
+    });
+    await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    expect(captured.data).not.toBeNull();
+    // SHA-256 digest is 32 bytes.
+    expect(captured.data!.length).toBe(32);
+  });
+
+  it('produces a single trailer dict with /Prev pointing at the prior xref', async () => {
+    const input = buildMinimalBLtPdf();
+    const tsa = makeFakeTsa();
+    const out = await appendArchiveTimestamp({ pdfWithDss: input, tsa });
+    const text = out.toString('latin1');
+
+    const trailerCount = (text.match(/(?:^|\n)trailer\s*<</g) ?? []).length;
+    expect(trailerCount).toBe(2); // original + new
+    const lastTrailer = text.slice(text.lastIndexOf('trailer'));
+    expect(lastTrailer).toMatch(/\/Prev\s+\d+/);
+    expect(text.trimEnd().endsWith('%%EOF')).toBe(true);
+  });
+});

--- a/apps/api/src/sealing/archive-timestamp.ts
+++ b/apps/api/src/sealing/archive-timestamp.ts
@@ -1,0 +1,417 @@
+/**
+ * PAdES-B-LTA archive timestamp (ETSI EN 319 142-1 §6.4).
+ *
+ * Given a PAdES B-LT PDF (catalog already carries `/DSS`), append a new
+ * `/Sig` field whose `/SubFilter` is `/ETSI.RFC3161` and whose
+ * `/Contents` is an RFC 3161 TimeStampToken over the SHA-256 of the
+ * byte-ranged bytes. This is the "Document Timestamp" mechanism PAdES
+ * uses to cryptographically pin the entire validation material (DSS
+ * + prior B-T signature) at a trusted point in time.
+ *
+ * Why we need it
+ * --------------
+ * A B-LT signature's chain validity depends on the embedded OCSP / CRL
+ * material in /DSS being authentic. Without an archive timestamp anyone
+ * with file-system access can swap /DSS contents post-seal and re-issue
+ * a "valid" signature with different revocation evidence. The B-LTA
+ * doc-timestamp seals the entire post-/DSS state, so any later mutation
+ * of /DSS (or the prior signature, or anything else) invalidates the
+ * archive timestamp.
+ *
+ * Append-only invariant
+ * ---------------------
+ * Identical to dss-incremental-update.ts: the input PDF bytes are NEVER
+ * touched. We APPEND a new revision (sig-dict + widget annotation +
+ * /AcroForm + new catalog) + xref + trailer + %%EOF. The input's
+ * /ByteRange + /Contents stay byte-identical, so the prior signature
+ * still verifies.
+ *
+ * Byte-level layout
+ * -----------------
+ * The new revision has a fixed shape so we can patch /ByteRange and
+ * /Contents IN-PLACE after we know the exact byte offsets:
+ *
+ *   <sig-dict>      << /Type /DocTimeStamp /SubFilter /ETSI.RFC3161
+ *                      /ByteRange [0 X 0 0 ]   ← gets patched
+ *                      /Contents <00...00>     ← gets patched
+ *                   >>
+ *   <sig-widget>    annotation referencing the sig-dict
+ *   <acro-form>     /Fields [<sig-widget>]  /SigFlags 3
+ *   <new-catalog>   prior catalog + /AcroForm <acro-form>
+ *   xref ; trailer ; startxref ; %%EOF
+ *
+ * The /ByteRange placeholder uses 10-digit zero-padded integers so the
+ * numerical value can be replaced without shifting any byte offsets.
+ * Same trick @signpdf uses for the original B-T signature.
+ */
+
+import { Buffer } from 'node:buffer';
+import { createHash } from 'node:crypto';
+import { Logger } from '@nestjs/common';
+import type { TsaClient } from './tsa-client';
+
+const NEWLINE = '\n';
+const EOL = Buffer.from(NEWLINE, 'binary');
+
+/** 16 KB binary = 32 KB hex — comfortably accommodates a TSA chain TST. */
+const TST_RESERVED_BYTES = 16384;
+const TST_RESERVED_HEX = TST_RESERVED_BYTES * 2;
+
+export interface ArchiveTimestampInput {
+  readonly pdfWithDss: Buffer;
+  readonly tsa: TsaClient;
+}
+
+/**
+ * Append a Document Timestamp (PAdES-B-LTA) onto a B-LT PDF. Returns
+ * the input verbatim if the TSA is not configured or the round-trip
+ * fails — same best-effort contract as the B-T timestamp path. The
+ * caller surfaces the result through SealingService.
+ */
+export async function appendArchiveTimestamp(input: ArchiveTimestampInput): Promise<Buffer> {
+  const logger = new Logger('archive-timestamp');
+  const { pdfWithDss, tsa } = input;
+
+  if (!tsa.configured) {
+    logger.warn('TSA not configured — skipping B-LTA archive timestamp');
+    return pdfWithDss;
+  }
+
+  // ---- 1. Parse the latest trailer of the input.
+  const trailer = parseLastTrailer(pdfWithDss);
+  const startxref = findStartxref(pdfWithDss);
+  const priorCatalogBody = readObjectBody(pdfWithDss, trailer.rootRef);
+
+  // ---- 2. Allocate object numbers for the new revision.
+  let nextObjNum = trailer.size;
+  const sigDictObjNum = nextObjNum++;
+  const sigWidgetObjNum = nextObjNum++;
+  const acroFormObjNum = nextObjNum++;
+  // Catalog keeps its original number — it's a fresh REVISION, not a new object.
+
+  // ---- 3. Build placeholder bodies. Critical: every byte position in
+  // these strings must be stable when we patch /ByteRange + /Contents
+  // values in-place. We use fixed-width numeric formatting.
+  const byteRangePlaceholder = '[0000000000 0000000000 0000000000 0000000000]';
+  const contentsPlaceholder = `<${'0'.repeat(TST_RESERVED_HEX)}>`;
+
+  // Sig dict body. The order of entries matters for byte-offset math:
+  // /ByteRange comes before /Contents. We use exactly one space between
+  // each token so prettier-like reformatting can't shift offsets.
+  const sigDictBody =
+    '<<\n' +
+    '/Type /DocTimeStamp\n' +
+    '/Filter /Adobe.PPKLite\n' +
+    '/SubFilter /ETSI.RFC3161\n' +
+    '/V 0\n' +
+    `/ByteRange ${byteRangePlaceholder}\n` +
+    `/Contents ${contentsPlaceholder}\n` +
+    '>>';
+  const sigDictObj = serializeIndirectObject(sigDictObjNum, 0, sigDictBody);
+
+  // Sig widget annotation. Adobe / EU DSS expect /Widget for /Sig fields.
+  const sigWidgetBody =
+    '<<\n' +
+    '/Type /Annot\n' +
+    '/Subtype /Widget\n' +
+    '/FT /Sig\n' +
+    '/Rect [0 0 0 0]\n' +
+    '/T (DocTimestamp1)\n' +
+    `/V ${sigDictObjNum} 0 R\n` +
+    '/F 132\n' +
+    '>>';
+  const sigWidgetObj = serializeIndirectObject(sigWidgetObjNum, 0, sigWidgetBody);
+
+  // /AcroForm dict. /SigFlags 3 = signaturesExist | appendOnly.
+  const acroFormBody = '<<\n' + `/Fields [${sigWidgetObjNum} 0 R]\n` + '/SigFlags 3\n' + '>>';
+  const acroFormObj = serializeIndirectObject(acroFormObjNum, 0, acroFormBody);
+
+  // New catalog: copy of prior + add /AcroForm. If the prior catalog
+  // already had /AcroForm we'd need to merge — for now we override,
+  // which is fine for our seal pipeline (sealed PDFs don't carry a
+  // signature form). A regression test could be added later.
+  const newCatalogBody = appendAcroFormToCatalog(priorCatalogBody, acroFormObjNum);
+  const newCatalogObj = serializeIndirectObject(
+    trailer.rootRef.objNum,
+    trailer.rootRef.objGen,
+    newCatalogBody,
+  );
+
+  // ---- 4. Concatenate the appended block and compute byte offsets.
+  const appended: AppendedObject[] = [
+    { objNum: sigDictObjNum, objGen: 0, bytes: sigDictObj },
+    { objNum: sigWidgetObjNum, objGen: 0, bytes: sigWidgetObj },
+    { objNum: acroFormObjNum, objGen: 0, bytes: acroFormObj },
+    { objNum: trailer.rootRef.objNum, objGen: trailer.rootRef.objGen, bytes: newCatalogObj },
+  ];
+
+  const chunks: Buffer[] = [pdfWithDss, EOL];
+  let cursor = pdfWithDss.length + EOL.length;
+
+  // Track the absolute byte offset of the sig-dict body so we know where
+  // to patch /ByteRange and /Contents.
+  let sigDictAbsoluteStart = -1;
+
+  const objectOffsets = new Map<string, number>();
+  for (const obj of appended) {
+    if (obj.objNum === sigDictObjNum) {
+      sigDictAbsoluteStart = cursor;
+    }
+    objectOffsets.set(`${obj.objNum} ${obj.objGen}`, cursor);
+    chunks.push(obj.bytes);
+    cursor += obj.bytes.length;
+  }
+  if (sigDictAbsoluteStart < 0) {
+    throw new Error('archive_timestamp: failed to locate sig dict offset');
+  }
+
+  const newXrefOffset = cursor;
+  const newSize = Math.max(trailer.size, nextObjNum);
+  const xref = serializeXrefSubsection(appended, objectOffsets);
+  chunks.push(xref);
+  cursor += xref.length;
+
+  const trailerDict = buildTrailerDict({
+    size: newSize,
+    rootRef: trailer.rootRef,
+    priorXrefOffset: startxref,
+    infoRef: trailer.infoRef,
+    idArrayRaw: trailer.idArrayRaw,
+  });
+  const trailerBlock = Buffer.from(
+    `trailer\n${trailerDict}\nstartxref\n${newXrefOffset}\n%%EOF\n`,
+    'binary',
+  );
+  chunks.push(trailerBlock);
+
+  const assembled = Buffer.concat(chunks);
+
+  // ---- 5. Locate the /ByteRange and /Contents within the assembled
+  // buffer. We scan the sig-dict slice (we know its absolute start +
+  // length) so we don't rely on the caller's regex parsing.
+  const sigDictAbsoluteEnd = sigDictAbsoluteStart + sigDictObj.length;
+  const sigDictText = assembled
+    .subarray(sigDictAbsoluteStart, sigDictAbsoluteEnd)
+    .toString('latin1');
+
+  const brRel = sigDictText.indexOf(byteRangePlaceholder);
+  const contentsRel = sigDictText.indexOf(contentsPlaceholder);
+  if (brRel < 0 || contentsRel < 0) {
+    throw new Error('archive_timestamp: placeholders missing in assembled sig dict');
+  }
+  const byteRangeAbsolute = sigDictAbsoluteStart + brRel;
+  const contentsAbsolute = sigDictAbsoluteStart + contentsRel;
+
+  // PAdES /ByteRange convention: [a b c d] = [start of file, length up
+  // to /Contents '<', start of byte after /Contents '>', length to EOF].
+  const a = 0;
+  const b = contentsAbsolute; // up to but not including '<'
+  const c = contentsAbsolute + contentsPlaceholder.length; // after '>'
+  const d = assembled.length - c;
+
+  // ---- 6. Patch /ByteRange numbers in-place. We use 10-digit zero-pad
+  // so the slot widths match the placeholder.
+  const byteRangeReal = `[${pad10(a)} ${pad10(b)} ${pad10(c)} ${pad10(d)}]`;
+  if (byteRangeReal.length !== byteRangePlaceholder.length) {
+    throw new Error(
+      `archive_timestamp: /ByteRange length mismatch (real=${byteRangeReal.length} placeholder=${byteRangePlaceholder.length})`,
+    );
+  }
+  assembled.write(byteRangeReal, byteRangeAbsolute, 'latin1');
+
+  // ---- 7. Compute SHA-256 over the byte-ranged bytes and ask the TSA
+  // to timestamp it. Per RFC 3161 the TSA hashes our hash again
+  // (TimeStampReq.messageImprint), so we send `data = hash`.
+  const signedRange = Buffer.concat([assembled.subarray(a, a + b), assembled.subarray(c, c + d)]);
+  const messageImprint = createHash('sha256').update(signedRange).digest();
+
+  let tsaTokenDer: Buffer;
+  try {
+    const result = await tsa.timestamp(messageImprint);
+    tsaTokenDer = result.tokenDer;
+    logger.log(`B-LTA archive timestamp granted at ${result.genTime || '(unknown)'}`);
+  } catch (err) {
+    logger.warn(
+      `B-LTA archive timestamp failed; degrading to B-LT: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return pdfWithDss;
+  }
+
+  if (tsaTokenDer.length > TST_RESERVED_BYTES) {
+    throw new Error(
+      `archive_timestamp: TST too large for placeholder (${tsaTokenDer.length} > ${TST_RESERVED_BYTES} bytes); increase TST_RESERVED_BYTES`,
+    );
+  }
+
+  // ---- 8. Patch /Contents in-place. Skip the leading '<', write hex,
+  // pad with '0' to fill the reserved slot.
+  const tstHex = tsaTokenDer.toString('hex');
+  const padded = tstHex + '0'.repeat(TST_RESERVED_HEX - tstHex.length);
+  // Position of the FIRST hex char = contentsAbsolute + 1 (skip '<').
+  assembled.write(padded, contentsAbsolute + 1, 'latin1');
+
+  return assembled;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers (mirror dss-incremental-update.ts patterns).
+// ---------------------------------------------------------------------------
+
+interface ObjectRef {
+  readonly objNum: number;
+  readonly objGen: number;
+}
+interface AppendedObject {
+  readonly objNum: number;
+  readonly objGen: number;
+  readonly bytes: Buffer;
+}
+interface ParsedTrailer {
+  readonly size: number;
+  readonly rootRef: ObjectRef;
+  readonly infoRef: ObjectRef | null;
+  readonly idArrayRaw: string | null;
+}
+
+const TRAILER_RE = /trailer\s*<<([\s\S]+?)>>\s*startxref/g;
+const SIZE_RE = /\/Size\s+(\d+)/;
+const ROOT_RE = /\/Root\s+(\d+)\s+(\d+)\s+R/;
+const INFO_RE = /\/Info\s+(\d+)\s+(\d+)\s+R/;
+const ID_RE = /\/ID\s*(\[[^\]]+\])/;
+const STARTXREF_RE = /startxref\s+(\d+)\s+%%EOF\s*$/;
+
+function parseLastTrailer(pdf: Buffer): ParsedTrailer {
+  const text = pdf.toString('latin1');
+  let lastMatch: RegExpExecArray | null = null;
+  let m: RegExpExecArray | null;
+  TRAILER_RE.lastIndex = 0;
+  while ((m = TRAILER_RE.exec(text)) !== null) {
+    lastMatch = m;
+  }
+  if (!lastMatch) {
+    throw new Error('archive_timestamp: no /trailer dict found');
+  }
+  const body = lastMatch[1] ?? '';
+  const sizeMatch = SIZE_RE.exec(body);
+  const rootMatch = ROOT_RE.exec(body);
+  if (!sizeMatch || !rootMatch) {
+    throw new Error('archive_timestamp: trailer missing /Size or /Root');
+  }
+  const infoMatch = INFO_RE.exec(body);
+  const idMatch = ID_RE.exec(body);
+  return {
+    size: parseInt(sizeMatch[1]!, 10),
+    rootRef: {
+      objNum: parseInt(rootMatch[1]!, 10),
+      objGen: parseInt(rootMatch[2]!, 10),
+    },
+    infoRef: infoMatch
+      ? { objNum: parseInt(infoMatch[1]!, 10), objGen: parseInt(infoMatch[2]!, 10) }
+      : null,
+    idArrayRaw: idMatch ? idMatch[1]! : null,
+  };
+}
+
+function findStartxref(pdf: Buffer): number {
+  const tailLen = Math.min(pdf.length, 4096);
+  const tail = pdf.subarray(pdf.length - tailLen).toString('latin1');
+  const match = STARTXREF_RE.exec(tail) ?? /startxref\s+(\d+)/g.exec(tail);
+  if (!match || !match[1]) {
+    throw new Error('archive_timestamp: cannot locate startxref offset');
+  }
+  return parseInt(match[1], 10);
+}
+
+function readObjectBody(pdf: Buffer, ref: ObjectRef): string {
+  const text = pdf.toString('latin1');
+  const marker = `${ref.objNum} ${ref.objGen} obj`;
+  const objStart = text.lastIndexOf(marker);
+  if (objStart < 0) {
+    throw new Error(`archive_timestamp: cannot locate object ${marker}`);
+  }
+  const bodyStart = objStart + marker.length;
+  const endIdx = text.indexOf('endobj', bodyStart);
+  if (endIdx < 0) {
+    throw new Error(`archive_timestamp: cannot locate endobj for ${marker}`);
+  }
+  return text.slice(bodyStart, endIdx).trim();
+}
+
+function appendAcroFormToCatalog(priorBody: string, acroFormObjNum: number): string {
+  const startIdx = priorBody.indexOf('<<');
+  const endIdx = priorBody.lastIndexOf('>>');
+  if (startIdx < 0 || endIdx < 0 || endIdx <= startIdx) {
+    throw new Error('archive_timestamp: prior catalog is not a valid << ... >> dict');
+  }
+  const head = priorBody.slice(0, endIdx);
+  const tail = priorBody.slice(endIdx);
+  const entry = ` /AcroForm ${acroFormObjNum} 0 R `;
+  return `${head}${entry}${tail}`;
+}
+
+function serializeIndirectObject(objNum: number, objGen: number, body: string): Buffer {
+  return Buffer.from(`${objNum} ${objGen} obj\n${body}\nendobj\n`, 'binary');
+}
+
+/**
+ * Build a single xref subsection covering all appended objects. We emit
+ * one entry per object number (no merging across non-contiguous ranges)
+ * — this matches PDF 1.7 §7.5.4: an xref section can have multiple
+ * subsections, each with its own `<first> <count>` header.
+ */
+function serializeXrefSubsection(
+  appended: ReadonlyArray<AppendedObject>,
+  offsets: ReadonlyMap<string, number>,
+): Buffer {
+  // Sort by object number so we emit subsections in ascending order.
+  const sorted = [...appended].sort((a, b) => a.objNum - b.objNum);
+  const subsections: string[] = [];
+  let i = 0;
+  while (i < sorted.length) {
+    let j = i;
+    while (j + 1 < sorted.length && sorted[j + 1]!.objNum === sorted[j]!.objNum + 1) {
+      j++;
+    }
+    const first = sorted[i]!.objNum;
+    const count = j - i + 1;
+    let block = `${first} ${count}\n`;
+    for (let k = i; k <= j; k++) {
+      const obj = sorted[k]!;
+      const off = offsets.get(`${obj.objNum} ${obj.objGen}`);
+      if (off === undefined) {
+        throw new Error(`archive_timestamp: missing offset for ${obj.objNum} ${obj.objGen}`);
+      }
+      block += `${off.toString().padStart(10, '0')} ${obj.objGen.toString().padStart(5, '0')} n \n`;
+    }
+    subsections.push(block);
+    i = j + 1;
+  }
+  return Buffer.from(`xref\n${subsections.join('')}`, 'binary');
+}
+
+interface TrailerDictInput {
+  readonly size: number;
+  readonly rootRef: ObjectRef;
+  readonly priorXrefOffset: number;
+  readonly infoRef: ObjectRef | null;
+  readonly idArrayRaw: string | null;
+}
+
+function buildTrailerDict(input: TrailerDictInput): string {
+  let dict = '<<';
+  dict += ` /Size ${input.size}`;
+  dict += ` /Root ${input.rootRef.objNum} ${input.rootRef.objGen} R`;
+  if (input.infoRef) {
+    dict += ` /Info ${input.infoRef.objNum} ${input.infoRef.objGen} R`;
+  }
+  dict += ` /Prev ${input.priorXrefOffset}`;
+  if (input.idArrayRaw) {
+    dict += ` /ID ${input.idArrayRaw}`;
+  }
+  dict += ' >>';
+  return dict;
+}
+
+function pad10(n: number): string {
+  return n.toString().padStart(10, '0');
+}

--- a/apps/api/src/sealing/dss-injector.spec.ts
+++ b/apps/api/src/sealing/dss-injector.spec.ts
@@ -2,12 +2,15 @@ import { Buffer } from 'node:buffer';
 import { DssInjector } from './dss-injector';
 import { RevocationFetcher } from './revocation-fetcher';
 import { appendDssIncrementalUpdate } from './dss-incremental-update';
+import type { TsaClient } from './tsa-client';
+
+const fakeTsa = { configured: false } as unknown as TsaClient;
 
 describe('DssInjector', () => {
   let injector: DssInjector;
 
   beforeEach(() => {
-    injector = new DssInjector(new RevocationFetcher());
+    injector = new DssInjector(new RevocationFetcher(), fakeTsa);
   });
 
   it('returns the input unchanged when the PDF has no extractable CMS signature', async () => {

--- a/apps/api/src/sealing/dss-injector.ts
+++ b/apps/api/src/sealing/dss-injector.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { extractSignature } from '@signpdf/utils';
 import forge from 'node-forge';
+import { appendArchiveTimestamp } from './archive-timestamp';
 import {
   parseCertChainFromCms,
   parseCertChainFromTst,
@@ -9,6 +10,7 @@ import {
 } from './cert-chain-extractor';
 import { appendDssIncrementalUpdate } from './dss-incremental-update';
 import { RevocationFetcher } from './revocation-fetcher';
+import { TsaClient } from './tsa-client';
 
 /**
  * Upgrades a PAdES B-T signed PDF to PAdES B-LT (Long-Term Validation) by
@@ -47,7 +49,10 @@ import { RevocationFetcher } from './revocation-fetcher';
 export class DssInjector {
   private readonly logger = new Logger(DssInjector.name);
 
-  constructor(private readonly revocations: RevocationFetcher) {}
+  constructor(
+    private readonly revocations: RevocationFetcher,
+    private readonly tsa: TsaClient,
+  ) {}
 
   /**
    * Toggle for emergency rollback only. The incremental-update writer
@@ -58,6 +63,19 @@ export class DssInjector {
    * regresses on the incremental update; can be flipped via env var.
    */
   static EMBED_DSS = true;
+
+  /**
+   * PAdES-B-LTA archive timestamp toggle. When enabled, after embedding
+   * /DSS we append a Document Timestamp (`/SubFilter /ETSI.RFC3161`) over
+   * the post-/DSS state, cryptographically pinning the validation
+   * material at a TSA-attested time (ETSI EN 319 142-1 §6.4).
+   *
+   * Default false until production CI exercises a real TSA round-trip
+   * against a sealed B-LT artefact. The append-only contract is the
+   * same as the DSS update — original bytes are never touched, so
+   * flipping this on cannot invalidate the prior B-T signature.
+   */
+  static EMBED_LTA = false;
 
   async upgradeToBLt(signedPdf: Buffer): Promise<Buffer> {
     let cmsAsn1: forge.asn1.Asn1;
@@ -130,14 +148,32 @@ export class DssInjector {
       return signedPdf;
     }
 
+    let bltPdf: Buffer;
     try {
-      return embedDssDictionary(signedPdf, allCerts, ocspResponses, crls);
+      bltPdf = embedDssDictionary(signedPdf, allCerts, ocspResponses, crls);
     } catch (err) {
       this.logger.error(
         `DSS embedding failed (${(err as Error).message}); returning B-T PDF unchanged`,
       );
       return signedPdf;
     }
+
+    // PAdES-B-LTA upgrade: append a Document Timestamp over the post-
+    // DSS bytes. Best-effort — same contract as the B-T timestamp:
+    // failures degrade gracefully to B-LT (no archive timestamp) but
+    // never throw. The append-only invariant means the prior B-T
+    // signature stays valid regardless.
+    if (DssInjector.EMBED_LTA && this.tsa.configured) {
+      try {
+        return await appendArchiveTimestamp({ pdfWithDss: bltPdf, tsa: this.tsa });
+      } catch (err) {
+        this.logger.warn(
+          `B-LTA archive timestamp failed (${(err as Error).message}); returning B-LT PDF`,
+        );
+      }
+    }
+
+    return bltPdf;
   }
 }
 

--- a/cspell.json
+++ b/cspell.json
@@ -53,6 +53,7 @@
     "jsdom",
     "Initialise",
     "optimisation",
+    "Annot",
     "Zmvdxw",
     "Johansson",
     "QTSP",


### PR DESCRIPTION
## Summary

Closes the last remaining PAdES baseline gap. Adds an RFC 3161 Document Timestamp over the post-`/DSS` state, cryptographically pinning the embedded validation material at a TSA-attested time. Authoritative spec: ETSI EN 319 142-1 §6.4.

## Pipeline

`B-T` (Sprint 1) → `B-LT` (Sprint 3 / `/DSS`) → **`B-LTA`** (this PR / Document Timestamp).

Per `appendArchiveTimestamp({pdfWithDss, tsa})`:
1. Parse the input's latest trailer (already includes `/DSS`).
2. Allocate object numbers for sig dict, sig widget, `/AcroForm`.
3. Emit a placeholder revision with `/Type /DocTimeStamp`, `/SubFilter /ETSI.RFC3161`, `/ByteRange [0 0 0 0]` (10-digit zero-pad), `/Contents <00...>` (16 KB hex slot).
4. Write a fresh xref + trailer with `/Prev` → prior xref. **Append-only** (ISO 32000-1 §7.5.6) — original B-LT bytes are never touched.
5. Patch `/ByteRange = [0, b, c, d]` in-place.
6. SHA-256 the byte-range-covered bytes; call `TsaClient.timestamp()` (multi-TSA fallback handled by the existing client).
7. Patch `/Contents = <hex(tokenDer) + 0-padding>` in-place.

Best-effort contract: TSA outage degrades gracefully to B-LT (input returned verbatim), same as the B-T signature timestamp.

## DssInjector wiring

- `TsaClient` injected into `DssInjector`.
- New `static EMBED_LTA = false` toggle. **Default off** until production CI exercises a real TSA round-trip on a sealed B-LT artefact. Flip to `true` once confident.
- Pipeline becomes `B-T → B-LT → B-LTA` in one call when `EMBED_LTA=true`; otherwise the existing B-LT behaviour is unchanged.

## Verifier (F-13) extension

`verify-pades.ts` now logs `"PAdES-B-LTA: archive timestamp present"` when a `/Sig` field with `/SubFilter /ETSI.RFC3161` is detected. Soft check — doesn't gate the build.

## Tests added (9)

`archive-timestamp.spec.ts`:
- returns input verbatim when TSA is not configured
- preserves the original B-LT bytes verbatim at the prefix
- writes `/Type /DocTimeStamp` + `/SubFilter /ETSI.RFC3161`
- `/ByteRange` covers everything except `/Contents` (asserts byte-level boundaries — `<` at offset b, `>` at offset c-1)
- embeds the TSA token bytes as the leading `/Contents` hex
- appends `/AcroForm` reference onto the catalog
- falls through to input PDF on TSA round-trip failure
- hashes byte-range-covered bytes for the TSA messageImprint
- emits a single new trailer dict with `/Prev` pointing at prior xref

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — green
- [x] `pnpm --filter api test` — **384 tests** green (was 375 on main)
- [ ] Production smoke once `EMBED_LTA` flipped on and KMS provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)