### PR TITLE
chore(infra): KMS RSA-3072 sealing key + binding-cert script

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -17,7 +17,8 @@
     "storage:init": "node scripts/ensure-storage-bucket.mjs",
     "smoke:upload": "node scripts/smoke-upload.mjs",
     "seed:signer": "ts-node --transpile-only scripts/seed-signer.ts",
-    "flush:emails": "ts-node --transpile-only scripts/flush-emails.ts"
+    "flush:emails": "ts-node --transpile-only scripts/flush-emails.ts",
+    "kms:gen-cert": "ts-node --transpile-only scripts/generate-kms-binding-cert.ts"
   },
   "dependencies": {
     "@aws-sdk/client-kms": "^3.1038.0",

--- a/apps/api/scripts/generate-kms-binding-cert.ts
+++ b/apps/api/scripts/generate-kms-binding-cert.ts
@@ -1,0 +1,318 @@
+/**
+ * generate-kms-binding-cert.ts — produces the X.509 binding certificate
+ * that pairs with the AWS KMS RSA-3072 SIGN_VERIFY key behind
+ * KmsPadesSigner (apps/api/src/sealing/pades-signer.ts).
+ *
+ * Why KMS-signed?
+ * ---------------
+ * KmsPadesSigner needs a PEM cert whose embedded public key matches
+ * what the KMS key returns from kms:GetPublicKey, so verifiers (Adobe
+ * Reader, EU DSS) can confirm the signature on each sealed PDF was
+ * produced by the holder of the cert's private key.
+ *
+ * Conceptually we could mint the cert with any CA (a local OpenSSL CA,
+ * a corporate PKI, or — for production — a qualified TSP). For the
+ * MVP the production policy is a *self-signed* cert where the issuer
+ * IS the KMS key. That keeps the trust chain to one element and
+ * removes the need to keep a second signing key around. The trade-off
+ * is that verifiers won't auto-trust the chain; the operator must
+ * surface the cert in the audit pack so end-users can pin it.
+ *
+ * What this script does:
+ *   1. kms:GetPublicKey -> DER-encoded SubjectPublicKeyInfo
+ *      -> parse into a forge-compatible public key.
+ *   2. Build the X.509 certificate body (forge.pki.createCertificate)
+ *      with the KMS public key as the subjectPublicKeyInfo, the
+ *      requested CN/O/C in subject AND issuer (self-signed),
+ *      validity 1 day -> 5 years from now, RSASSA_PKCS1_V1_5_SHA_256.
+ *   3. DER-encode the tbsCertificate (the bytes the signature covers).
+ *   4. SHA-256 the tbsCertificate; kms:Sign({ MessageType: DIGEST,
+ *      SigningAlgorithm: RSASSA_PKCS1_V1_5_SHA_256 }) — the same
+ *      operation KmsCmsSigner performs at runtime, which proves the
+ *      cert and the runtime signer agree on the algorithm.
+ *   5. Assemble the full Certificate ASN.1 (tbsCertificate +
+ *      signatureAlgorithm + signature OCTET STRING) and PEM-encode.
+ *   6. Write to --out (or stdout).
+ *
+ * Args:
+ *   --key-id     KMS key id, ARN, or alias (required)
+ *   --region     AWS region (required)
+ *   --out        Output PEM path (default: stdout)
+ *   --cn         Subject CN (default: "Seald PAdES Sealing")
+ *   --org        Subject O  (default: "Seald")
+ *   --country    Subject C  (default: "US")
+ *   --years      Validity period in years (default: 5)
+ *
+ * Usage:
+ *   pnpm --filter api ts-node scripts/generate-kms-binding-cert.ts \
+ *     --key-id alias/seald-pades-sealing-prod \
+ *     --region us-east-1 \
+ *     --out apps/api/.local/seald-pades-prod.crt.pem
+ *
+ * After writing the PEM, set on the API host:
+ *   PDF_SIGNING_PROVIDER=kms
+ *   PDF_SIGNING_KMS_KEY_ID=<key-id-or-alias>
+ *   PDF_SIGNING_KMS_REGION=<region>
+ *   PDF_SIGNING_KMS_CERT_PEM_PATH=<path-to-pem>
+ *
+ * Compliance refs:
+ *   - cryptography-expert §8 (production keys live in KMS).
+ *   - esignature-standards-expert §3.2 (PAdES signing-cert binding).
+ *   - RFC 5280 §4.1 (Certificate / TBSCertificate ASN.1).
+ *   - AWS docs: Sign API + RSASSA_PKCS1_V1_5_SHA_256 expects a 32-byte
+ *     digest when MessageType = DIGEST.
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { createHash } from 'node:crypto';
+import { parseArgs } from 'node:util';
+import {
+  KMSClient,
+  GetPublicKeyCommand,
+  SignCommand,
+  DescribeKeyCommand,
+} from '@aws-sdk/client-kms';
+import forge from 'node-forge';
+
+// --- OIDs -----------------------------------------------------------
+const OID_SHA256_WITH_RSA = '1.2.840.113549.1.1.11';
+
+interface CliArgs {
+  keyId: string;
+  region: string;
+  out: string | null;
+  cn: string;
+  org: string;
+  country: string;
+  years: number;
+}
+
+function parseCli(): CliArgs {
+  const { values } = parseArgs({
+    options: {
+      'key-id': { type: 'string' },
+      region: { type: 'string' },
+      out: { type: 'string' },
+      cn: { type: 'string', default: 'Seald PAdES Sealing' },
+      org: { type: 'string', default: 'Seald' },
+      country: { type: 'string', default: 'US' },
+      years: { type: 'string', default: '5' },
+    },
+    strict: true,
+    allowPositionals: false,
+  });
+
+  if (!values['key-id'] || !values.region) {
+    throw new Error(
+      'Missing required args. Usage: --key-id <id|alias|arn> --region <aws-region> [--out path] [--cn "..."] [--org "..."] [--country US] [--years 5]',
+    );
+  }
+
+  const years = Number.parseInt(String(values.years ?? '5'), 10);
+  if (!Number.isFinite(years) || years < 1 || years > 30) {
+    throw new Error(`--years must be an integer 1..30 (got ${String(values.years)})`);
+  }
+
+  return {
+    keyId: String(values['key-id']),
+    region: String(values.region),
+    out: values.out ? String(values.out) : null,
+    cn: String(values.cn),
+    org: String(values.org),
+    country: String(values.country),
+    years,
+  };
+}
+
+/**
+ * AWS KMS returns the public key as a DER-encoded
+ * SubjectPublicKeyInfo (RFC 5280 §4.1.2.7). Forge parses PEM, so wrap
+ * the DER in a SPKI PEM block first.
+ */
+function publicKeyFromKmsDer(spkiDer: Uint8Array): forge.pki.rsa.PublicKey {
+  const b64 = Buffer.from(spkiDer).toString('base64');
+  const pem = `-----BEGIN PUBLIC KEY-----\n${b64.match(/.{1,64}/g)!.join('\n')}\n-----END PUBLIC KEY-----\n`;
+  const key = forge.pki.publicKeyFromPem(pem);
+  // forge.pki.publicKeyFromPem returns the union type forge.pki.PublicKey;
+  // for RSA SPKIs it's always an rsa.PublicKey.
+  if (!('n' in key) || !('e' in key)) {
+    throw new Error('KMS GetPublicKey returned a non-RSA SPKI; KmsPadesSigner only supports RSA.');
+  }
+  return key as forge.pki.rsa.PublicKey;
+}
+
+/**
+ * Build an RFC 5280 X.509 certificate with the KMS public key as
+ * subject SPKI and pre-computed serial / validity. The signature is
+ * filled in *afterwards* by computing tbsCertificate's DER, hashing
+ * it, and asking KMS to sign that hash — the standard external-CA
+ * flow, just with KMS as the CA.
+ *
+ * Returns the prepared forge cert plus its tbsCertificate ASN.1 node
+ * (for DER encoding) and the issuer/subject DN (so we can assemble
+ * the final Certificate by hand).
+ */
+function buildCertSkeleton(args: CliArgs, pubKey: forge.pki.rsa.PublicKey): forge.pki.Certificate {
+  const cert = forge.pki.createCertificate();
+  cert.publicKey = pubKey;
+
+  // Random 20-byte positive serial — RFC 5280 §4.1.2.2 says serials
+  // SHOULD be unique and non-negative; OWASP cheat sheet recommends
+  // ≥ 64 random bits. 20 bytes is well past that.
+  const serialBytes = forge.random.getBytesSync(20);
+  // Strip the high bit so the INTEGER stays positive once DER-encoded.
+  const positiveSerial =
+    String.fromCharCode(serialBytes.charCodeAt(0) & 0x7f) + serialBytes.slice(1);
+  cert.serialNumber = forge.util.bytesToHex(positiveSerial);
+
+  const now = new Date();
+  cert.validity.notBefore = new Date(now.getTime() - 24 * 60 * 60 * 1000); // -1 day for clock skew
+  cert.validity.notAfter = new Date(now.getTime());
+  cert.validity.notAfter.setFullYear(cert.validity.notAfter.getFullYear() + args.years);
+
+  const dn: forge.pki.CertificateField[] = [
+    { name: 'commonName', value: args.cn },
+    { name: 'organizationName', value: args.org },
+    { name: 'countryName', value: args.country },
+  ];
+  cert.setSubject(dn);
+  cert.setIssuer(dn); // self-signed: subject == issuer
+
+  cert.setExtensions([
+    { name: 'basicConstraints', cA: false },
+    {
+      name: 'keyUsage',
+      digitalSignature: true,
+      nonRepudiation: true,
+      keyEncipherment: false,
+      dataEncipherment: false,
+    },
+    {
+      name: 'extKeyUsage',
+      // 1.3.6.1.5.5.7.3.4 = id-kp-emailProtection (covers document
+      // signing in most PAdES verifiers' trust evaluation). We
+      // intentionally do NOT include serverAuth/clientAuth.
+      emailProtection: true,
+    },
+    {
+      name: 'subjectKeyIdentifier',
+    },
+  ]);
+
+  // forge needs signatureOid set so DER encoding emits the correct
+  // signatureAlgorithm field; the .signature OCTET STRING is filled
+  // by us after the KMS round trip.
+  cert.signatureOid = OID_SHA256_WITH_RSA;
+  cert.siginfo = { algorithmOid: OID_SHA256_WITH_RSA };
+
+  return cert;
+}
+
+/**
+ * The TBS portion (tbsCertificate) is the part of the X.509 cert that
+ * gets signed. forge exposes tbsCertificate construction via the
+ * internal pki.getTBSCertificate helper.
+ */
+function tbsCertificateDer(cert: forge.pki.Certificate): Buffer {
+  // forge's public API: pki.getTBSCertificate(cert) returns the ASN.1
+  // tbsCertificate node. DER-encode it.
+  // (The function exists at runtime; types occasionally lag the impl,
+  // hence the loose access.)
+  const getTbs = (
+    forge.pki as unknown as {
+      getTBSCertificate: (c: forge.pki.Certificate) => forge.asn1.Asn1;
+    }
+  ).getTBSCertificate;
+  const tbs = getTbs(cert);
+  return Buffer.from(forge.asn1.toDer(tbs).getBytes(), 'binary');
+}
+
+/**
+ * Final assembly: { tbsCertificate, signatureAlgorithm, signatureValue }.
+ * Returned as a forge cert ready to PEM-encode.
+ */
+function attachSignatureToCert(
+  cert: forge.pki.Certificate,
+  signature: Buffer,
+): forge.pki.Certificate {
+  // forge stores the signature as a binary string on .signature; the
+  // PEM serialiser reads it from there.
+  cert.signature = signature.toString('binary');
+  return cert;
+}
+
+async function main(): Promise<void> {
+  const args = parseCli();
+  const kms = new KMSClient({ region: args.region });
+
+  // --- Sanity: verify the key spec / usage match what we expect ---
+  const describe = await kms.send(new DescribeKeyCommand({ KeyId: args.keyId }));
+  const meta = describe.KeyMetadata;
+  if (!meta) {
+    throw new Error(`kms:DescribeKey returned no metadata for ${args.keyId}`);
+  }
+  if (meta.KeyUsage !== 'SIGN_VERIFY') {
+    throw new Error(`KMS key ${args.keyId} has KeyUsage=${meta.KeyUsage}; expected SIGN_VERIFY`);
+  }
+  if (meta.CustomerMasterKeySpec !== 'RSA_3072' && meta.KeySpec !== 'RSA_3072') {
+    throw new Error(
+      `KMS key ${args.keyId} has spec=${meta.KeySpec ?? meta.CustomerMasterKeySpec}; expected RSA_3072`,
+    );
+  }
+  console.log(
+    `[kms] key=${meta.Arn ?? args.keyId} spec=RSA_3072 usage=SIGN_VERIFY state=${meta.KeyState ?? 'unknown'}`,
+  );
+
+  // --- 1. Pull the public key ---
+  const pkOut = await kms.send(new GetPublicKeyCommand({ KeyId: args.keyId }));
+  if (!pkOut.PublicKey) {
+    throw new Error('kms:GetPublicKey returned no PublicKey');
+  }
+  const pubKey = publicKeyFromKmsDer(pkOut.PublicKey);
+  console.log(`[kms] retrieved public key: modulus_bits=${pubKey.n.bitLength()}`);
+
+  // --- 2. Build the cert skeleton ---
+  const cert = buildCertSkeleton(args, pubKey);
+
+  // --- 3. DER-encode the tbsCertificate, hash it ---
+  const tbsDer = tbsCertificateDer(cert);
+  const tbsDigest = createHash('sha256').update(tbsDer).digest();
+  console.log(
+    `[cert] tbs_bytes=${tbsDer.length} tbs_sha256=${tbsDigest.toString('hex').slice(0, 16)}…`,
+  );
+
+  // --- 4. Ask KMS to sign the digest ---
+  const signOut = await kms.send(
+    new SignCommand({
+      KeyId: args.keyId,
+      Message: tbsDigest,
+      MessageType: 'DIGEST',
+      SigningAlgorithm: 'RSASSA_PKCS1_V1_5_SHA_256',
+    }),
+  );
+  if (!signOut.Signature) {
+    throw new Error('kms:Sign returned no Signature');
+  }
+  const signature = Buffer.from(signOut.Signature);
+  console.log(`[kms] signed: signature_bytes=${signature.length}`);
+
+  // --- 5. Attach signature, PEM-encode, write ---
+  const signedCert = attachSignatureToCert(cert, signature);
+  const pem = forge.pki.certificateToPem(signedCert);
+
+  if (args.out) {
+    const outPath = resolve(process.cwd(), args.out);
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, pem, { encoding: 'utf8', mode: 0o600 });
+    console.log(`[ok] wrote ${pem.length} bytes -> ${outPath}`);
+  } else {
+    process.stdout.write(pem);
+  }
+}
+
+main().catch((err: unknown) => {
+  const msg = err instanceof Error ? (err.stack ?? err.message) : String(err);
+  console.error(`[fatal] ${msg}`);
+  process.exit(1);
+});

--- a/deploy/terraform/SEALING_KMS_RUNBOOK.md
+++ b/deploy/terraform/SEALING_KMS_RUNBOOK.md
@@ -1,0 +1,211 @@
+# Sealing KMS — provisioning runbook
+
+End-to-end procedure for standing up the AWS KMS RSA-3072 SIGN_VERIFY
+key that backs `KmsPadesSigner` (apps/api/src/sealing/pades-signer.ts).
+Read this in full before the first apply; the steps are idempotent
+once the key exists, but the **30-day deletion window** makes a wrong
+move expensive.
+
+> **TL;DR:** apply the Terraform module → run `pnpm --filter api
+> kms:gen-cert` → drop the PEM and three env vars on the API host →
+> `docker compose restart api`.
+
+---
+
+## 1. Prerequisites
+
+| Item | Notes |
+|---|---|
+| AWS creds with `kms:CreateKey`, `kms:CreateAlias`, `iam:CreatePolicy` | Apply runs once; afterwards the API role only needs `kms:Sign` + `kms:GetPublicKey`. |
+| Terraform ≥ 1.6.0 | Match the CI pin (1.8.5) when possible. |
+| `pnpm` + Node 20 + `ts-node` | Required to run the cert generator script. |
+| Repo checkout at the branch that has `modules/sealing-kms` merged | The root `main.tf` only reads it through `module "sealing_kms"`. |
+| Sealing env decided | The module names everything `seald-pades-sealing-<env>`. Stick to `prod`. |
+
+State backend: the existing `.github/workflows/terraform.yml` already
+configures the S3 backend + DynamoDB lock. For local plans run
+`terraform init -backend=false`.
+
+---
+
+## 2. Plan + apply
+
+```sh
+cd deploy/terraform
+
+terraform fmt -check -recursive
+terraform validate
+
+# CI normally runs the apply on push; for a manual run:
+gh workflow run terraform.yml --ref main -f action=plan
+gh workflow run terraform.yml --ref main -f action=apply
+```
+
+What gets created on first apply (`var.enable_kms_sealing = true`,
+default for prod):
+
+| Resource | Identifier |
+|---|---|
+| `aws_kms_key.sealing` | RSA-3072 SIGN_VERIFY, 30-day deletion window |
+| `aws_kms_alias.sealing` | `alias/seald-pades-sealing-prod` |
+| `aws_iam_policy.api_kms_sign` | `seald-pades-sealing-prod-sign` |
+| `aws_iam_role_policy_attachment.api_kms_sign` *(conditional)* | Attached only when `var.sealing_api_role_name != ""` |
+
+Charges: ~$1/month per asymmetric KMS key + per-API-call usage. At
+expected seal volumes (≪ 10 k seals/month) total spend stays under $5.
+
+---
+
+## 3. Capture the outputs
+
+Fetch the values the API and cert-generator script need:
+
+```sh
+terraform -chdir=deploy/terraform output -raw sealing_kms_key_id
+terraform -chdir=deploy/terraform output -raw sealing_kms_alias
+terraform -chdir=deploy/terraform output -raw sealing_kms_region
+terraform -chdir=deploy/terraform output -raw sealing_kms_iam_policy_arn
+```
+
+Note them in 1Password under "Seald — production secrets" alongside
+the existing Caddy / Supabase entries.
+
+---
+
+## 4. Generate the binding certificate
+
+The cert binds the KMS public key to a human-readable subject
+("Seald PAdES Sealing"). It is signed *by the KMS key itself*, so the
+chain is exactly one cert deep — verifiers like Adobe Reader and EU
+DSS will mark the chain as untrusted unless the operator pins the
+cert in their trust store. We surface the cert in the audit pack so
+end-recipients can do that.
+
+From a workstation with prod AWS creds (or a CI runner with the
+attached IAM policy):
+
+```sh
+mkdir -p apps/api/.local
+pnpm --filter api kms:gen-cert -- \
+  --key-id alias/seald-pades-sealing-prod \
+  --region us-east-1 \
+  --out apps/api/.local/seald-pades-prod.crt.pem \
+  --cn "Seald PAdES Sealing" \
+  --org "Seald" \
+  --country US \
+  --years 5
+```
+
+The script:
+
+1. `kms:DescribeKey` — sanity-checks `RSA_3072` + `SIGN_VERIFY`.
+2. `kms:GetPublicKey` — fetches the SubjectPublicKeyInfo.
+3. Builds an X.509 v3 cert with that public key and your subject DN.
+4. SHA-256 hashes the tbsCertificate.
+5. `kms:Sign(MessageType=DIGEST, RSASSA_PKCS1_V1_5_SHA_256)`.
+6. Wraps the signature into the cert and writes a PEM at `--out`.
+
+Keep the PEM. Lose it and you have to re-issue (the *cert*, not the
+key — the key is reusable).
+
+### LocalStack smoke test (optional)
+
+LocalStack's pro tier supports asymmetric KMS; the community edition
+returns a stub. For smoke purposes:
+
+```sh
+docker run --rm -d -p 4566:4566 -e SERVICES=kms localstack/localstack-pro
+aws --endpoint-url=http://localhost:4566 kms create-key \
+  --customer-master-key-spec RSA_3072 --key-usage SIGN_VERIFY
+# copy KeyId, then:
+AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test \
+  pnpm --filter api kms:gen-cert -- \
+    --key-id <key-id> --region us-east-1 \
+    --out /tmp/local.crt.pem
+```
+
+Skip this step if LocalStack pro isn't available — it does not gate
+the runbook.
+
+---
+
+## 5. Wire env on the API host
+
+SSH to the production EC2 host and edit `/opt/seald/apps/api/.env`:
+
+```env
+PDF_SIGNING_PROVIDER=kms
+PDF_SIGNING_KMS_KEY_ID=alias/seald-pades-sealing-prod
+PDF_SIGNING_KMS_REGION=us-east-1
+PDF_SIGNING_KMS_CERT_PEM_PATH=/opt/seald/secrets/seald-pades-prod.crt.pem
+```
+
+Copy the PEM to the host:
+
+```sh
+scp apps/api/.local/seald-pades-prod.crt.pem \
+  ubuntu@api.seald.nromomentum.com:/opt/seald/secrets/seald-pades-prod.crt.pem
+ssh ubuntu@api.seald.nromomentum.com 'sudo chown root:root /opt/seald/secrets/seald-pades-prod.crt.pem && sudo chmod 0640 /opt/seald/secrets/*.pem'
+```
+
+Restart the API container so `KmsPadesSigner` re-initialises:
+
+```sh
+ssh ubuntu@api.seald.nromomentum.com 'cd /opt/seald && docker compose restart api'
+```
+
+Verify the log line:
+
+```
+[Nest] LOG  KmsPadesSigner — KMS signer ready: key=alias/seald-pades-sealing-prod region=us-east-1 subject="Seald PAdES Sealing" TSA=enabled
+```
+
+---
+
+## 6. Rotation
+
+Asymmetric KMS keys cannot be auto-rotated by AWS; rotation is a
+human-driven re-key. When you do rotate (cert expiry, suspected
+compromise, or the planned 5-year cadence):
+
+1. Apply a *second* sealing module instance with a fresh `environment`
+   slug (e.g. `prod-2027`) — both keys coexist while you migrate.
+2. Generate a new cert (`kms:gen-cert`) against the new key id.
+3. Flip the API env vars to point at the new key+cert. Restart.
+4. Smoke-test by signing one document and running
+   `pnpm --filter api ts-node scripts/verify-pades.ts <dir>`.
+5. After ≥ 30 days (so any in-flight signed PDFs can still be verified
+   against the public key on the *old* key), delete the old module
+   block. Terraform schedules deletion with the 30-day window — the
+   key isn't actually destroyed until day 30, recoverable until then
+   via `aws kms cancel-key-deletion`.
+
+---
+
+## 7. Deletion (last resort)
+
+```sh
+# Tear down the entire sealing key. PAdES signatures previously made
+# against this key remain VERIFIABLE only as long as relying parties
+# already have the binding cert pinned — the public key disappears
+# from KMS once the deletion window elapses.
+terraform -chdir=deploy/terraform apply \
+  -var enable_kms_sealing=false
+```
+
+Until day 30:
+```sh
+aws kms cancel-key-deletion --key-id <key-id>
+```
+restores the key fully.
+
+---
+
+## 8. Troubleshooting
+
+| Symptom | Cause / fix |
+|---|---|
+| `KmsPadesSigner: cannot read cert PEM at ...` | Path inside the container differs from the host path. Mount it via `docker-compose.yml` or copy under the bind-mounted `secrets/` dir. |
+| `kms:Sign returned no Signature` | API role missing the policy. Re-check `terraform output sealing_kms_iam_policy_arn` is attached to the running role. |
+| `KMS key ... has spec=...; expected RSA_3072` | Wrong `--key-id`. The script targets a non-sealing key (e.g. data-key). |
+| TSA fallback to B-B in logs | Not a KMS issue; check `PDF_SIGNING_TSA_URL` reachability. |

--- a/deploy/terraform/main.tf
+++ b/deploy/terraform/main.tf
@@ -236,3 +236,28 @@ resource "aws_eip" "api" {
   instance = aws_instance.api.id
   tags     = merge(local.common_tags, { Name = "${var.project}-api" })
 }
+
+# --------------------------------------------------------------------
+# PAdES sealing key (RSA-3072 SIGN_VERIFY).
+#
+# Backs apps/api/src/sealing/pades-signer.ts -> KmsPadesSigner. The
+# private key never leaves AWS KMS; the API only ever calls kms:Sign
+# with a SHA-256 digest. After apply, run:
+#
+#   pnpm --filter api ts-node scripts/generate-kms-binding-cert.ts \
+#     --key-id <module.sealing_kms[0].key_id> \
+#     --region <module.sealing_kms[0].region> \
+#     --out apps/api/.local/seald-pades-prod.crt.pem
+#
+# Then set PDF_SIGNING_KMS_KEY_ID + PDF_SIGNING_KMS_REGION +
+# PDF_SIGNING_KMS_CERT_PEM_PATH on the API host. Full walkthrough in
+# deploy/terraform/SEALING_KMS_RUNBOOK.md.
+# --------------------------------------------------------------------
+module "sealing_kms" {
+  count  = var.enable_kms_sealing ? 1 : 0
+  source = "./modules/sealing-kms"
+
+  environment   = var.sealing_environment
+  api_role_name = var.sealing_api_role_name
+  tags          = local.common_tags
+}

--- a/deploy/terraform/modules/sealing-kms/main.tf
+++ b/deploy/terraform/modules/sealing-kms/main.tf
@@ -1,0 +1,121 @@
+# Sealing-KMS module — provisions the asymmetric AWS KMS key that backs
+# the production PAdES signer (apps/api/src/sealing/pades-signer.ts ->
+# KmsPadesSigner). The private key never leaves KMS; the API process
+# only ever calls kms:Sign with a SHA-256 digest of the CMS
+# SignedAttributes (RFC 5652 §5.4).
+#
+# Resources:
+#   - aws_kms_key       RSA-3072 SIGN_VERIFY, no rotation (asymmetric
+#                       keys cannot be rotated by AWS), 30-day deletion
+#                       window so an accidental destroy is recoverable.
+#   - aws_kms_alias     Stable handle for the API to reference; the
+#                       underlying key id can be rebuilt without touching
+#                       env vars.
+#   - aws_iam_policy    Least-privilege grant: kms:Sign + kms:GetPublicKey
+#                       on this single key arn. Attached to the API role
+#                       passed in via var.api_role_name.
+#
+# What this module deliberately does NOT do:
+#   - Generate or sign the X.509 binding certificate (handled by
+#     apps/api/scripts/generate-kms-binding-cert.ts after apply).
+#   - Configure rotation / re-key (asymmetric SIGN_VERIFY keys are
+#     intentionally long-lived; rotation = new key + new cert + env
+#     update, see SEALING_KMS_RUNBOOK.md §Rotation).
+
+terraform {
+  required_version = ">= 1.6.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.40"
+    }
+  }
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# --------------------------------------------------------------------
+# The KMS key itself.
+#
+# - customer_master_key_spec = RSA_3072 — matches KmsCmsSigner's
+#   RSASSA_PKCS1_V1_5_SHA_256 algorithm (cryptography-expert §8 — the
+#   smallest RSA size NIST SP 800-131A still considers acceptable past
+#   2030 is 3072).
+# - key_usage = SIGN_VERIFY — the only usage the signer ever invokes.
+# - enable_key_rotation is omitted: AWS rejects rotation on asymmetric
+#   keys, so leaving it unset is the only valid configuration.
+# - deletion_window_in_days = 30 — maximum window. PAdES sealed PDFs
+#   stay valid only as long as the public key behind the binding cert
+#   is reachable for verification, so accidental deletion is the worst
+#   class of failure here. 30 days gives plenty of recovery time.
+# --------------------------------------------------------------------
+resource "aws_kms_key" "sealing" {
+  description              = "Seald PAdES sealing key (${var.environment}) — RSA-3072 SIGN_VERIFY, used by KmsPadesSigner"
+  customer_master_key_spec = "RSA_3072"
+  key_usage                = "SIGN_VERIFY"
+  deletion_window_in_days  = 30
+  is_enabled               = true
+
+  tags = merge(var.tags, {
+    Name        = "seald-pades-sealing-${var.environment}"
+    Environment = var.environment
+    Purpose     = "pades-signing"
+  })
+}
+
+resource "aws_kms_alias" "sealing" {
+  name          = "alias/seald-pades-sealing-${var.environment}"
+  target_key_id = aws_kms_key.sealing.key_id
+}
+
+# --------------------------------------------------------------------
+# Least-privilege IAM policy.
+#
+# kms:Sign           — invoked once per sealed PDF.
+# kms:GetPublicKey   — invoked by the binding-cert generator script,
+#                      and on first boot if the API ever needs to
+#                      rebuild the cert from scratch (it doesn't
+#                      currently — cert is provisioned offline — but
+#                      keeping the permission cheap means the script
+#                      doesn't need a separate role).
+# kms:DescribeKey    — used by the script for sanity checks (key spec,
+#                      key usage). Read-only metadata.
+#
+# Resource is pinned to the single key arn so the role can't pivot to
+# any other KMS key in the account.
+# --------------------------------------------------------------------
+data "aws_iam_policy_document" "api_kms_sign" {
+  statement {
+    sid    = "AllowPadesSign"
+    effect = "Allow"
+    actions = [
+      "kms:Sign",
+      "kms:GetPublicKey",
+      "kms:DescribeKey",
+    ]
+    resources = [aws_kms_key.sealing.arn]
+  }
+}
+
+resource "aws_iam_policy" "api_kms_sign" {
+  name        = "seald-pades-sealing-${var.environment}-sign"
+  description = "Allow the Seald API role to call kms:Sign + kms:GetPublicKey on the PAdES sealing key (${var.environment})."
+  policy      = data.aws_iam_policy_document.api_kms_sign.json
+
+  tags = merge(var.tags, {
+    Environment = var.environment
+    Purpose     = "pades-signing"
+  })
+}
+
+# Attaching the policy is conditional: var.api_role_name = "" means the
+# caller hasn't wired up an instance/task role yet (e.g. spot EC2 still
+# uses static credentials). In that case we provision the policy + key
+# but leave attachment to the operator. Once an IAM role is in place,
+# set var.api_role_name and re-apply.
+resource "aws_iam_role_policy_attachment" "api_kms_sign" {
+  count      = var.api_role_name == "" ? 0 : 1
+  role       = var.api_role_name
+  policy_arn = aws_iam_policy.api_kms_sign.arn
+}

--- a/deploy/terraform/modules/sealing-kms/outputs.tf
+++ b/deploy/terraform/modules/sealing-kms/outputs.tf
@@ -1,0 +1,24 @@
+output "key_arn" {
+  description = "ARN of the PAdES sealing KMS key. Used by the IAM policy and surfaced for operator runbooks."
+  value       = aws_kms_key.sealing.arn
+}
+
+output "key_id" {
+  description = "Bare key id (UUID). This is what `PDF_SIGNING_KMS_KEY_ID` expects in the API env. Prefer the alias for human-facing references."
+  value       = aws_kms_key.sealing.key_id
+}
+
+output "key_alias" {
+  description = "Human-friendly alias (`alias/seald-pades-sealing-<env>`). The API can also accept this in PDF_SIGNING_KMS_KEY_ID."
+  value       = aws_kms_alias.sealing.name
+}
+
+output "region" {
+  description = "Region the key was created in. Mirrors the provider region; surfaced so the operator can copy it directly into PDF_SIGNING_KMS_REGION."
+  value       = data.aws_region.current.name
+}
+
+output "iam_policy_arn" {
+  description = "ARN of the kms:Sign + kms:GetPublicKey policy. Attach to additional roles (e.g. one-off ops, CI cert-rotation jobs) as needed."
+  value       = aws_iam_policy.api_kms_sign.arn
+}

--- a/deploy/terraform/modules/sealing-kms/variables.tf
+++ b/deploy/terraform/modules/sealing-kms/variables.tf
@@ -1,0 +1,26 @@
+variable "environment" {
+  description = "Deployment environment slug — appears in the alias (`alias/seald-pades-sealing-<env>`) and in tags. Use `prod`, `staging`, etc."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,15}$", var.environment))
+    error_message = "environment must be 2-16 chars, lowercase alphanumeric + hyphen, starting with a letter."
+  }
+}
+
+variable "api_role_name" {
+  description = <<-EOT
+    Name (not ARN) of the IAM role attached to the API runtime
+    (EC2 instance profile or ECS task role). The kms:Sign + kms:GetPublicKey
+    policy is attached to this role. Pass empty string ("") to provision the
+    policy but skip attachment — useful on first apply when no role exists yet.
+  EOT
+  type        = string
+  default     = ""
+}
+
+variable "tags" {
+  description = "Extra tags to merge onto every resource the module creates."
+  type        = map(string)
+  default     = {}
+}

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -35,3 +35,35 @@ output "godaddy_dns_instructions" {
   description = "DNS setup instructions. If godaddy_enabled is true, Terraform already wrote the A record for you. If false, paste the EIP into the GoDaddy DNS dashboard after apply."
   value       = var.godaddy_enabled ? local.dns_managed_msg : local.dns_manual_msg
 }
+
+# --------------------------------------------------------------------
+# Sealing KMS outputs — surface the values needed by
+# apps/api/scripts/generate-kms-binding-cert.ts and the API runtime
+# env vars (PDF_SIGNING_KMS_KEY_ID, PDF_SIGNING_KMS_REGION).
+# All null when var.enable_kms_sealing = false.
+# --------------------------------------------------------------------
+
+output "sealing_kms_key_arn" {
+  description = "ARN of the PAdES sealing KMS key. Null when enable_kms_sealing = false."
+  value       = var.enable_kms_sealing ? module.sealing_kms[0].key_arn : null
+}
+
+output "sealing_kms_key_id" {
+  description = "Key id (UUID) for PDF_SIGNING_KMS_KEY_ID. Null when enable_kms_sealing = false."
+  value       = var.enable_kms_sealing ? module.sealing_kms[0].key_id : null
+}
+
+output "sealing_kms_alias" {
+  description = "Stable alias (alias/seald-pades-sealing-<env>) — accepted by KmsPadesSigner in lieu of the key id."
+  value       = var.enable_kms_sealing ? module.sealing_kms[0].key_alias : null
+}
+
+output "sealing_kms_region" {
+  description = "Region the sealing key lives in. Goes into PDF_SIGNING_KMS_REGION."
+  value       = var.enable_kms_sealing ? module.sealing_kms[0].region : null
+}
+
+output "sealing_kms_iam_policy_arn" {
+  description = "ARN of the kms:Sign + kms:GetPublicKey IAM policy. Attach to additional roles as needed."
+  value       = var.enable_kms_sealing ? module.sealing_kms[0].iam_policy_arn : null
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -52,6 +52,38 @@ variable "tags" {
   default     = {}
 }
 
+# ---------- Sealing KMS (PAdES signing) ----------
+
+variable "enable_kms_sealing" {
+  description = <<-EOT
+    Provision the production PAdES sealing key (RSA-3072 SIGN_VERIFY)
+    via modules/sealing-kms. Default true so prod gets it on first
+    apply; flip to false in non-prod tfvars (staging, dev, ephemeral
+    review envs) to avoid the per-key/month KMS charge and the
+    30-day deletion window when tearing down.
+  EOT
+  type        = bool
+  default     = true
+}
+
+variable "sealing_environment" {
+  description = "Environment slug fed into the sealing-kms module (alias suffix + tags). Defaults to `prod` because that's the only env the seal currently runs in."
+  type        = string
+  default     = "prod"
+}
+
+variable "sealing_api_role_name" {
+  description = <<-EOT
+    Name of the IAM role attached to the API runtime that should be
+    granted kms:Sign + kms:GetPublicKey on the sealing key. Leave
+    empty to provision the policy without attaching — the EC2 spot
+    instance currently runs with static credentials, so attachment
+    is deferred until the migration to an instance profile.
+  EOT
+  type        = string
+  default     = ""
+}
+
 # ---------- GoDaddy DNS (optional) ----------
 
 variable "godaddy_enabled" {


### PR DESCRIPTION
## Summary

- New \`deploy/terraform/modules/sealing-kms\` module — RSA-3072 SIGN_VERIFY KMS key, alias \`alias/seald-pades-sealing-prod\`, 30-day deletion window, and a least-privilege \`kms:Sign\` + \`kms:GetPublicKey\` IAM policy attached (when \`var.sealing_api_role_name\` is set) to the API runtime role.
- Wired into root \`main.tf\` behind \`var.enable_kms_sealing\` (default true). Outputs surface key arn / id / alias / region / policy arn.
- New \`apps/api/scripts/generate-kms-binding-cert.ts\` — Node CLI that calls \`kms:GetPublicKey\`, builds an X.509 cert with the KMS pubkey, then signs the tbsCertificate via \`kms:Sign\` (same RSASSA_PKCS1_V1_5_SHA_256 the runtime signer uses). Wired as \`pnpm --filter api kms:gen-cert\`.
- \`SEALING_KMS_RUNBOOK.md\` walks through plan/apply, output capture, cert generation, env wiring (\`PDF_SIGNING_KMS_*\`), rotation, and the 30-day deletion path.

## Verification

- \`terraform fmt -check -recursive deploy/terraform/\` — clean.
- \`terraform validate\` (root + module) — Success.
- \`pnpm --filter api typecheck\` — 0 new errors (pre-existing main breakage unrelated to this change resolves once \`shared\` is built).
- \`pnpm --filter api lint\` — clean.
- \`pnpm --filter api test\` — 375/375 passing.
- Script smoke: arg validation paths exercised locally; full KMS round-trip deferred to staging apply (per runbook).

## Test plan

- [ ] CI: terraform fmt/validate/plan
- [ ] CI: api typecheck + lint + jest
- [ ] CI: web vitest
- [ ] CI: api e2e (PAdES suite still uses P12 fixture — KMS path unaffected)
- [ ] Manual (post-merge, before prod cut-over): \`gh workflow run terraform.yml --ref main -f action=apply\` then run the cert generator per runbook §4.

## Out of scope

- No \`terraform apply\` performed; production key not yet provisioned.
- API \`SealingModule\` factory selection (\`PDF_SIGNING_PROVIDER=kms\`) already lands when \`KmsPadesSigner\` was merged in #12. This PR only adds the infra + generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)