### PR TITLE
feat(api): templates table + CRUD endpoints (post-PR-11)

### DIFF
--- a/apps/api/db/migrations/0008_templates.sql
+++ b/apps/api/db/migrations/0008_templates.sql
@@ -1,0 +1,43 @@
+-- 0008_templates.sql
+-- Per-user reusable signing templates. A template captures a saved field
+-- layout (signature/initial/date/text/checkbox positions, addressed by
+-- page-rule: 'all' | 'allButLast' | 'first' | 'last' | <page-num>) so the
+-- sender can swap in a new PDF and have the same fields snap onto it.
+--
+-- Scoped by owner_id → auth.users(id). Cascades on user deletion (GDPR-
+-- aligned). RLS enabled with no policies — the backend connects as admin
+-- and is the sole gate. Mirrors the contacts (0001) and envelopes (0002)
+-- patterns.
+
+create table public.templates (
+  id              uuid        primary key default gen_random_uuid(),
+  owner_id        uuid        not null references auth.users(id) on delete cascade,
+  title           text        not null check (char_length(title) between 1 and 200),
+  description     text                 check (description is null or char_length(description) <= 2000),
+  cover_color     text                 check (cover_color is null or cover_color ~ '^#[0-9A-Fa-f]{6}$'),
+  -- field_layout is a JSON array of { type, pageRule, x, y, label? } per the
+  -- TemplateField type in packages/shared/src/templates.ts. We keep it as
+  -- jsonb (not a separate child table) because:
+  --   1. Layouts are read/written atomically — there's no per-field query.
+  --   2. The shape is bounded (typically 5-15 entries) and validated at
+  --      the HTTP boundary by class-validator + the shared zod schema.
+  field_layout    jsonb       not null default '[]'::jsonb,
+  uses_count      integer     not null default 0 check (uses_count >= 0),
+  last_used_at    timestamptz,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now()
+);
+
+create index templates_owner_idx           on public.templates (owner_id);
+-- Sort: last_used_at desc nulls last is the primary list ordering.
+create index templates_owner_last_used_idx on public.templates (owner_id, last_used_at desc nulls last);
+
+alter table public.templates enable row level security;
+
+-- Reuse the set_updated_at function defined in 0001_contacts.sql.
+create trigger templates_set_updated_at
+  before update on public.templates
+  for each row execute function public.set_updated_at();
+
+comment on column public.templates.field_layout is
+  'JSON array of TemplateField records: { type: signature|initial|date|text|checkbox, pageRule: all|allButLast|first|last|<int>, x: number, y: number, label?: string }. See packages/shared/src/templates.ts.';

--- a/apps/api/db/schema.ts
+++ b/apps/api/db/schema.ts
@@ -10,6 +10,35 @@ export interface Database {
   outbound_emails: OutboundEmailsTable;
   idempotency_records: IdempotencyRecordsTable;
   email_webhooks: EmailWebhooksTable;
+  templates: TemplatesTable;
+}
+
+export type TemplateFieldTypeDb = 'signature' | 'initial' | 'date' | 'text' | 'checkbox';
+
+/**
+ * One field layout entry inside `templates.field_layout`. Mirrors the
+ * `TemplateField` shape exported from packages/shared/src/templates.ts —
+ * the canonical client-side type. See migration 0008 for the column comment.
+ */
+export interface TemplateFieldLayoutDb {
+  type: TemplateFieldTypeDb;
+  pageRule: 'all' | 'allButLast' | 'first' | 'last' | number;
+  x: number;
+  y: number;
+  label?: string;
+}
+
+export interface TemplatesTable {
+  id: Generated<string>;
+  owner_id: string;
+  title: string;
+  description: string | null;
+  cover_color: string | null;
+  field_layout: ColumnType<ReadonlyArray<TemplateFieldLayoutDb>, string, string | undefined>;
+  uses_count: ColumnType<number, number | undefined, number | undefined>;
+  last_used_at: ColumnType<Date | null, string | null | undefined, string | null | undefined>;
+  created_at: ColumnType<Date, string | undefined, never>;
+  updated_at: ColumnType<Date, string | undefined, string | undefined>;
 }
 
 export interface ContactsTable {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -11,6 +11,7 @@ import { CronModule } from './cron/cron.module';
 import { EnvelopesModule } from './envelopes/envelopes.module';
 import { HealthModule } from './health/health.module';
 import { SealingModule } from './sealing/sealing.module';
+import { TemplatesModule } from './templates/templates.module';
 import { VerifyModule } from './verify/verify.module';
 import { SigningModule } from './signing/signing.module';
 import { StorageModule } from './storage/storage.module';
@@ -43,6 +44,7 @@ import { StorageModule } from './storage/storage.module';
     HealthModule,
     ContactsModule,
     EnvelopesModule,
+    TemplatesModule,
     SealingModule,
     VerifyModule,
     CronModule,

--- a/apps/api/src/templates/dto/create-template.dto.ts
+++ b/apps/api/src/templates/dto/create-template.dto.ts
@@ -1,0 +1,96 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsIn,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+  registerDecorator,
+  type ValidationArguments,
+  type ValidationOptions,
+} from 'class-validator';
+import { TEMPLATE_FIELD_TYPES, type TemplatePageRule } from 'shared';
+
+const PAGE_RULE_LITERALS = ['all', 'allButLast', 'first', 'last'] as const;
+
+/**
+ * Accept either a pageRule literal OR a positive integer (1-indexed page
+ * number). class-validator can't natively express that union; we register
+ * a one-off decorator instead of stacking two with conflicting semantics.
+ */
+function IsPageRule(options?: ValidationOptions): PropertyDecorator {
+  return (target: object, propertyKey: string | symbol): void => {
+    registerDecorator({
+      name: 'isPageRule',
+      target: target.constructor,
+      propertyName: String(propertyKey),
+      ...(options ? { options } : {}),
+      validator: {
+        validate(value: unknown): boolean {
+          if (
+            typeof value === 'string' &&
+            (PAGE_RULE_LITERALS as ReadonlyArray<string>).includes(value)
+          ) {
+            return true;
+          }
+          return typeof value === 'number' && Number.isInteger(value) && value >= 1;
+        },
+        defaultMessage(args: ValidationArguments): string {
+          return `${args.property} must be one of [${PAGE_RULE_LITERALS.join(', ')}] or a positive integer (1-indexed page number)`;
+        },
+      },
+    });
+  };
+}
+
+/**
+ * One field layout entry inside `field_layout`. The `pageRule` union is
+ * validated by the custom decorator above; `type` against the shared
+ * enum so the seald API and SPA share the same allowed values.
+ */
+export class TemplateFieldDto {
+  @IsString()
+  @IsIn([...TEMPLATE_FIELD_TYPES])
+  readonly type!: (typeof TEMPLATE_FIELD_TYPES)[number];
+
+  @IsPageRule()
+  readonly pageRule!: TemplatePageRule;
+
+  @IsNumber()
+  readonly x!: number;
+
+  @IsNumber()
+  readonly y!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  readonly label?: string;
+}
+
+export class CreateTemplateDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  readonly title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  readonly description?: string | null;
+
+  @IsOptional()
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: 'cover_color must be a 6-digit hex like #RRGGBB',
+  })
+  readonly cover_color?: string | null;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TemplateFieldDto)
+  readonly field_layout!: ReadonlyArray<TemplateFieldDto>;
+}

--- a/apps/api/src/templates/dto/update-template.dto.ts
+++ b/apps/api/src/templates/dto/update-template.dto.ts
@@ -1,0 +1,36 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsOptional,
+  IsString,
+  Matches,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { TemplateFieldDto } from './create-template.dto';
+
+export class UpdateTemplateDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  readonly title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  readonly description?: string | null;
+
+  @IsOptional()
+  @Matches(/^#[0-9A-Fa-f]{6}$/, {
+    message: 'cover_color must be a 6-digit hex like #RRGGBB',
+  })
+  readonly cover_color?: string | null;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => TemplateFieldDto)
+  readonly field_layout?: ReadonlyArray<TemplateFieldDto>;
+}

--- a/apps/api/src/templates/templates.controller.ts
+++ b/apps/api/src/templates/templates.controller.ts
@@ -1,0 +1,66 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import type { Template } from 'shared';
+import type { AuthUser } from '../auth/auth-user';
+import { CurrentUser } from '../auth/current-user.decorator';
+import { CreateTemplateDto } from './dto/create-template.dto';
+import { UpdateTemplateDto } from './dto/update-template.dto';
+import { TemplatesService } from './templates.service';
+
+// AuthGuard is registered globally as APP_GUARD in AuthModule — every
+// route here authenticates by default.
+@Controller('templates')
+export class TemplatesController {
+  constructor(private readonly svc: TemplatesService) {}
+
+  @Get()
+  list(@CurrentUser() user: AuthUser): Promise<ReadonlyArray<Template>> {
+    return this.svc.list(user.id);
+  }
+
+  @Post()
+  create(@CurrentUser() user: AuthUser, @Body() dto: CreateTemplateDto): Promise<Template> {
+    return this.svc.create(user.id, dto);
+  }
+
+  @Get(':id')
+  get(@CurrentUser() user: AuthUser, @Param('id', ParseUUIDPipe) id: string): Promise<Template> {
+    return this.svc.get(user.id, id);
+  }
+
+  @Patch(':id')
+  update(
+    @CurrentUser() user: AuthUser,
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: UpdateTemplateDto,
+  ): Promise<Template> {
+    return this.svc.update(user.id, id, dto);
+  }
+
+  @Delete(':id')
+  @HttpCode(204)
+  remove(@CurrentUser() user: AuthUser, @Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    return this.svc.remove(user.id, id);
+  }
+
+  /**
+   * Bumps `uses_count` and `last_used_at`. Called by the upload-flow
+   * integration when a sender clicks "Continue with this template" on
+   * `/templates/:id/use`. Returns the updated record so the SPA can
+   * reflect the new lastUsed timestamp without a follow-up GET.
+   */
+  @Post(':id/use')
+  @HttpCode(200)
+  use(@CurrentUser() user: AuthUser, @Param('id', ParseUUIDPipe) id: string): Promise<Template> {
+    return this.svc.use(user.id, id);
+  }
+}

--- a/apps/api/src/templates/templates.module.ts
+++ b/apps/api/src/templates/templates.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { TemplatesController } from './templates.controller';
+import { TemplatesRepository } from './templates.repository';
+import { TemplatesPgRepository } from './templates.repository.pg';
+import { TemplatesService } from './templates.service';
+
+@Module({
+  imports: [AuthModule],
+  controllers: [TemplatesController],
+  providers: [TemplatesService, { provide: TemplatesRepository, useClass: TemplatesPgRepository }],
+  exports: [TemplatesRepository],
+})
+export class TemplatesModule {}

--- a/apps/api/src/templates/templates.repository.pg.spec.ts
+++ b/apps/api/src/templates/templates.repository.pg.spec.ts
@@ -1,0 +1,123 @@
+import type { TemplateField } from 'shared';
+import { createPgMemDb, type PgMemHandle, seedUser } from '../../test/pg-mem-db';
+import { TemplatesPgRepository } from './templates.repository.pg';
+
+const OWNER_A = '11111111-1111-4111-8111-111111111111';
+const OWNER_B = '22222222-2222-4222-8222-222222222222';
+
+const SAMPLE_FIELDS: ReadonlyArray<TemplateField> = [
+  { type: 'signature', pageRule: 'last', x: 60, y: 540 },
+  { type: 'date', pageRule: 'last', x: 320, y: 540 },
+  { type: 'initial', pageRule: 'all', x: 522, y: 50 },
+];
+
+describe('TemplatesPgRepository (pg-mem)', () => {
+  let handle: PgMemHandle;
+  let repo: TemplatesPgRepository;
+
+  beforeEach(async () => {
+    handle = createPgMemDb();
+    await seedUser(handle, OWNER_A);
+    await seedUser(handle, OWNER_B);
+    // Inject the Kysely instance directly — TemplatesPgRepository's
+    // constructor uses Nest @Inject which we bypass in unit tests.
+    repo = new TemplatesPgRepository(handle.db);
+  });
+
+  afterEach(async () => {
+    await handle.close();
+  });
+
+  it('round-trips a template through create + findOneByOwner', async () => {
+    const created = await repo.create({
+      owner_id: OWNER_A,
+      title: 'NDA — short form',
+      description: 'Mutual NDA',
+      cover_color: '#FFFBEB',
+      field_layout: SAMPLE_FIELDS,
+    });
+
+    expect(created.id).toEqual(expect.any(String));
+    expect(created.uses_count).toBe(0);
+    expect(created.last_used_at).toBeNull();
+    expect(created.field_layout).toEqual(SAMPLE_FIELDS);
+
+    const reloaded = await repo.findOneByOwner(OWNER_A, created.id);
+    expect(reloaded).toEqual(created);
+  });
+
+  it('scopes findAllByOwner — never returns rows from other owners', async () => {
+    await repo.create({
+      owner_id: OWNER_A,
+      title: 'A1',
+      description: null,
+      cover_color: null,
+      field_layout: SAMPLE_FIELDS,
+    });
+    await repo.create({
+      owner_id: OWNER_B,
+      title: 'B1',
+      description: null,
+      cover_color: null,
+      field_layout: SAMPLE_FIELDS,
+    });
+    const aList = await repo.findAllByOwner(OWNER_A);
+    const bList = await repo.findAllByOwner(OWNER_B);
+    expect(aList.map((t) => t.title)).toEqual(['A1']);
+    expect(bList.map((t) => t.title)).toEqual(['B1']);
+  });
+
+  it('update applies a partial patch and bumps updated_at', async () => {
+    const t = await repo.create({
+      owner_id: OWNER_A,
+      title: 'Original',
+      description: 'foo',
+      cover_color: '#000000',
+      field_layout: SAMPLE_FIELDS,
+    });
+    const updated = await repo.update(OWNER_A, t.id, { title: 'Renamed' });
+    expect(updated?.title).toBe('Renamed');
+    expect(updated?.description).toBe('foo'); // untouched
+  });
+
+  it('update returns null when the template is owned by someone else', async () => {
+    const t = await repo.create({
+      owner_id: OWNER_A,
+      title: 'A',
+      description: null,
+      cover_color: null,
+      field_layout: SAMPLE_FIELDS,
+    });
+    const out = await repo.update(OWNER_B, t.id, { title: 'attacker' });
+    expect(out).toBeNull();
+  });
+
+  it('incrementUseCount bumps uses_count and sets last_used_at', async () => {
+    const t = await repo.create({
+      owner_id: OWNER_A,
+      title: 'Use me',
+      description: null,
+      cover_color: null,
+      field_layout: SAMPLE_FIELDS,
+    });
+    expect(t.uses_count).toBe(0);
+    expect(t.last_used_at).toBeNull();
+
+    const after = await repo.incrementUseCount(OWNER_A, t.id);
+    expect(after?.uses_count).toBe(1);
+    expect(after?.last_used_at).not.toBeNull();
+  });
+
+  it('delete returns true when row exists and false otherwise', async () => {
+    const t = await repo.create({
+      owner_id: OWNER_A,
+      title: 'D',
+      description: null,
+      cover_color: null,
+      field_layout: SAMPLE_FIELDS,
+    });
+    expect(await repo.delete(OWNER_A, t.id)).toBe(true);
+    expect(await repo.findOneByOwner(OWNER_A, t.id)).toBeNull();
+    expect(await repo.delete(OWNER_A, t.id)).toBe(false);
+  });
+});

--- a/apps/api/src/templates/templates.repository.pg.ts
+++ b/apps/api/src/templates/templates.repository.pg.ts
@@ -1,0 +1,119 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Kysely, Selectable } from 'kysely';
+import { sql } from 'kysely';
+import type { Template, TemplateField } from 'shared';
+import type { Database, TemplatesTable } from '../../db/schema';
+import { DB_TOKEN } from '../db/db.provider';
+import {
+  TemplatesRepository,
+  type CreateTemplateInput,
+  type UpdateTemplatePatch,
+} from './templates.repository';
+
+type Row = Selectable<TemplatesTable>;
+
+function toDomain(r: Row): Template {
+  return {
+    id: r.id,
+    owner_id: r.owner_id,
+    title: r.title,
+    description: r.description,
+    cover_color: r.cover_color,
+    field_layout: r.field_layout as ReadonlyArray<TemplateField>,
+    uses_count: r.uses_count,
+    last_used_at: r.last_used_at ? new Date(r.last_used_at).toISOString() : null,
+    created_at: new Date(r.created_at).toISOString(),
+    updated_at: new Date(r.updated_at).toISOString(),
+  };
+}
+
+@Injectable()
+export class TemplatesPgRepository extends TemplatesRepository {
+  constructor(@Inject(DB_TOKEN) private readonly db: Kysely<Database>) {
+    super();
+  }
+
+  async create(input: CreateTemplateInput): Promise<Template> {
+    const row = await this.db
+      .insertInto('templates')
+      .values({
+        owner_id: input.owner_id,
+        title: input.title,
+        description: input.description,
+        cover_color: input.cover_color,
+        field_layout: JSON.stringify(input.field_layout),
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return toDomain(row);
+  }
+
+  async findAllByOwner(owner_id: string): Promise<ReadonlyArray<Template>> {
+    const rows = await this.db
+      .selectFrom('templates')
+      .selectAll()
+      .where('owner_id', '=', owner_id)
+      // Recently-used first; never-used (last_used_at IS NULL) at the bottom.
+      .orderBy(sql`last_used_at desc nulls last`)
+      .orderBy('created_at', 'desc')
+      .execute();
+    return rows.map(toDomain);
+  }
+
+  async findOneByOwner(owner_id: string, id: string): Promise<Template | null> {
+    const row = await this.db
+      .selectFrom('templates')
+      .selectAll()
+      .where('owner_id', '=', owner_id)
+      .where('id', '=', id)
+      .executeTakeFirst();
+    return row ? toDomain(row) : null;
+  }
+
+  async update(owner_id: string, id: string, patch: UpdateTemplatePatch): Promise<Template | null> {
+    const update: Record<string, unknown> = { updated_at: new Date().toISOString() };
+    if (patch.title !== undefined) update['title'] = patch.title;
+    if (patch.description !== undefined) update['description'] = patch.description;
+    if (patch.cover_color !== undefined) update['cover_color'] = patch.cover_color;
+    if (patch.field_layout !== undefined) {
+      update['field_layout'] = JSON.stringify(patch.field_layout);
+    }
+    if (Object.keys(update).length === 1) {
+      // Only updated_at — caller passed an empty patch. Return current.
+      return this.findOneByOwner(owner_id, id);
+    }
+    const row = await this.db
+      .updateTable('templates')
+      .set(update)
+      .where('owner_id', '=', owner_id)
+      .where('id', '=', id)
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toDomain(row) : null;
+  }
+
+  async delete(owner_id: string, id: string): Promise<boolean> {
+    const res = await this.db
+      .deleteFrom('templates')
+      .where('owner_id', '=', owner_id)
+      .where('id', '=', id)
+      .executeTakeFirst();
+    return (res?.numDeletedRows ?? 0n) > 0n;
+  }
+
+  async incrementUseCount(owner_id: string, id: string): Promise<Template | null> {
+    const now = new Date().toISOString();
+    const row = await this.db
+      .updateTable('templates')
+      .set({
+        uses_count: sql`uses_count + 1` as never,
+        last_used_at: now,
+        updated_at: now,
+      })
+      .where('owner_id', '=', owner_id)
+      .where('id', '=', id)
+      .returningAll()
+      .executeTakeFirst();
+    return row ? toDomain(row) : null;
+  }
+}

--- a/apps/api/src/templates/templates.repository.ts
+++ b/apps/api/src/templates/templates.repository.ts
@@ -1,0 +1,42 @@
+import type { Template, TemplateField } from 'shared';
+
+export interface CreateTemplateInput {
+  readonly owner_id: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly cover_color: string | null;
+  readonly field_layout: ReadonlyArray<TemplateField>;
+}
+
+export interface UpdateTemplatePatch {
+  readonly title?: string;
+  readonly description?: string | null;
+  readonly cover_color?: string | null;
+  readonly field_layout?: ReadonlyArray<TemplateField>;
+}
+
+/**
+ * Port for template persistence. Every method takes `owner_id` as an
+ * explicit argument so the scoping rule is visible at every call site.
+ * The repository does not know about "the current user" — the caller
+ * (controller / service) enforces that.
+ */
+export abstract class TemplatesRepository {
+  abstract create(input: CreateTemplateInput): Promise<Template>;
+  abstract findAllByOwner(owner_id: string): Promise<ReadonlyArray<Template>>;
+  abstract findOneByOwner(owner_id: string, id: string): Promise<Template | null>;
+  abstract update(
+    owner_id: string,
+    id: string,
+    patch: UpdateTemplatePatch,
+  ): Promise<Template | null>;
+  abstract delete(owner_id: string, id: string): Promise<boolean>;
+  /**
+   * Bump `uses_count` and set `last_used_at = now()` for the given
+   * template. Returns null if the template doesn't exist or isn't owned
+   * by `owner_id`. Callers wire this from the upload-flow integration:
+   * when a sender clicks "Continue with this template", the upload flow
+   * POSTs `/templates/:id/use` to record the usage.
+   */
+  abstract incrementUseCount(owner_id: string, id: string): Promise<Template | null>;
+}

--- a/apps/api/src/templates/templates.service.ts
+++ b/apps/api/src/templates/templates.service.ts
@@ -1,0 +1,54 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import type { Template } from 'shared';
+import type { CreateTemplateDto } from './dto/create-template.dto';
+import type { UpdateTemplateDto } from './dto/update-template.dto';
+import { TemplatesRepository, type UpdateTemplatePatch } from './templates.repository';
+
+@Injectable()
+export class TemplatesService {
+  constructor(private readonly repo: TemplatesRepository) {}
+
+  list(owner_id: string): Promise<ReadonlyArray<Template>> {
+    return this.repo.findAllByOwner(owner_id);
+  }
+
+  async get(owner_id: string, id: string): Promise<Template> {
+    const t = await this.repo.findOneByOwner(owner_id, id);
+    if (!t) throw new NotFoundException('template_not_found');
+    return t;
+  }
+
+  create(owner_id: string, dto: CreateTemplateDto): Promise<Template> {
+    return this.repo.create({
+      owner_id,
+      title: dto.title,
+      description: dto.description ?? null,
+      cover_color: dto.cover_color ?? null,
+      field_layout: dto.field_layout,
+    });
+  }
+
+  async update(owner_id: string, id: string, dto: UpdateTemplateDto): Promise<Template> {
+    // Strip undefined keys (class-transformer may inject `field: undefined`
+    // for absent optional fields). Forwarding undefined would cause the PG
+    // adapter to update only `updated_at`. Follows the contacts.service
+    // pattern.
+    const patch = Object.fromEntries(
+      Object.entries(dto).filter(([, v]) => v !== undefined),
+    ) as UpdateTemplatePatch;
+    const t = await this.repo.update(owner_id, id, patch);
+    if (!t) throw new NotFoundException('template_not_found');
+    return t;
+  }
+
+  async remove(owner_id: string, id: string): Promise<void> {
+    const ok = await this.repo.delete(owner_id, id);
+    if (!ok) throw new NotFoundException('template_not_found');
+  }
+
+  async use(owner_id: string, id: string): Promise<Template> {
+    const t = await this.repo.incrementUseCount(owner_id, id);
+    if (!t) throw new NotFoundException('template_not_found');
+    return t;
+  }
+}

--- a/apps/api/test/in-memory-templates-repository.ts
+++ b/apps/api/test/in-memory-templates-repository.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import type { Template } from 'shared';
+import {
+  TemplatesRepository,
+  type CreateTemplateInput,
+  type UpdateTemplatePatch,
+} from '../src/templates/templates.repository';
+
+/**
+ * In-memory repo used by controller e2e. Mirrors the real adapter's
+ * contract — no DB dependency keeps the e2e fast and hermetic.
+ */
+export class InMemoryTemplatesRepository extends TemplatesRepository {
+  private readonly rows = new Map<string, Template>();
+
+  reset(): void {
+    this.rows.clear();
+  }
+
+  async create(input: CreateTemplateInput): Promise<Template> {
+    const now = new Date().toISOString();
+    const t: Template = {
+      id: randomUUID(),
+      owner_id: input.owner_id,
+      title: input.title,
+      description: input.description,
+      cover_color: input.cover_color,
+      field_layout: input.field_layout,
+      uses_count: 0,
+      last_used_at: null,
+      created_at: now,
+      updated_at: now,
+    };
+    this.rows.set(t.id, t);
+    return t;
+  }
+
+  async findAllByOwner(owner_id: string): Promise<ReadonlyArray<Template>> {
+    return [...this.rows.values()]
+      .filter((t) => t.owner_id === owner_id)
+      .sort((a, b) => {
+        // last_used_at desc nulls last, then created_at desc
+        if (a.last_used_at && b.last_used_at) {
+          return b.last_used_at.localeCompare(a.last_used_at);
+        }
+        if (a.last_used_at) return -1;
+        if (b.last_used_at) return 1;
+        return b.created_at.localeCompare(a.created_at);
+      });
+  }
+
+  async findOneByOwner(owner_id: string, id: string): Promise<Template | null> {
+    const t = this.rows.get(id);
+    return t && t.owner_id === owner_id ? t : null;
+  }
+
+  async update(owner_id: string, id: string, patch: UpdateTemplatePatch): Promise<Template | null> {
+    const existing = this.rows.get(id);
+    if (!existing || existing.owner_id !== owner_id) return null;
+    const next: Template = {
+      ...existing,
+      ...patch,
+      updated_at: new Date().toISOString(),
+    };
+    this.rows.set(id, next);
+    return next;
+  }
+
+  async delete(owner_id: string, id: string): Promise<boolean> {
+    const existing = this.rows.get(id);
+    if (!existing || existing.owner_id !== owner_id) return false;
+    this.rows.delete(id);
+    return true;
+  }
+
+  async incrementUseCount(owner_id: string, id: string): Promise<Template | null> {
+    const existing = this.rows.get(id);
+    if (!existing || existing.owner_id !== owner_id) return null;
+    const now = new Date().toISOString();
+    const next: Template = {
+      ...existing,
+      uses_count: existing.uses_count + 1,
+      last_used_at: now,
+      updated_at: now,
+    };
+    this.rows.set(id, next);
+    return next;
+  }
+}

--- a/apps/api/test/pg-mem-db.ts
+++ b/apps/api/test/pg-mem-db.ts
@@ -147,6 +147,26 @@ export function createPgMemDb(): PgMemHandle {
   const patched0007 = raw0007.replace(/comment on column[\s\S]*?;/g, '');
   mem.public.none(patched0007);
 
+  const migration0008Path = resolve(__dirname, '../db/migrations/0008_templates.sql');
+  const raw0008 = readFileSync(migration0008Path, 'utf8');
+  // Same `comment on column` strip as 0007. Also drop `nulls last` from
+  // the index DDL — pg-mem's parser chokes on it at create time. The
+  // runtime ORDER BY in templates.repository.pg.ts re-applies `nulls
+  // last` at query time, which pg-mem does support.
+  const patched0008 = raw0008
+    .replace(/comment on column[\s\S]*?;/g, '')
+    .replace(/\s+nulls\s+last/gi, '')
+    // Strip the updated_at trigger — the function `public.set_updated_at`
+    // is not present here (we already stripped it in 0001) and pg-mem's
+    // plpgsql coverage is limited. The repo overwrites updated_at
+    // explicitly anyway.
+    .replace(/alter table public\.templates enable row level security;/g, '')
+    .replace(
+      /create trigger templates_set_updated_at[\s\S]*?execute function public\.set_updated_at\(\);/g,
+      '',
+    );
+  mem.public.none(patched0008);
+
   const { Pool } = mem.adapters.createPg();
   const pool = new Pool();
   const db = new Kysely<Database>({ dialect: new PostgresDialect({ pool }) });

--- a/apps/api/test/templates.e2e-spec.ts
+++ b/apps/api/test/templates.e2e-spec.ts
@@ -1,0 +1,222 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { JWKS_RESOLVER } from '../src/auth/jwks.provider';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { APP_ENV } from '../src/config/config.module';
+import type { AppEnv } from '../src/config/env.schema';
+import { TemplatesRepository } from '../src/templates/templates.repository';
+import { InMemoryTemplatesRepository } from './in-memory-templates-repository';
+import { buildTestJwks } from './test-jwks';
+
+const TEST_ENV: AppEnv = {
+  NODE_ENV: 'test',
+  PORT: 0,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_JWT_AUDIENCE: 'authenticated',
+  CORS_ORIGIN: 'http://localhost:5173',
+  APP_PUBLIC_URL: 'http://localhost:5173',
+  DATABASE_URL: 'postgres://test',
+  STORAGE_BUCKET: 'envelopes',
+  TC_VERSION: '2026-04-24',
+  PRIVACY_VERSION: '2026-04-24',
+  EMAIL_PROVIDER: 'logging',
+  EMAIL_FROM_ADDRESS: 'no-reply@seald.test',
+  EMAIL_FROM_NAME: 'Seald',
+  PDF_SIGNING_PROVIDER: 'local',
+  PDF_SIGNING_TSA_URL: 'https://freetsa.org/tsr',
+  ENVELOPE_RETENTION_YEARS: 7,
+  WORKER_ENABLED: false,
+};
+
+const ISSUER = `${TEST_ENV.SUPABASE_URL}/auth/v1`;
+const USER_A = '11111111-1111-4111-8111-111111111111';
+const USER_B = '22222222-2222-4222-8222-222222222222';
+
+const SAMPLE_PAYLOAD = {
+  title: 'NDA — short form',
+  description: 'Mutual NDA',
+  cover_color: '#FFFBEB',
+  field_layout: [
+    { type: 'signature', pageRule: 'last', x: 60, y: 540 },
+    { type: 'date', pageRule: 'last', x: 320, y: 540 },
+    { type: 'initial', pageRule: 'all', x: 522, y: 50 },
+  ],
+};
+
+describe('Templates HTTP (e2e)', () => {
+  let app: INestApplication;
+  let templates: InMemoryTemplatesRepository;
+  let tk: Awaited<ReturnType<typeof buildTestJwks>>;
+  let tokenA: string;
+  let tokenB: string;
+
+  beforeAll(async () => {
+    tk = await buildTestJwks();
+    templates = new InMemoryTemplatesRepository();
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(APP_ENV)
+      .useValue(TEST_ENV)
+      .overrideProvider(JWKS_RESOLVER)
+      .useValue(tk.resolver)
+      .overrideProvider(TemplatesRepository)
+      .useValue(templates)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    tokenA = await tk.sign(
+      { sub: USER_A, email: 'a@example.com' },
+      { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE },
+    );
+    tokenB = await tk.sign(
+      { sub: USER_B, email: 'b@example.com' },
+      { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE },
+    );
+  });
+
+  beforeEach(() => {
+    templates.reset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('rejects unauthenticated requests', async () => {
+    await request(app.getHttpServer()).get('/templates').expect(401);
+  });
+
+  it('CRUD round-trip — create, list, get, update, delete', async () => {
+    // Create
+    const createRes = await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send(SAMPLE_PAYLOAD)
+      .expect(201);
+    const id = createRes.body.id as string;
+    expect(createRes.body).toMatchObject({
+      title: 'NDA — short form',
+      uses_count: 0,
+      last_used_at: null,
+    });
+    expect(createRes.body.field_layout).toHaveLength(3);
+
+    // List
+    const listRes = await request(app.getHttpServer())
+      .get('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(listRes.body).toHaveLength(1);
+    expect(listRes.body[0].id).toBe(id);
+
+    // Get
+    const getRes = await request(app.getHttpServer())
+      .get(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(getRes.body.title).toBe('NDA — short form');
+
+    // Update
+    const updateRes = await request(app.getHttpServer())
+      .patch(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({ title: 'Renamed NDA' })
+      .expect(200);
+    expect(updateRes.body.title).toBe('Renamed NDA');
+
+    // Delete
+    await request(app.getHttpServer())
+      .delete(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(204);
+    await request(app.getHttpServer())
+      .get(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(404);
+  });
+
+  it('scopes by owner — user B cannot see user A templates', async () => {
+    const created = await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send(SAMPLE_PAYLOAD)
+      .expect(201);
+    const id = created.body.id as string;
+
+    // User B cannot list it.
+    const listB = await request(app.getHttpServer())
+      .get('/templates')
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(200);
+    expect(listB.body).toEqual([]);
+
+    // User B cannot read or modify it.
+    await request(app.getHttpServer())
+      .get(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .expect(404);
+    await request(app.getHttpServer())
+      .patch(`/templates/${id}`)
+      .set('Authorization', `Bearer ${tokenB}`)
+      .send({ title: 'attacker' })
+      .expect(404);
+  });
+
+  it('POST /templates/:id/use bumps uses_count + last_used_at', async () => {
+    const created = await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send(SAMPLE_PAYLOAD)
+      .expect(201);
+    const id = created.body.id as string;
+
+    const useRes = await request(app.getHttpServer())
+      .post(`/templates/${id}/use`)
+      .set('Authorization', `Bearer ${tokenA}`)
+      .expect(200);
+    expect(useRes.body.uses_count).toBe(1);
+    expect(useRes.body.last_used_at).not.toBeNull();
+  });
+
+  it('rejects unknown pageRule literals at validation', async () => {
+    await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({
+        ...SAMPLE_PAYLOAD,
+        field_layout: [{ type: 'signature', pageRule: 'middle', x: 0, y: 0 }],
+      })
+      .expect(400);
+  });
+
+  it('accepts an integer pageRule (1-indexed page number)', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({
+        ...SAMPLE_PAYLOAD,
+        field_layout: [{ type: 'text', pageRule: 3, x: 100, y: 200, label: 'Note' }],
+      })
+      .expect(201);
+    expect(res.body.field_layout[0].pageRule).toBe(3);
+  });
+
+  it('rejects 0 or negative pageRule integers', async () => {
+    await request(app.getHttpServer())
+      .post('/templates')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .send({
+        ...SAMPLE_PAYLOAD,
+        field_layout: [{ type: 'signature', pageRule: 0, x: 0, y: 0 }],
+      })
+      .expect(400);
+  });
+});

--- a/apps/web/src/features/templates/templates.ts
+++ b/apps/web/src/features/templates/templates.ts
@@ -3,32 +3,22 @@
  *
  * Templates capture a saved field layout (initial / signature / date / text /
  * checkbox positions) on a representative document, so a sender can pick a
- * template, swap in a new PDF, and have the layout snap onto it. The seed
- * data here mirrors the design canvas mock at
- * `Design-Guide/project/templates-flow/TemplatesList.jsx` — it stays purely
- * client-side until a backend templates service lands.
- */
-
-export type TemplateFieldType = 'signature' | 'initial' | 'date' | 'text' | 'checkbox';
-
-/**
- * Where a saved field lands when the template is applied to a target document.
+ * template, swap in a new PDF, and have the layout snap onto it.
  *
- * - `'all'` — every page in the target.
- * - `'allButLast'` — every page except the final one (initials on body pages).
- * - `'first' | 'last'` — first / last page only.
- * - A page number (1-indexed) — exact page; ignored if the target is shorter.
+ * The canonical `TemplateField` / `TemplateFieldType` / `TemplatePageRule`
+ * types live in `packages/shared/src/templates.ts` so the API and SPA share
+ * one source of truth — re-exported here under the local
+ * `TemplateFieldLayout` alias for back-compat with existing call sites.
+ *
+ * The seed `TEMPLATES` array stays purely client-side; the upcoming
+ * backend (`feat/templates-api` PR) will replace it with a real query.
  */
-export type TemplatePageRule = 'all' | 'allButLast' | 'first' | 'last' | number;
 
-export interface TemplateFieldLayout {
-  readonly type: TemplateFieldType;
-  readonly pageRule: TemplatePageRule;
-  /** PDF point coordinate, top-left origin. */
-  readonly x: number;
-  readonly y: number;
-  readonly label?: string;
-}
+import type { TemplateField, TemplateFieldType } from 'shared';
+
+export type { TemplateFieldType, TemplatePageRule } from 'shared';
+/** Local alias kept for back-compat — same shape as the shared `TemplateField`. */
+export type TemplateFieldLayout = TemplateField;
 
 export interface TemplateSummary {
   readonly id: string;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,13 @@
 export * from './signer';
+export { TEMPLATE_FIELD_TYPES } from './templates';
+export type {
+  Template,
+  TemplateField,
+  TemplateFieldType,
+  TemplatePageRule,
+  CreateTemplateInput,
+  UpdateTemplateInput,
+} from './templates';
 export {
   ENVELOPE_STATUSES,
   DELIVERY_MODES,

--- a/packages/shared/src/templates.ts
+++ b/packages/shared/src/templates.ts
@@ -1,0 +1,77 @@
+/**
+ * Templates — shared domain types between the API and the SPA.
+ *
+ * A template captures a saved field layout (signature/initial/date/text/
+ * checkbox positions, addressed by a `pageRule` like `'all' | 'first' |
+ * 'last' | <page-num>`) so the sender can apply it to a new PDF and have
+ * the same fields snap onto every signing flow that reuses this layout.
+ *
+ * The HTTP contract uses these types directly. The DB schema in
+ * `apps/api/db/schema.ts` mirrors the `TemplateField` shape inside the
+ * `field_layout` jsonb column.
+ */
+
+export const TEMPLATE_FIELD_TYPES = [
+  'signature',
+  'initial',
+  'date',
+  'text',
+  'checkbox',
+] as const;
+export type TemplateFieldType = (typeof TEMPLATE_FIELD_TYPES)[number];
+
+/**
+ * Where a saved field lands when the template is applied to a target document.
+ *
+ *   `'all'`        — every page in the target.
+ *   `'allButLast'` — every page except the final one (initials on body pages).
+ *   `'first'`      — first page only.
+ *   `'last'`       — last page only.
+ *   `<page-num>`   — exact 1-indexed page; ignored if the target is shorter.
+ */
+export type TemplatePageRule =
+  | 'all'
+  | 'allButLast'
+  | 'first'
+  | 'last'
+  | number;
+
+export interface TemplateField {
+  readonly type: TemplateFieldType;
+  readonly pageRule: TemplatePageRule;
+  /** PDF point coordinate, top-left origin. */
+  readonly x: number;
+  readonly y: number;
+  readonly label?: string;
+}
+
+/**
+ * Full template record as returned by the API. ISO timestamps; `null` for
+ * a never-used template (`uses_count` is 0 and `last_used_at` is `null`).
+ */
+export interface Template {
+  readonly id: string;
+  readonly owner_id: string;
+  readonly title: string;
+  readonly description: string | null;
+  readonly cover_color: string | null;
+  readonly field_layout: ReadonlyArray<TemplateField>;
+  readonly uses_count: number;
+  readonly last_used_at: string | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+}
+
+export interface CreateTemplateInput {
+  readonly title: string;
+  readonly description?: string | null;
+  readonly cover_color?: string | null;
+  readonly field_layout: ReadonlyArray<TemplateField>;
+}
+
+export interface UpdateTemplateInput {
+  readonly title?: string;
+  readonly description?: string | null;
+  readonly cover_color?: string | null;
+  readonly field_layout?: ReadonlyArray<TemplateField>;
+}


### PR DESCRIPTION
## Summary

Adds the real backend for the Templates feature whose SPA shipped in PR #11. The list page currently runs on local-state mock data — this PR makes it possible to swap that for a query against the API.

## Schema (migration 0008)

`public.templates`: `id` pk, `owner_id` fk `auth.users(id)` on delete cascade, `title`, `description?`, `cover_color?` (`#RRGGBB`), `field_layout jsonb` (array of `TemplateField` records), `uses_count`, `last_used_at?`, `created_at`, `updated_at`. Indexes on `(owner_id)` and `(owner_id, last_used_at desc nulls last)`. RLS enabled with no policies (mirrors contacts/envelopes — backend connects as admin).

## Shared types

`packages/shared/src/templates.ts` exports `Template`, `TemplateField`, `TemplateFieldType`, `TemplatePageRule`. The web `templates.ts` now imports from `shared` instead of redefining — single source of truth between API and SPA.

## API surface

- `TemplatesRepository` (port) + `TemplatesPgRepository` (impl) + `InMemoryTemplatesRepository` (test fake).
- Service handles owner scoping + `NotFoundException` mapping.
- Controller routes:
  - `GET /templates` — list owner's, sorted by `last_used_at desc nulls last`
  - `GET /templates/:id` — single
  - `POST /templates` — create
  - `PATCH /templates/:id` — partial update
  - `DELETE /templates/:id` — delete
  - `POST /templates/:id/use` — bumps `uses_count` + `last_used_at`. Called by the upload flow when a sender clicks "Continue with this template".

## DTOs

class-validator with a custom `IsPageRule` decorator that accepts the four literals (`all` / `allButLast` / `first` / `last`) **OR** a positive integer (1-indexed page number).

## Tests added

- **6 unit** (`templates.repository.pg.spec.ts`) — CRUD via pg-mem, cross-owner isolation, `incrementUseCount`, partial-patch updates.
- **7 e2e** (`templates.e2e-spec.ts`) — auth required, full CRUD round-trip, cross-owner isolation, `/:id/use` bumps counters, `pageRule` validation (rejects unknown literals + 0/negative integers, accepts integer pageRule).

**Total: 388 unit (was 381) + 125 e2e (was 118) — all green.**

## pg-mem wiring

Migration 0008 strips `comment on column`, `nulls last` from the index DDL (pg-mem chokes; the runtime ORDER BY re-applies it), the trigger, and the RLS statement (same pattern as 0001's `set_updated_at` strip).

## Test plan
- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — green
- [x] `pnpm --filter api test` — 388 tests green
- [x] `pnpm --filter api test:e2e` — 125 tests green
- [x] `pnpm --filter web test` — 642 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)