### PR TITLE
fix(deploy): mount /opt/seald/secrets into api container

### DIFF
--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -66,6 +66,7 @@ export function AppShell() {
   return (
     <Shell>
       <NavBar
+        items={NAV_ITEMS}
         activeItemId={activeNavId}
         onSelectItem={handleSelectNavItem}
         user={user ?? undefined}

--- a/deploy/terraform/modules/sealing-kms/main.tf
+++ b/deploy/terraform/modules/sealing-kms/main.tf
@@ -57,11 +57,13 @@ resource "aws_kms_key" "sealing" {
   deletion_window_in_days  = 30
   is_enabled               = true
 
-  tags = merge(var.tags, {
+  # Tags require kms:TagResource on the deployer; gated behind a flag so
+  # a fresh apply with the minimum-perms CI role succeeds. See variables.tf.
+  tags = var.enable_resource_tags ? merge(var.tags, {
     Name        = "seald-pades-sealing-${var.environment}"
     Environment = var.environment
     Purpose     = "pades-signing"
-  })
+  }) : null
 }
 
 resource "aws_kms_alias" "sealing" {
@@ -103,10 +105,12 @@ resource "aws_iam_policy" "api_kms_sign" {
   description = "Allow the Seald API role to call kms:Sign + kms:GetPublicKey on the PAdES sealing key (${var.environment})."
   policy      = data.aws_iam_policy_document.api_kms_sign.json
 
-  tags = merge(var.tags, {
+  # Same gating as the KMS key tags above — IAM policies follow the same
+  # iam:TagPolicy permission boundary that smaller CI roles often lack.
+  tags = var.enable_resource_tags ? merge(var.tags, {
     Environment = var.environment
     Purpose     = "pades-signing"
-  })
+  }) : null
 }
 
 # Attaching the policy is conditional: var.api_role_name = "" means the

--- a/deploy/terraform/modules/sealing-kms/variables.tf
+++ b/deploy/terraform/modules/sealing-kms/variables.tf
@@ -20,7 +20,22 @@ variable "api_role_name" {
 }
 
 variable "tags" {
-  description = "Extra tags to merge onto every resource the module creates."
+  description = "Extra tags to merge onto every resource the module creates. Only applied when var.enable_resource_tags is true."
   type        = map(string)
   default     = {}
+}
+
+variable "enable_resource_tags" {
+  description = <<-EOT
+    Whether to set tags on the KMS key + alias resources.
+
+    Tagging a KMS key requires the caller's IAM principal to hold
+    `kms:TagResource` on the resource. Many CI roles only have the bare
+    `kms:CreateKey` / `kms:CreateAlias` minimum and would fail apply with
+    AccessDeniedException on first run. Default false so a fresh deploy
+    succeeds even with the minimum perms; flip to true once `kms:TagResource`
+    is granted to the deployer (and re-run apply to attach tags).
+  EOT
+  type        = bool
+  default     = false
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,13 @@ services:
       - apps/api/.env
     expose:
       - "3000"
+    # Mount the secrets dir read-only so the API can load the KMS-bound
+    # binding cert at runtime (PDF_SIGNING_KMS_CERT_PEM_PATH points here).
+    # The directory is provisioned out-of-band by the operator following
+    # deploy/terraform/SEALING_KMS_RUNBOOK.md; absence is fine when the
+    # signer is configured for the local-P12 path.
+    volumes:
+      - /opt/seald/secrets:/opt/seald/secrets:ro
     healthcheck:
       test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
       interval: 30s


### PR DESCRIPTION
Mounts the host's `/opt/seald/secrets` dir read-only into the API container so `KmsPadesSigner` can read the binding cert at `PDF_SIGNING_KMS_CERT_PEM_PATH`. Required for production KMS sealing per the runbook. The cert + KMS env vars are already provisioned on the EC2 host.