### PR TITLE
feat(workflows): seed AWS Secrets Manager from PROD_API_ENV

### DIFF
--- a/.github/workflows/seed-secrets-manager.yml
+++ b/.github/workflows/seed-secrets-manager.yml
@@ -1,0 +1,141 @@
+name: Seed AWS Secrets Manager (seald-api-prod)
+
+# One-shot operator workflow. Reads the merged production env blob from
+# the `PROD_API_ENV` GitHub Actions secret, filters it to the known
+# tier-2 (sensitive) keys documented in apps/api/.env.example, packs the
+# result as a JSON object, and writes it as a new version on the
+# `seald-api-prod` AWS Secrets Manager entry (us-east-2).
+#
+# Tier-2 keys come from apps/api/.env.example header — kept in sync
+# with the entrypoint.sh fetcher. If the runtime adds a new sensitive
+# env var, append it to TIER2_KEYS below AND to .env.example so the
+# entrypoint picks it up at boot.
+#
+# IAM:
+# - The `seald-github-actions` user has `secretsmanager:PutSecretValue`
+#   + `GetSecretValue` + `DescribeSecret` on `seald-api-prod*` via the
+#   `seald-tf-iam-and-secrets` managed policy (granted alongside the
+#   terraform IAM role provisioning permissions, 2026-04-30).
+#
+# Idempotent: re-running just adds a new AWSCURRENT version. Old
+# versions stay until rotation policy retires them.
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: seed-secrets-manager
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
+jobs:
+  seed:
+    name: Pack PROD_API_ENV into Secrets Manager
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Configure AWS CLI
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity --query 'Arn' --output text
+
+      - name: Pack and put secret value
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          PROD_API_ENV: ${{ secrets.PROD_API_ENV }}
+          # The secret lives in us-east-2 (same region as the EC2 host
+          # and the sealing KMS key). The runner's default region from
+          # secrets.AWS_REGION may not match, so we pin it here.
+          SECRET_REGION: us-east-2
+          SECRET_ID: seald-api-prod
+        run: |
+          set -euo pipefail
+
+          # Tier-2 keys from apps/api/.env.example header. Anything NOT
+          # in this list stays in the host-side .env (or is read from
+          # the entrypoint shell). Mirror this list with the comment in
+          # apps/api/scripts/entrypoint.sh.
+          TIER2_KEYS=(
+            DATABASE_URL
+            SUPABASE_SERVICE_ROLE_KEY
+            SUPABASE_ANON_KEY
+            JWT_SECRET
+            SIGNER_SESSION_SECRET
+            CRON_SECRET
+            METRICS_SECRET
+            RESEND_API_KEY
+            SMTP_PASS
+            PDF_SIGNING_LOCAL_P12_PASS
+            PDF_SIGNING_SSLCOM_CLIENT_SECRET
+          )
+
+          # Write PROD_API_ENV to a tmp file (runner-local, mode 0600).
+          # We deliberately do NOT echo any values to logs — only keys.
+          umask 0177
+          tmpenv=$(mktemp)
+          tmpjson=$(mktemp)
+          trap 'rm -f "$tmpenv" "$tmpjson"' EXIT
+          printf '%s' "$PROD_API_ENV" > "$tmpenv"
+
+          # Build the JSON object via jq. Approach: read the env file
+          # line-by-line, strip comments / blank lines, split on the
+          # first '=' so values may contain '='. Skip keys that aren't
+          # in TIER2_KEYS. Emit one '\0'-delimited "K=V" record per
+          # selected line so jq can reassemble safely (env values may
+          # contain newlines / quotes / etc.).
+          {
+            while IFS= read -r line || [ -n "$line" ]; do
+              case "$line" in
+                ''|\#*) continue ;;
+              esac
+              key="${line%%=*}"
+              # Skip lines that aren't KEY=VALUE
+              if [ "$key" = "$line" ]; then continue ;fi
+              for k in "${TIER2_KEYS[@]}"; do
+                if [ "$key" = "$k" ]; then
+                  printf '%s\0' "$line"
+                  break
+                fi
+              done
+            done < "$tmpenv"
+          } | jq -Rs '
+              split("\u0000")
+              | map(select(length > 0))
+              | map(
+                  capture("^(?<k>[^=]+)=(?<v>[\\s\\S]*)$")
+                  | { (.k): .v }
+                )
+              | add // {}
+            ' > "$tmpjson"
+
+          # Sanity: count keys, list KEY NAMES ONLY (never values).
+          count=$(jq 'length' "$tmpjson")
+          echo "Packed $count tier-2 keys."
+          jq -r 'keys[]' "$tmpjson" | sed 's/^/  - /'
+          if [ "$count" -eq 0 ]; then
+            echo "ERROR: zero tier-2 keys matched. Check that PROD_API_ENV contains the expected names." >&2
+            exit 1
+          fi
+
+          # Push the new version. Secrets Manager rejects payloads >
+          # 65,536 bytes — fail loudly if we've outgrown that.
+          size=$(wc -c < "$tmpjson")
+          echo "JSON payload size: ${size} bytes"
+          if [ "$size" -gt 60000 ]; then
+            echo "WARN: payload nearing the 65,536-byte Secrets Manager limit." >&2
+          fi
+
+          aws secretsmanager put-secret-value \
+            --region "$SECRET_REGION" \
+            --secret-id "$SECRET_ID" \
+            --secret-string "file://$tmpjson" \
+            --query '[ARN,VersionId,VersionStages]' \
+            --output json
+
+          echo "Done."

--- a/cspell.json
+++ b/cspell.json
@@ -450,7 +450,9 @@
     "Nakamura",
     "IMDS",
     "AKID",
-    "noout"
+    "noout",
+    "tmpenv",
+    "esac"
   ],
   "ignoreRegExpList": [
     "Base64",


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/seed-secrets-manager.yml` — a manual operator workflow that filters `PROD_API_ENV` (GH secret) down to tier-2 sensitive keys and writes them as a JSON object to `seald-api-prod` (us-east-2 Secrets Manager).
- Tier-2 key list mirrors the header comment in `apps/api/.env.example` and the boot-time fetcher in `apps/api/scripts/entrypoint.sh`. All three must be kept in sync.
- Idempotent: re-runs just bump the AWSCURRENT version.

## Why
PR #27 stood up the empty `seald-api-prod` Secrets Manager entry (`{}` placeholder) plus the entrypoint.sh logic that reads it at boot. Terraform applied cleanly today (run 25179504544). This workflow is the seam that populates the secret from the existing `PROD_API_ENV` GH secret.

## Test plan
- [ ] Merge → `gh workflow run seed-secrets-manager.yml --ref main`
- [ ] Verify `aws secretsmanager describe-secret --secret-id seald-api-prod --region us-east-2` returns the new VersionId
- [ ] Verify `aws secretsmanager get-secret-value --secret-id seald-api-prod --region us-east-2 --version-stage AWSCURRENT --query SecretString --output text | jq 'keys'` lists the expected tier-2 keys
- [ ] On the EC2 host, `sudo docker compose restart api` and confirm via `docker compose logs api | grep "Secrets Manager"` that entrypoint.sh fetched the blob without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)