### PR TITLE
feat(web): consume ?template= in /document/new

### DIFF
--- a/apps/web/src/features/templates/index.ts
+++ b/apps/web/src/features/templates/index.ts
@@ -1,4 +1,5 @@
 export type {
+  ResolvedField,
   TemplateFieldLayout,
   TemplateFieldType,
   TemplatePageRule,

--- a/apps/web/src/features/templates/templates.ts
+++ b/apps/web/src/features/templates/templates.ts
@@ -125,7 +125,7 @@ export function findTemplateById(id: string): TemplateSummary | undefined {
   return TEMPLATES.find((t) => t.id === id);
 }
 
-interface ResolvedField {
+export interface ResolvedField {
   readonly id: string;
   readonly page: number;
   readonly type: TemplateFieldType;

--- a/apps/web/src/pages/UploadPage/UploadPage.stories.tsx
+++ b/apps/web/src/pages/UploadPage/UploadPage.stories.tsx
@@ -50,3 +50,29 @@ export const CustomCopy: Story = {
     />
   ),
 };
+
+export const WithTemplateBanner: Story = {
+  name: 'With template banner',
+  render: () => (
+    <UploadPage
+      user={{ name: 'Jamie Okonkwo' }}
+      onFileSelected={() => {}}
+      templateBannerTitle="Mutual NDA — short form"
+      templateBannerTone="info"
+      onClearTemplate={() => {}}
+    />
+  ),
+};
+
+export const WithTemplateNotFound: Story = {
+  name: 'With template not-found banner',
+  render: () => (
+    <UploadPage
+      user={{ name: 'Jamie Okonkwo' }}
+      onFileSelected={() => {}}
+      templateBannerTitle="Template not found — starting empty"
+      templateBannerTone="warning"
+      onClearTemplate={() => {}}
+    />
+  ),
+};

--- a/apps/web/src/pages/UploadPage/UploadPage.styles.ts
+++ b/apps/web/src/pages/UploadPage/UploadPage.styles.ts
@@ -270,3 +270,49 @@ export const LoaderStepDot = styled.span<{ $active: boolean; $done: boolean }>`
   flex-shrink: 0;
   transition: background 200ms ease;
 `;
+
+/* ---- Template banner ---- */
+
+export const TemplateBanner = styled.div<{ $tone: 'info' | 'warning' }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[3]};
+  padding: ${({ theme }) => `${theme.space[3]} ${theme.space[4]}`};
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid
+    ${({ theme, $tone }) => ($tone === 'warning' ? theme.color.warn[500] : theme.color.indigo[200])};
+  background: ${({ theme, $tone }) =>
+    $tone === 'warning' ? theme.color.warn[50] : theme.color.indigo[50]};
+  color: ${({ theme, $tone }) =>
+    $tone === 'warning' ? theme.color.warn[700] : theme.color.indigo[800]};
+  font-size: ${({ theme }) => theme.font.size.bodySm};
+`;
+
+export const TemplateBannerText = styled.span`
+  flex: 1 1 auto;
+  min-width: 0;
+`;
+
+export const TemplateBannerStrong = styled.strong`
+  font-weight: 600;
+`;
+
+export const TemplateBannerClear = styled.button`
+  appearance: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+  &:hover {
+    opacity: 0.85;
+  }
+  &:focus-visible {
+    outline: 2px solid currentColor;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+`;

--- a/apps/web/src/pages/UploadPage/UploadPage.tsx
+++ b/apps/web/src/pages/UploadPage/UploadPage.tsx
@@ -28,6 +28,10 @@ import {
   Main,
   Shell,
   Subtitle,
+  TemplateBanner,
+  TemplateBannerClear,
+  TemplateBannerStrong,
+  TemplateBannerText,
 } from './UploadPage.styles';
 
 const DEFAULT_MAX_BYTES = 25 * 1024 * 1024;
@@ -142,6 +146,9 @@ export const UploadPage = forwardRef<HTMLDivElement, UploadPageProps>((props, re
     maxSizeBytes = DEFAULT_MAX_BYTES,
     status = 'idle',
     analyzingFileName,
+    templateBannerTitle,
+    templateBannerTone = 'info',
+    onClearTemplate,
     ...rest
   } = props;
 
@@ -280,6 +287,22 @@ export const UploadPage = forwardRef<HTMLDivElement, UploadPageProps>((props, re
               <Heading>{title}</Heading>
               <Subtitle>{subtitle}</Subtitle>
             </div>
+            {templateBannerTitle ? (
+              <TemplateBanner
+                $tone={templateBannerTone}
+                role={templateBannerTone === 'warning' ? 'alert' : 'status'}
+                aria-live="polite"
+              >
+                <TemplateBannerText>
+                  Using template: <TemplateBannerStrong>{templateBannerTitle}</TemplateBannerStrong>
+                </TemplateBannerText>
+                {onClearTemplate ? (
+                  <TemplateBannerClear type="button" onClick={onClearTemplate}>
+                    Clear template
+                  </TemplateBannerClear>
+                ) : null}
+              </TemplateBanner>
+            ) : null}
             {status === 'analyzing' ? (
               <AnalyzingLoader fileName={analyzingFileName} />
             ) : (

--- a/apps/web/src/pages/UploadPage/UploadPage.types.ts
+++ b/apps/web/src/pages/UploadPage/UploadPage.types.ts
@@ -61,4 +61,16 @@ export interface UploadPageProps extends Omit<HTMLAttributes<HTMLDivElement>, 'o
   readonly status?: UploadPageStatus | undefined;
   /** File name to display in the analyzing state. */
   readonly analyzingFileName?: string | undefined;
+
+  // Template integration -------------------------------------------------
+  /**
+   * Title of the template the sender chose on `/templates/:id/use`. When
+   * present, a "Using template: <title>" banner renders above the dropzone
+   * with a "Clear template" affordance that fires `onClearTemplate`.
+   */
+  readonly templateBannerTitle?: string | undefined;
+  /** Tone of the template banner. Defaults to `info`. */
+  readonly templateBannerTone?: 'info' | 'warning' | undefined;
+  /** Strips the `?template=` query arg + any pre-populated field state. */
+  readonly onClearTemplate?: (() => void) | undefined;
 }

--- a/apps/web/src/routes/UploadRoute.test.tsx
+++ b/apps/web/src/routes/UploadRoute.test.tsx
@@ -1,0 +1,159 @@
+import type { JSX } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation, useParams } from 'react-router-dom';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { UploadRoute } from './UploadRoute';
+import { TEMPLATES } from '../features/templates';
+
+// `UploadRoute` calls `usePdfDocument` to learn the page count of the
+// uploaded file. pdfjs is impractical to drive in jsdom, so the test
+// stub returns a deterministic page count instead.
+vi.mock('../lib/pdf', () => ({
+  usePdfDocument: (file: File | null) => ({
+    doc: null,
+    numPages: file ? 6 : 0,
+    loading: false,
+    error: null,
+  }),
+}));
+
+// `CreateSignatureRequestDialog` pulls in heavy chrome that isn't
+// relevant to the template-wiring assertions; replace it with a tiny
+// shim that exposes "Add Jamie" + "Apply" buttons so we can drive the
+// flow deterministically.
+vi.mock('../components/CreateSignatureRequestDialog', () => ({
+  CreateSignatureRequestDialog: (props: {
+    open: boolean;
+    signers: ReadonlyArray<{ readonly id: string; readonly name: string }>;
+    onAddFromContact: (c: {
+      readonly id: string;
+      readonly name: string;
+      readonly email: string;
+      readonly color: string;
+    }) => void;
+    onApply: () => void;
+  }): JSX.Element | null => {
+    if (!props.open) return null;
+    return (
+      <div data-testid="signer-dialog">
+        <button
+          type="button"
+          onClick={() =>
+            props.onAddFromContact({
+              id: 'c-jamie',
+              name: 'Jamie Okonkwo',
+              email: 'jamie@seald.app',
+              color: '#818CF8',
+            })
+          }
+        >
+          Add Jamie
+        </button>
+        <button type="button" onClick={() => props.onApply()}>
+          Apply
+        </button>
+        <span data-testid="signer-count">{props.signers.length}</span>
+      </div>
+    );
+  },
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="probe">{`${location.pathname}${location.search}`}</div>;
+}
+
+function DocumentProbe() {
+  const params = useParams();
+  return <div data-testid="doc-probe">{params.id ?? ''}</div>;
+}
+
+function renderAt(initialPath: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/document/new" element={<UploadRoute />} />
+        <Route path="/document/:id" element={<DocumentProbe />} />
+        <Route path="*" element={<LocationProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function makePdf(name: string): File {
+  const file = new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], name, {
+    type: 'application/pdf',
+  });
+  return file;
+}
+
+const SAMPLE = TEMPLATES[0]!;
+
+describe('UploadRoute (template integration)', () => {
+  let consoleInfoSpy: ReturnType<typeof vi.spyOn>;
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleInfoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('renders the "Using template" banner when ?template= matches a known id', () => {
+    renderAt(`/document/new?template=${encodeURIComponent(SAMPLE.id)}`);
+    const banner = screen.getByRole('status');
+    expect(banner).toHaveTextContent(/using template/i);
+    expect(banner).toHaveTextContent(SAMPLE.name);
+    expect(screen.getByRole('button', { name: /clear template/i })).toBeInTheDocument();
+  });
+
+  it('renders a warning banner + Clear when the template id is unknown', () => {
+    renderAt('/document/new?template=TPL-NOPE');
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent(/template not found/i);
+    expect(screen.getByRole('button', { name: /clear template/i })).toBeInTheDocument();
+  });
+
+  it('Clear template strips the query arg from the URL', async () => {
+    renderAt(`/document/new?template=${encodeURIComponent(SAMPLE.id)}`);
+    expect(screen.getByRole('button', { name: /clear template/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /clear template/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /clear template/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it('omits the banner when no template arg is present', () => {
+    renderAt('/document/new');
+    expect(screen.queryByText(/using template/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /clear template/i })).not.toBeInTheDocument();
+  });
+
+  it('pre-populates fields from the template on confirm and routes to the editor', async () => {
+    renderAt(`/document/new?template=${encodeURIComponent(SAMPLE.id)}`);
+    const input = screen.getByLabelText(/choose pdf file/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { files: [makePdf('contract.pdf')] } });
+
+    // The mocked `usePdfDocument` reports 6 pages — same as SAMPLE, so
+    // every layout entry resolves and no page-count warning fires.
+    const addBtn = await screen.findByRole('button', { name: /add jamie/i });
+    fireEvent.click(addBtn);
+    await waitFor(() => {
+      expect(screen.getByTestId('signer-count')).toHaveTextContent('1');
+    });
+    fireEvent.click(screen.getByRole('button', { name: /apply/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('doc-probe')).toBeInTheDocument();
+    });
+    // uses_count++ was logged (TODO until /templates/:id/use lands).
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`uses_count++ for ${SAMPLE.id}`),
+    );
+  });
+});

--- a/apps/web/src/routes/UploadRoute.tsx
+++ b/apps/web/src/routes/UploadRoute.tsx
@@ -1,26 +1,85 @@
-import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { UploadPage } from '../pages/UploadPage';
 import { CreateSignatureRequestDialog } from '../components/CreateSignatureRequestDialog';
 import type { AddSignerContact } from '../components/AddSignerDropdown/AddSignerDropdown.types';
+import type { PlacedFieldValue } from '../components/PlacedField/PlacedField.types';
+import type { FieldKind } from '../features/envelopes';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
 import { usePdfDocument } from '../lib/pdf';
 import { NAV_ITEMS } from '../layout/navItems';
+import {
+  findTemplateById,
+  resolveTemplateFields,
+  type ResolvedField,
+  type TemplateFieldType,
+  type TemplateSummary,
+} from '../features/templates';
+
+const TEMPLATE_QUERY_PARAM = 'template';
+
+// Template field kinds use the singular `initial`; `PlacedFieldValue.type`
+// uses the canonical `FieldKind` ('initials'). Keep the mapping local to the
+// upload route — templates are otherwise an isolated authoring concept.
+const TEMPLATE_TO_FIELD_KIND: Record<TemplateFieldType, FieldKind> = {
+  signature: 'signature',
+  initial: 'initials',
+  date: 'date',
+  text: 'text',
+  checkbox: 'checkbox',
+};
+
+function templateFieldsToPlaced(
+  resolved: ReadonlyArray<ResolvedField>,
+): ReadonlyArray<PlacedFieldValue> {
+  return resolved.map((rf) => ({
+    id: rf.id,
+    page: rf.page,
+    type: TEMPLATE_TO_FIELD_KIND[rf.type],
+    x: rf.x,
+    y: rf.y,
+    // No signer assigned yet — sender will pick signers in the dialog and
+    // assign them to fields once the editor opens. Empty array keeps the
+    // PlacedFieldValue contract.
+    signerIds: [],
+  }));
+}
 
 /**
  * Route wrapper around `UploadPage` that gates document creation on the
  * "add signers" dialog — the user must pick at least one signer before the
  * new document is created and routed to the editor.
+ *
+ * If the URL carries `?template=<id>` (set by `/templates/:id/use`'s
+ * "Continue with this template" CTA), the route looks up the template,
+ * shows a "Using template: <title>" banner, and after the uploaded PDF is
+ * parsed projects the template's field layout onto the new document via
+ * `resolveTemplateFields`. The pre-populated fields are written into the
+ * draft so the editor renders them immediately. "Clear template" strips
+ * the query arg and resets the pending field state.
  */
 export function UploadRoute() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const { user, contacts, createDocument, addContact, updateDocument } = useAppState();
   const { guest, exitGuestMode, signOut } = useAuth();
   const [pdfFile, setPdfFile] = useState<File | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const [selectedSigners, setSelectedSigners] = useState<ReadonlyArray<AddSignerContact>>([]);
   const { numPages } = usePdfDocument(pdfFile);
+
+  // Resolve the template from the query arg (local lookup today;
+  // TODO(api): swap for `GET /templates/:id` once the templates service
+  // ships). `templateMissing` is true when a `?template=` arg is present
+  // but doesn't match any known id — we surface a warning banner so the
+  // sender knows the editor will start empty.
+  const templateIdFromQuery = searchParams.get(TEMPLATE_QUERY_PARAM);
+  const template: TemplateSummary | null = useMemo(() => {
+    if (!templateIdFromQuery) return null;
+    return findTemplateById(templateIdFromQuery) ?? null;
+  }, [templateIdFromQuery]);
+  const templateMissing = templateIdFromQuery !== null && template === null;
 
   // Open the signer-picker once the PDF has been parsed (numPages > 0).
   // In the meantime UploadPage shows the "Analyzing" loader. If parsing
@@ -71,7 +130,32 @@ export function UploadRoute() {
 
   const handleConfirm = useCallback(() => {
     if (!pdfFile || selectedSigners.length === 0) return;
-    const id = createDocument(pdfFile, Math.max(1, numPages));
+    const resolvedPages = Math.max(1, numPages);
+    const id = createDocument(pdfFile, resolvedPages);
+
+    // Pre-populate fields when the sender came from a template. Pages
+    // that don't exist on the new PDF (e.g. layout asks for `page: 5`
+    // on a 3-page upload) are filtered out by `resolveTemplateFields`;
+    // we surface a console warning so the dropoff is observable.
+    let pendingFields: ReadonlyArray<PlacedFieldValue> = [];
+    if (template) {
+      const resolved = resolveTemplateFields(template.fields, resolvedPages);
+      pendingFields = templateFieldsToPlaced(resolved);
+      if (resolvedPages < template.pages) {
+        // Use console.warn so the SPA's debug build flags the gap. The
+        // banner already informs the user; this is for engineering.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[templates] Uploaded PDF has ${resolvedPages} pages but template "${template.name}" was authored on ${template.pages}; some fields may have been skipped.`,
+        );
+      }
+      // TODO(api): POST /templates/:id/use — bumps `uses_count` server-side
+      // once the templates service lands. Today we just log; the local
+      // `TEMPLATES` array is read-only seed data.
+      // eslint-disable-next-line no-console
+      console.info(`[templates] uses_count++ for ${template.id}`);
+    }
+
     updateDocument(id, {
       signers: selectedSigners.map((s) => ({
         id: s.id,
@@ -79,18 +163,32 @@ export function UploadRoute() {
         email: s.email,
         color: s.color,
       })),
+      ...(pendingFields.length > 0 ? { fields: pendingFields } : {}),
     });
     setDialogOpen(false);
     setPdfFile(null);
     setSelectedSigners([]);
     navigate(`/document/${id}`);
-  }, [pdfFile, selectedSigners, createDocument, updateDocument, numPages, navigate]);
+  }, [pdfFile, selectedSigners, createDocument, updateDocument, numPages, navigate, template]);
 
   const handleCancelDialog = useCallback(() => {
     setDialogOpen(false);
     setPdfFile(null);
     setSelectedSigners([]);
   }, []);
+
+  const handleClearTemplate = useCallback((): void => {
+    // Strip the `template` arg only — preserve any other query params the
+    // entry might one day carry. Also drop the in-progress file so the
+    // sender starts from a clean slate; otherwise the dialog would still
+    // be queued to open with no template-derived fields.
+    const next = new URLSearchParams(searchParams);
+    next.delete(TEMPLATE_QUERY_PARAM);
+    setSearchParams(next, { replace: true });
+    setPdfFile(null);
+    setDialogOpen(false);
+    setSelectedSigners([]);
+  }, [searchParams, setSearchParams]);
 
   const handleSelectNavItem = useCallback(
     (id: string): void => {
@@ -120,6 +218,13 @@ export function UploadRoute() {
 
   const navMode = !user && guest ? 'guest' : 'authed';
 
+  const bannerTitle = template
+    ? template.name
+    : templateMissing
+      ? 'Template not found — starting empty'
+      : undefined;
+  const bannerTone: 'info' | 'warning' = templateMissing ? 'warning' : 'info';
+
   return (
     <>
       <UploadPage
@@ -133,6 +238,9 @@ export function UploadRoute() {
         onSignOut={handleSignOut}
         status={pdfFile && !dialogOpen ? 'analyzing' : 'idle'}
         {...(pdfFile ? { analyzingFileName: pdfFile.name } : {})}
+        {...(bannerTitle ? { templateBannerTitle: bannerTitle } : {})}
+        templateBannerTone={bannerTone}
+        {...(template || templateMissing ? { onClearTemplate: handleClearTemplate } : {})}
       />
       <CreateSignatureRequestDialog
         open={dialogOpen}


### PR DESCRIPTION
## Summary
- `UploadRoute` now reads `?template=<id>`, looks up the template, and renders a "Using template: <title>" banner above the dropzone with a "Clear template" affordance.
- After the uploaded PDF is parsed, the route projects the template's saved field layout onto the new draft via `resolveTemplateFields` and writes the resolved `PlacedFieldValue[]` into the editor's draft state. Template `initial` is mapped to the canonical `FieldKind` `initials`.
- Unknown template ids surface a warning banner and start the editor empty; bumping `uses_count` is stubbed with `TODO(api): POST /templates/:id/use` (a `console.info` records the bump in the meantime). Fewer pages than the layout triggers a `console.warn` so the dropoff is observable.

## Test plan
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm --filter web test` — 647 tests pass, including the new `UploadRoute.test.tsx` covering banner render, Clear strips the query arg, unknown id renders the warning, and pre-population fires `uses_count++`.
- [ ] Storybook visual check of `L4/UploadPage` → `WithTemplateBanner` and `WithTemplateNotFound` stories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)