### PR TITLE
fix: templates nav in production + terraform tag perms

### DIFF
--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -66,6 +66,7 @@ export function AppShell() {
   return (
     <Shell>
       <NavBar
+        items={NAV_ITEMS}
         activeItemId={activeNavId}
         onSelectItem={handleSelectNavItem}
         user={user ?? undefined}

--- a/deploy/terraform/modules/sealing-kms/main.tf
+++ b/deploy/terraform/modules/sealing-kms/main.tf
@@ -57,11 +57,13 @@ resource "aws_kms_key" "sealing" {
   deletion_window_in_days  = 30
   is_enabled               = true
 
-  tags = merge(var.tags, {
+  # Tags require kms:TagResource on the deployer; gated behind a flag so
+  # a fresh apply with the minimum-perms CI role succeeds. See variables.tf.
+  tags = var.enable_resource_tags ? merge(var.tags, {
     Name        = "seald-pades-sealing-${var.environment}"
     Environment = var.environment
     Purpose     = "pades-signing"
-  })
+  }) : null
 }
 
 resource "aws_kms_alias" "sealing" {
@@ -103,10 +105,12 @@ resource "aws_iam_policy" "api_kms_sign" {
   description = "Allow the Seald API role to call kms:Sign + kms:GetPublicKey on the PAdES sealing key (${var.environment})."
   policy      = data.aws_iam_policy_document.api_kms_sign.json
 
-  tags = merge(var.tags, {
+  # Same gating as the KMS key tags above — IAM policies follow the same
+  # iam:TagPolicy permission boundary that smaller CI roles often lack.
+  tags = var.enable_resource_tags ? merge(var.tags, {
     Environment = var.environment
     Purpose     = "pades-signing"
-  })
+  }) : null
 }
 
 # Attaching the policy is conditional: var.api_role_name = "" means the

--- a/deploy/terraform/modules/sealing-kms/variables.tf
+++ b/deploy/terraform/modules/sealing-kms/variables.tf
@@ -20,7 +20,22 @@ variable "api_role_name" {
 }
 
 variable "tags" {
-  description = "Extra tags to merge onto every resource the module creates."
+  description = "Extra tags to merge onto every resource the module creates. Only applied when var.enable_resource_tags is true."
   type        = map(string)
   default     = {}
+}
+
+variable "enable_resource_tags" {
+  description = <<-EOT
+    Whether to set tags on the KMS key + alias resources.
+
+    Tagging a KMS key requires the caller's IAM principal to hold
+    `kms:TagResource` on the resource. Many CI roles only have the bare
+    `kms:CreateKey` / `kms:CreateAlias` minimum and would fail apply with
+    AccessDeniedException on first run. Default false so a fresh deploy
+    succeeds even with the minimum perms; flip to true once `kms:TagResource`
+    is granted to the deployer (and re-run apply to attach tags).
+  EOT
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
## Two post-merge fixes

### 1. Templates nav not showing in production

`NAV_ITEMS` in `apps/web/src/layout/navItems.ts` lists `Templates` as a top-level entry (added in PR #11), but `AppShell` was rendering `<NavBar />` without an `items` prop — so the NavBar fell back to its internal `DEFAULT_ITEMS` constant (only `documents` / `sign` / `signers`). Production therefore never showed the Templates tab.

**Fix**: pass `items={NAV_ITEMS}` from `AppShell` to `<NavBar>`. The existing `NavBar.test.tsx:9-18` test stays valid — it asserts the default behaviour when `items` is omitted (Storybook + standalone usage), which is unchanged.

### 2. Terraform `sealing-kms` apply failure on CI

The new `deploy/terraform.yml` apply step failed with:

```
AccessDeniedException: User .../seald-github-actions is not authorized
to perform: kms:TagResource because no identity-based policy allows
the kms:TagResource action
```

Tagging a KMS key (or IAM policy) needs the deployer to hold `kms:TagResource` / `iam:TagPolicy` on top of the bare `CreateKey` perms most CI roles ship with.

**Fix**: gate tags behind a new `var.enable_resource_tags` (default `false`). Fresh applies succeed with the minimum perms. Operator flips the flag once `kms:TagResource` is granted to the deployer, and re-runs apply to attach tags.

Pattern (both `aws_kms_key.sealing` and `aws_iam_policy.api_kms_sign`):

```hcl
tags = var.enable_resource_tags ? merge(var.tags, {...}) : null
```

`aws_kms_alias` doesn't accept tags, so no change there.

## Test plan

- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — green
- [x] `pnpm --filter web test` — 659 passing
- [x] `terraform fmt -check -recursive deploy/terraform/` — green
- [x] `terraform validate` (root + module) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)