### PR TITLE
feat(ops): pull runtime secrets from AWS Secrets Manager at boot

### DIFF
--- a/.github/workflows/prod-restore.yml
+++ b/.github/workflows/prod-restore.yml
@@ -57,11 +57,26 @@ jobs:
             # we hand the API container static keys via env_file. The
             # `seald-pades-signer-prod` user has *only* kms:Sign +
             # kms:GetPublicKey on alias/seald-pades-sealing-prod.
+            #
+            # TODO: remove these AWS_* lines once `feat/terraform-api-iam-role`
+            # has applied — the EC2 instance profile + IAM role will let
+            # the SDK pick up creds via IMDSv2 automatically, including
+            # for the kms:Sign + secretsmanager:GetSecretValue calls.
             {
               printf '\nAWS_ACCESS_KEY_ID=%s\n' "$AWS_KMS_ACCESS_KEY_ID"
               printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$AWS_KMS_SECRET_ACCESS_KEY"
               printf 'AWS_REGION=us-east-2\n'
             } | sudo tee -a /opt/seald/apps/api/.env >/dev/null
+            # Point entrypoint.sh at the AWS Secrets Manager entry
+            # provisioned by deploy/terraform/secrets.tf. The container
+            # fetches this at boot and exports each key (DATABASE_URL,
+            # SUPABASE_SERVICE_ROLE_KEY, JWT_SECRET, RESEND_API_KEY, ...)
+            # as an env var — but only when not already set, so anything
+            # in the .env above still wins. Operator populates the
+            # secret values via `aws secretsmanager put-secret-value`
+            # (one-time, see PR #feat/aws-secrets-manager runbook).
+            printf 'SEALD_API_SECRET_ID=seald-api-prod\n' \
+              | sudo tee -a /opt/seald/apps/api/.env >/dev/null
             sudo chmod 0600 /opt/seald/apps/api/.env
             sudo wc -c /opt/seald/apps/api/.env
             # Sanity-check critical keys are present (no values printed).

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,14 @@ ENV NODE_ENV=production \
     NODE_OPTIONS="--enable-source-maps"
 # dumb-init for clean SIGTERM propagation → lets the worker's OnModuleDestroy
 # run before the container dies mid-seal. postgresql-client is the psql
-# binary used by scripts/migrate.sh at container boot.
+# binary used by scripts/migrate.sh at container boot. awscli + jq are
+# used by scripts/entrypoint.sh to fetch the runtime secret blob from
+# AWS Secrets Manager (when SEALD_API_SECRET_ID is set) and parse it
+# into per-key env vars before launching node. Debian's `awscli` is
+# v1.x — small enough for this single-call use case (~25 MB) and
+# notably lighter than bundling AWS CLI v2.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates dumb-init postgresql-client \
+ && apt-get install -y --no-install-recommends ca-certificates dumb-init postgresql-client awscli jq \
  && rm -rf /var/lib/apt/lists/* \
  && useradd --system --uid 10001 --home-dir /app --shell /usr/sbin/nologin seald
 WORKDIR /app

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,3 +1,43 @@
+# =====================================================================
+# Seald API runtime configuration
+#
+# Two-tier "fetch at boot" model (production):
+#
+#   tier 1 — bootstrap (this file / docker-compose env)
+#     Non-sensitive values that are safe to commit in CI logs:
+#       AWS_REGION, APP_PUBLIC_URL, CORS_ORIGIN, CADDY_DOMAIN,
+#       WEB_DOMAIN, EMAIL_PROVIDER, EMAIL_FROM_ADDRESS,
+#       EMAIL_FROM_NAME, NODE_ENV, PORT, STORAGE_BUCKET,
+#       TC_VERSION, PRIVACY_VERSION, ENVELOPE_RETENTION_YEARS,
+#       WORKER_ENABLED, PDF_SIGNING_PROVIDER,
+#       PDF_SIGNING_KMS_KEY_ID, PDF_SIGNING_KMS_REGION,
+#       PDF_SIGNING_KMS_CERT_PEM_PATH, PDF_SIGNING_TSA_URLS,
+#       SUPABASE_URL, SUPABASE_JWT_AUDIENCE.
+#     Plus the pointer to tier 2:
+#       SEALD_API_SECRET_ID
+#
+#   tier 2 — fetched from AWS Secrets Manager at container boot
+#     Sensitive values (apps/api/scripts/entrypoint.sh fetches JSON
+#     blob, jq-parses, exports any key that's currently unset):
+#       DATABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_ANON_KEY,
+#       JWT_SECRET, SIGNER_SESSION_SECRET, CRON_SECRET,
+#       METRICS_SECRET, RESEND_API_KEY, SMTP_PASS,
+#       PDF_SIGNING_LOCAL_P12_PASS, PDF_SIGNING_SSLCOM_CLIENT_SECRET,
+#       AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY (legacy — going
+#       away once the EC2 instance role is wired up).
+#
+# This .env.example documents BOTH tiers as defaults — if
+# SEALD_API_SECRET_ID is unset (e.g. local dev) the values here are
+# used; in prod, tier-2 keys come from Secrets Manager and these
+# entries are placeholders.
+# =====================================================================
+
+# AWS Secrets Manager — pointer to the runtime secret blob. When set,
+# entrypoint.sh fetches the JSON object and exports each key as an env
+# var ONLY if that key is currently unset (so values in this file still
+# win for explicit overrides). Leave blank for local dev.
+SEALD_API_SECRET_ID=
+
 # Runtime
 NODE_ENV=development
 PORT=3000

--- a/apps/api/scripts/entrypoint.sh
+++ b/apps/api/scripts/entrypoint.sh
@@ -1,10 +1,98 @@
 #!/usr/bin/env sh
-# Container entrypoint — runs migrations, then starts the API.
+# Container entrypoint — fetches runtime secrets from AWS Secrets
+# Manager (when SEALD_API_SECRET_ID is set), runs migrations, then
+# starts the API.
 #
 # Opt-out via SKIP_MIGRATIONS=1 if you want to run the container without
 # touching the DB (e.g. for a horizontally-scaled deploy where one node
 # owns migrations and the rest just start).
+#
+# Secrets-Manager fetch model
+# ---------------------------
+# When SEALD_API_SECRET_ID is set, we fetch a JSON blob from AWS Secrets
+# Manager and export each key as an environment variable — but ONLY
+# when the variable is currently unset. That way:
+#
+#   - prod (set SEALD_API_SECRET_ID, leave sensitive vars unset in
+#     env_file): values come from Secrets Manager.
+#   - local dev (unset SEALD_API_SECRET_ID, fill apps/api/.env): values
+#     come from env_file, fetch is skipped entirely.
+#   - hybrid debugging (set both): env_file wins, Secrets Manager fills
+#     gaps. Useful when overriding a single key for a hotfix without
+#     touching the secret.
+#
+# The fetch uses the AWS CLI v1 (`apt-get install awscli`) which is
+# already present in the runtime image. Auth comes from either
+# (a) the EC2 instance role exposed via IMDSv2, or (b) static
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY env vars (legacy path,
+# removed once the parallel feat/terraform-api-iam-role lands).
 set -eu
+
+fetch_secrets_from_aws() {
+  if [ -z "${SEALD_API_SECRET_ID:-}" ]; then
+    echo "entrypoint: SEALD_API_SECRET_ID unset — skipping Secrets Manager fetch (using env_file values only)."
+    return 0
+  fi
+
+  region="${AWS_REGION:-us-east-1}"
+  echo "entrypoint: fetching runtime secrets from AWS Secrets Manager (id=$SEALD_API_SECRET_ID region=$region)..."
+
+  if ! command -v aws >/dev/null 2>&1; then
+    echo "entrypoint: ERROR — aws CLI not found in image. Rebuild Dockerfile with awscli installed." >&2
+    return 1
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "entrypoint: ERROR — jq not found in image. Rebuild Dockerfile with jq installed." >&2
+    return 1
+  fi
+
+  # `aws secretsmanager get-secret-value` returns the JSON blob in
+  # `SecretString`. Pull it out as raw text, then have jq emit one
+  # snippet per key that conditionally assigns + exports it.
+  secret_json=$(aws secretsmanager get-secret-value \
+    --secret-id "$SEALD_API_SECRET_ID" \
+    --region "$region" \
+    --query SecretString \
+    --output text 2>/dev/null) || {
+      echo "entrypoint: ERROR — aws secretsmanager get-secret-value failed (check IAM perms / secret id / region)." >&2
+      return 1
+    }
+
+  if [ -z "$secret_json" ] || [ "$secret_json" = "null" ]; then
+    echo "entrypoint: WARN — Secrets Manager returned an empty blob; nothing to export."
+    return 0
+  fi
+
+  # Validate it's an object before iterating; if an operator put a
+  # raw string in there by mistake, we'd loop over its characters.
+  shape=$(printf '%s' "$secret_json" | jq -r 'type' 2>/dev/null || echo "invalid")
+  if [ "$shape" != "object" ]; then
+    echo "entrypoint: ERROR — Secrets Manager value is not a JSON object (got $shape). Refusing to export." >&2
+    return 1
+  fi
+
+  # Emit one shell snippet per key that:
+  #   1. Skips if the key is already set (env_file / pre-set vars take
+  #      precedence — local overrides always win).
+  #   2. Otherwise eval-assigns the value (jq's `@sh` filter renders a
+  #      POSIX-shell-safe single-quoted literal, pasted directly after
+  #      the `=`, NOT inside outer quotes — newlines, spaces, and
+  #      embedded single-quotes round-trip cleanly).
+  #   3. Exports the variable.
+  exports=$(printf '%s' "$secret_json" | jq -r '
+    to_entries
+    | .[]
+    | "if [ -z \"${" + .key + "+x}\" ]; then " + .key + "=" + (.value | tostring | @sh) + "; export " + .key + "; fi"
+  ')
+
+  total=$(printf '%s' "$secret_json" | jq -r 'length')
+  echo "entrypoint: $total key(s) in Secrets Manager blob (env_file / pre-set vars take precedence)."
+
+  # shellcheck disable=SC2086
+  eval "$exports"
+}
+
+fetch_secrets_from_aws
 
 if [ "${SKIP_MIGRATIONS:-0}" != "1" ]; then
   /app/apps/api/scripts/migrate.sh

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -72,3 +72,14 @@ output "api_iam_role_name" {
   description = "Name of the IAM role attached to the API EC2 instance profile. The sealing-kms module attaches its kms:Sign policy to this role by default."
   value       = aws_iam_role.api.name
 }
+
+# --------------------------------------------------------------------
+# Secrets Manager — exposed so the deploy workflow can echo the ARN
+# into logs (without ever printing the secret material) and so the
+# parallel IAM-role PR can sanity-check the ARN it's attaching to.
+# --------------------------------------------------------------------
+
+output "api_secret_arn" {
+  description = "ARN of the Seald API runtime Secrets Manager entry. Fed into SEALD_API_SECRET_ID at container boot (entrypoint.sh fetches + parses + exports as env vars)."
+  value       = aws_secretsmanager_secret.api.arn
+}

--- a/deploy/terraform/secrets.tf
+++ b/deploy/terraform/secrets.tf
@@ -1,0 +1,97 @@
+# --------------------------------------------------------------------
+# AWS Secrets Manager — runtime config for the API container.
+#
+# The Seald API used to read every secret (DATABASE_URL, Supabase
+# service role, JWT/CRON/METRICS secrets, RESEND_API_KEY, ...) from a
+# host-side `apps/api/.env` file written by `.github/workflows/prod-restore.yml`
+# from the GH `PROD_API_ENV` secret. That works but couples secret
+# rotation to a redeploy, leaks values into the GH Actions log surface,
+# and forces every host that holds the .env file to be in scope for
+# secret hygiene.
+#
+# This file provisions a single Secrets Manager entry that the
+# container fetches at boot via `aws secretsmanager get-secret-value`,
+# parses with `jq`, and exports as env vars (only when the variable is
+# unset — i.e. local docker-compose env_file values still win). See
+# apps/api/scripts/entrypoint.sh for the fetch+parse logic.
+#
+# IMPORTANT: this Terraform ships the *resource* and *least-privilege
+# IAM policy* — it does NOT ship secret values. The initial
+# `aws_secretsmanager_secret_version` is a JSON `{}` placeholder.
+# After `terraform apply`, an operator populates real values out-of-band:
+#
+#   aws secretsmanager put-secret-value \
+#     --secret-id seald-api-prod \
+#     --region us-east-1 \
+#     --secret-string file://secrets.json
+#
+# (`secrets.json` should be a flat object: { "DATABASE_URL": "...",
+# "SUPABASE_SERVICE_ROLE_KEY": "...", ... }. See the PR description
+# for the canonical key list.)
+#
+# Region: us-east-1 (same region as the EC2 instance that fetches it).
+# The KMS sealing key intentionally stays in us-east-2; that's a
+# separate, lower-frequency call path and does not benefit from
+# co-locating with this secret.
+# --------------------------------------------------------------------
+
+resource "aws_secretsmanager_secret" "api" {
+  name                    = "seald-api-${var.environment_slug}"
+  description             = "Seald API runtime secrets (DATABASE_URL, Supabase keys, JWT/CRON/METRICS secrets, RESEND_API_KEY). Fetched at container boot by apps/api/scripts/entrypoint.sh."
+  recovery_window_in_days = 7
+
+  tags = local.common_tags
+}
+
+# Placeholder — real values are written out-of-band via
+# `aws secretsmanager put-secret-value` (see header comment). We ship
+# an empty JSON object so the secret has a parseable initial version
+# and `terraform plan` is stable across re-runs.
+resource "aws_secretsmanager_secret_version" "api_placeholder" {
+  secret_id     = aws_secretsmanager_secret.api.id
+  secret_string = jsonencode({})
+
+  # Operator updates supersede this placeholder. Don't fight them on
+  # subsequent applies — Terraform should manage the resource shape,
+  # not the secret material.
+  lifecycle {
+    ignore_changes = [secret_string, version_stages]
+  }
+}
+
+# Least-privilege policy: GetSecretValue + DescribeSecret on this one
+# secret ARN. No wildcards. No write permissions (rotation is a manual
+# operator action; if/when we wire automated rotation we can attach a
+# separate policy then).
+resource "aws_iam_policy" "api_secret_read" {
+  name        = "${var.project}-api-secret-read-${var.environment_slug}"
+  description = "Allow the Seald API runtime to fetch its Secrets Manager entry (read-only, single ARN)."
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ReadSealdApiSecret"
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+        ]
+        Resource = aws_secretsmanager_secret.api.arn
+      },
+    ]
+  })
+
+  tags = local.common_tags
+}
+
+# Attach to the API instance role (provisioned by the parallel
+# `feat/terraform-api-iam-role` PR as `aws_iam_role.api`). MERGE
+# ORDERING: that PR must land + apply before this one, otherwise
+# `terraform validate` will flag this reference as undefined. The PR
+# description for `feat/aws-secrets-manager` calls this dependency out
+# explicitly.
+resource "aws_iam_role_policy_attachment" "api_secret_read" {
+  role       = aws_iam_role.api.name
+  policy_arn = aws_iam_policy.api_secret_read.arn
+}

--- a/deploy/terraform/variables.tf
+++ b/deploy/terraform/variables.tf
@@ -52,6 +52,18 @@ variable "tags" {
   default     = {}
 }
 
+variable "environment_slug" {
+  description = <<-EOT
+    Deploy environment slug, used as a suffix on environment-scoped
+    resource names (e.g. the AWS Secrets Manager entry becomes
+    `seald-api-$${environment_slug}`). Defaults to `prod` because the
+    hosted EC2 deploy is currently prod-only; staging/review envs
+    should override via tfvars.
+  EOT
+  type        = string
+  default     = "prod"
+}
+
 # ---------- Sealing KMS (PAdES signing) ----------
 
 variable "enable_kms_sealing" {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
       # migrations. Single-node deploys leave this unset.
       SKIP_MIGRATIONS: "${SKIP_MIGRATIONS:-0}"
       NODE_OPTIONS: --enable-source-maps
+      # AWS Secrets Manager secret id (or ARN). When set, entrypoint.sh
+      # fetches the JSON blob at boot, parses it with jq, and exports
+      # each key as an env var ONLY if currently unset — so anything in
+      # env_file below still wins. Leave empty for local dev.
+      SEALD_API_SECRET_ID: "${SEALD_API_SECRET_ID:-}"
     env_file:
       - apps/api/.env
     expose:


### PR DESCRIPTION
## Summary

Move sensitive runtime config (DATABASE_URL, Supabase service-role key, JWT/CRON/METRICS secrets, RESEND_API_KEY, ...) out of the host-side `apps/api/.env` file (currently written from the GH `PROD_API_ENV` secret) and into AWS Secrets Manager. The container fetches the JSON blob at boot via `aws secretsmanager get-secret-value`, parses with `jq`, and exports each key as an env var — but only when not already set, so docker-compose `env_file` / pre-set vars always win.

- Rotation no longer requires a redeploy (operator runs `aws secretsmanager put-secret-value` and bounces the container).
- Sensitive values stop flowing through GH Actions log surfaces.
- Local dev is unchanged: leave `SEALD_API_SECRET_ID` unset and the fetch is skipped.

## Why

Today every secret travels through the GH `PROD_API_ENV` secret → SSH → host file → docker `env_file`. That couples rotation to CI access, scopes any host that holds the file, and forces `prod-restore.yml` to ship 26 env keys whenever any one of them changes. Centralizing on Secrets Manager (us-east-1, same region as EC2) gives us least-privilege IAM scoping, audit logging, and out-of-band rotation.

## Merge ordering

**Depends on `feat/terraform-api-iam-role` landing + applying first.** That PR provisions `aws_iam_role.api` (the EC2 instance role + instance profile). Without it:
- `terraform validate` on this branch fails with `Reference to undeclared resource ... aws_iam_role.api` (the only validate failure — `terraform fmt -recursive` is clean).
- The container can call Secrets Manager only via the legacy static-key path (kept in `prod-restore.yml` with a `TODO` for cleanup).

After `feat/terraform-api-iam-role` applies:
1. Apply this PR's terraform → secret + IAM policy + role attachment land.
2. Operator populates the secret values (runbook below).
3. Re-run `prod-restore.yml`; entrypoint fetches at boot.
4. Follow-up PR removes the static AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY block from `prod-restore.yml`.

## Operator runbook (one-time after apply)

After `terraform apply` succeeds (which creates the empty `seald-api-prod` secret), populate the values:

```sh
# Build a flat JSON object with the sensitive keys.
cat > /tmp/seald-api-prod.json <<'JSON'
{
  "DATABASE_URL": "postgres://...",
  "SUPABASE_URL": "https://....supabase.co",
  "SUPABASE_SERVICE_ROLE_KEY": "eyJ...",
  "SUPABASE_ANON_KEY": "eyJ...",
  "JWT_SECRET": "<hex-64>",
  "SIGNER_SESSION_SECRET": "<hex-64>",
  "CRON_SECRET": "<hex-64>",
  "METRICS_SECRET": "<hex-64>",
  "RESEND_API_KEY": "re_...",
  "PDF_SIGNING_LOCAL_P12_PASS": "...",
  "AWS_ACCESS_KEY_ID": "AKIA...",
  "AWS_SECRET_ACCESS_KEY": "..."
}
JSON

aws secretsmanager put-secret-value \
  --secret-id seald-api-prod \
  --region us-east-1 \
  --secret-string file:///tmp/seald-api-prod.json

shred -u /tmp/seald-api-prod.json   # do NOT leave on disk
```

Non-sensitive keys (`AWS_REGION`, `APP_PUBLIC_URL`, `CORS_ORIGIN`, `CADDY_DOMAIN`, `WEB_DOMAIN`, `PDF_SIGNING_PROVIDER`, `PDF_SIGNING_KMS_KEY_ID`, `PDF_SIGNING_KMS_REGION`, `PDF_SIGNING_KMS_CERT_PEM_PATH`, `PDF_SIGNING_TSA_URLS`, `EMAIL_*`, `STORAGE_BUCKET`, `TC_VERSION`, `PRIVACY_VERSION`, `ENVELOPE_RETENTION_YEARS`, `WORKER_ENABLED`, `NODE_ENV`, `PORT`) stay in the bootstrap `apps/api/.env` (sourced from `PROD_API_ENV`).

## Files changed

- `deploy/terraform/secrets.tf` — new; provisions `aws_secretsmanager_secret` + placeholder version + least-privilege IAM policy + attachment to `aws_iam_role.api`.
- `deploy/terraform/variables.tf` — `environment_slug` (default `prod`).
- `deploy/terraform/outputs.tf` — `api_secret_arn` output.
- `apps/api/scripts/entrypoint.sh` — fetch + parse + conditional export logic (`@sh`-quoted, env-precedence-preserving, validates JSON shape).
- `Dockerfile` — install `awscli` (Debian v1, ~25 MB) + `jq` in runtime stage.
- `docker-compose.yml` — pass `SEALD_API_SECRET_ID` from host env.
- `apps/api/.env.example` — header documenting the two-tier model + `SEALD_API_SECRET_ID` placeholder.
- `.github/workflows/prod-restore.yml` — append `SEALD_API_SECRET_ID=seald-api-prod` to the .env it writes; `TODO` to remove static AWS_* keys post-IAM-role-apply.

## Test plan

- [x] `terraform fmt -recursive` — clean.
- [x] `terraform validate` — only the documented `aws_iam_role.api` reference fails (cross-PR dep with `feat/terraform-api-iam-role`); resolves once that lands.
- [x] `pnpm --filter api lint` — clean.
- [x] `pnpm --filter web lint` — clean (after building `shared`).
- [x] `pnpm --filter api typecheck` — clean.
- [x] `pnpm --filter web typecheck` — clean.
- [x] `pnpm --filter api test` — 38 suites / 393 tests pass.
- [x] entrypoint smoke test (mocked aws output): correctly preserves pre-set env values, round-trips newlines + spaces + embedded single quotes, rejects non-object Secrets Manager payloads.
- [ ] After IAM-role PR applies + operator populates the secret, restart the container and confirm `entrypoint: N key(s) in Secrets Manager blob` appears in logs and the API boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)