### PR TITLE
fix: remove unsupported certifications + correct eIDAS framing (T-13, T-23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ apps/web/e2e/.bdd/
 # MCP-driven Playwright + visual-diff scratch (logs, screenshots, traces)
 .playwright-mcp/
 .visual-diff/
+# Internal audit reports (gap analyses, inventories) — never published
+.audit/

--- a/apps/api/src/email/templates/completed/body.html
+++ b/apps/api/src/email/templates/completed/body.html
@@ -119,7 +119,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/email/templates/declined_to_sender/body.html
+++ b/apps/api/src/email/templates/declined_to_sender/body.html
@@ -218,7 +218,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/email/templates/expired_to_sender/body.html
+++ b/apps/api/src/email/templates/expired_to_sender/body.html
@@ -125,7 +125,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/email/templates/expired_to_signer/body.html
+++ b/apps/api/src/email/templates/expired_to_signer/body.html
@@ -189,7 +189,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/email/templates/invite/body.html
+++ b/apps/api/src/email/templates/invite/body.html
@@ -203,8 +203,9 @@
           <path d="M7 10 L9 12 L13 8" />
         </svg>
         <div>
-          Seald uses eIDAS-qualified signatures with a full audit trail. Your signature is legally
-          binding and independently verifiable.
+          Seald uses eIDAS-aligned advanced electronic signatures (PAdES-LT) with a full audit
+          trail. Your signature is independently verifiable and, in most jurisdictions, legally
+          equivalent to a handwritten signature.
         </div>
       </div>
       <div class="verify">
@@ -213,7 +214,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       You received this because <a href="mailto:{{sender_email}}">{{sender_email}}</a> invited you
       to sign a document.<br />
       <a href="{{public_url}}">{{public_url}}</a>

--- a/apps/api/src/email/templates/reminder/body.html
+++ b/apps/api/src/email/templates/reminder/body.html
@@ -169,7 +169,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       Automated reminder for a pending signature request.<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>

--- a/apps/api/src/email/templates/withdrawn_after_sign/body.html
+++ b/apps/api/src/email/templates/withdrawn_after_sign/body.html
@@ -153,7 +153,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/email/templates/withdrawn_to_signer/body.html
+++ b/apps/api/src/email/templates/withdrawn_to_signer/body.html
@@ -195,7 +195,7 @@
       </div>
     </div>
     <div class="foot">
-      <strong style="color: #1f2937">Seald</strong> · End-to-end encrypted document signing<br />
+      <strong style="color: #1f2937">Seald</strong> · Encrypted in transit and at rest<br />
       <a href="{{public_url}}">{{public_url}}</a>
     </div>
   </div>

--- a/apps/api/src/sealing/audit-pdf.tsx
+++ b/apps/api/src/sealing/audit-pdf.tsx
@@ -1347,8 +1347,8 @@ function TrustBar({ ctx }: { ctx: RenderCtx }): React.ReactElement {
     },
     {
       label: 'Timestamp',
-      value: 'eIDAS qualified',
-      sub: 'Issued by a trusted service provider.',
+      value: 'RFC 3161 trusted',
+      sub: 'Issued by an external timestamp authority.',
       icon: ICONS.clockCircle,
     },
     {
@@ -1426,7 +1426,7 @@ const TERMS_PAGE_3: ReadonlyArray<TermDef> = [
   {
     num: '07',
     name: 'Digital signature',
-    body: 'An additional layer of authenticity which adds a certificate to the signed document. A certificate indicates an embedded eIDAS qualified timestamp. Validity is revoked if the document is tampered with after signing.',
+    body: 'An additional layer of authenticity which adds a certificate to the signed document. A certificate indicates an embedded RFC 3161 trusted timestamp. Validity is revoked if the document is tampered with after signing.',
   },
   {
     num: '08',
@@ -1480,8 +1480,8 @@ const TERMS_PAGE_4: ReadonlyArray<TermDef> = [
   },
   {
     num: '12',
-    name: 'Qualified timestamp',
-    body: 'A technological instrument that validates a document existed before a certain date and has not been modified since. Issued by an eIDAS trusted service provider.',
+    name: 'Trusted timestamp (RFC 3161)',
+    body: 'A technological instrument that validates a document existed before a certain date and has not been modified since. Issued by an external timestamp authority over the RFC 3161 protocol.',
   },
   {
     num: '13',
@@ -1581,7 +1581,7 @@ function buildDatagridCells(ctx: RenderCtx): ReadonlyArray<DataCellInfo> {
       label: 'Digital signature',
       value:
         ctx.sealedSha256 !== null
-          ? 'Enabled · eIDAS qualified timestamp'
+          ? 'Enabled · RFC 3161 trusted timestamp'
           : 'Not applicable (unsealed)',
       check: ctx.sealedSha256 !== null,
     },

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -33,7 +33,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
       <div class="container">
         <div class="hero-grid">
           <div class="hero-copy">
-            <span class="eyebrow"><span class="dot"></span>New · eIDAS qualified timestamps</span>
+            <span class="eyebrow"><span class="dot"></span>New · RFC 3161 trusted timestamps</span>
             <h1>
               <span class="word-stack">Put your</span>
               <span class="word-stack"><span class="name">name<svg class="underline" viewBox="0 0 220 28" preserveAspectRatio="none"><path d="M4 18 C 40 6, 90 22, 140 14 C 180 7, 200 18, 216 12" /></svg></span></span>
@@ -50,9 +50,9 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <div class="hero-trust">
               <span><span class="check">✓</span> No credit card</span>
               <span class="sep"></span>
-              <span><span class="check">✓</span> 3 free signs / month</span>
+              <span><span class="check">✓</span> Free during beta</span>
               <span class="sep"></span>
-              <span><span class="check">✓</span> SOC 2 Type II</span>
+              <span><span class="check">✓</span> Tamper-evident audit trail</span>
             </div>
           </div>
 
@@ -133,20 +133,20 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
       <div class="container">
         <div class="trust-grid">
           <div class="trust-cell">
-            <div class="trust-num"><span data-count="42000">0</span><span class="unit">+</span></div>
-            <div class="trust-label">Documents sealed every day</div>
+            <div class="trust-num">AES-256</div>
+            <div class="trust-label">Encryption at rest</div>
           </div>
           <div class="trust-cell">
-            <div class="trust-num"><span data-count="98">0</span><span class="unit">%</span></div>
-            <div class="trust-label">Of signature requests completed within 24 hours</div>
+            <div class="trust-num">TLS 1.3</div>
+            <div class="trust-label">Encryption in transit</div>
           </div>
           <div class="trust-cell">
-            <div class="trust-num"><span data-count="3">0</span><span class="unit">×</span></div>
-            <div class="trust-label">Faster than the email-and-print round-trip</div>
+            <div class="trust-num">RFC 3161</div>
+            <div class="trust-label">Trusted timestamping</div>
           </div>
           <div class="trust-cell">
-            <div class="trust-num"><span data-count="100">0</span><span class="unit">%</span></div>
-            <div class="trust-label">eIDAS-qualified, AES-256 encrypted at rest</div>
+            <div class="trust-num">PAdES-LT</div>
+            <div class="trust-label">EU long-term signature profile</div>
           </div>
         </div>
       </div>
@@ -258,36 +258,13 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
               <svg viewBox="0 0 24 24"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z"/><polyline points="9 12 11 14 15 10"/></svg>
             </div>
             <h3>Court-ready audit trail</h3>
-            <p>Every signature carries a SHA-256 fingerprint, an IP, and a UTC timestamp issued by an eIDAS trusted service provider — not us.</p>
+            <p>Every signature carries a SHA-256 fingerprint, an IP, and a UTC timestamp issued by an external RFC 3161 timestamp authority — not us.</p>
             <div class="feat-art">
               <div class="audit-line"><span class="ts">21:20:50</span><span class="ev">VIEWED</span><span class="ip">4.28.55.97</span></div>
               <div class="audit-line"><span class="ts">21:21:08</span><span class="ev">CONSENTED</span><span class="ip">4.28.55.97</span></div>
               <div class="audit-line"><span class="ts">21:21:22</span><span class="ev">SIGNED</span><span class="ip">4.28.55.97</span></div>
               <div class="audit-line"><span class="ts">21:21:23</span><span class="ev">HASH</span><span class="ip">a2e35e…f675ee</span></div>
-              <div class="audit-line"><span class="ts">21:21:25</span><span class="ev">SEALED</span><span class="ip">eIDAS qts</span></div>
-            </div>
-          </div>
-
-          <div class="feat feat-mobile reveal">
-            <div class="feat-ico">
-              <svg viewBox="0 0 24 24"><rect x="5" y="2" width="14" height="20" rx="2"/><line x1="12" y1="18" x2="12" y2="18"/></svg>
-            </div>
-            <h3>Sign from your phone</h3>
-            <p>The Seald iOS app lives in your pocket — sign, send, and check status with Face ID.</p>
-            <div class="feat-art">
-              <div class="phone">
-                <div class="phone-screen">
-                  <div class="pl" style="width:50%"></div>
-                  <div class="pl"></div>
-                  <div class="pl"></div>
-                  <div class="pl" style="width:80%"></div>
-                  <div class="pl"></div>
-                  <div class="pl" style="width:60%"></div>
-                  <div class="phone-sig">
-                    <svg viewBox="0 0 100 20" preserveAspectRatio="none"><path d="M4 14 C 14 2, 24 18, 34 8 C 44 0, 54 16, 64 8 C 74 0, 84 14, 96 6"/></svg>
-                  </div>
-                </div>
-              </div>
+              <div class="audit-line"><span class="ts">21:21:25</span><span class="ev">SEALED</span><span class="ip">RFC 3161</span></div>
             </div>
           </div>
 
@@ -295,8 +272,8 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <div class="feat-ico">
               <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>
             </div>
-            <h3>Encrypted end-to-end</h3>
-            <p>AES-256 at rest, TLS 1.3 in transit. We hold the keys to your account; you hold the keys to your documents.</p>
+            <h3>Encrypted in transit and at rest</h3>
+            <p>TLS 1.3 in transit and AES-256 at rest. Sealed PDFs carry their own SHA-256 fingerprint so tampering shows up on inspection — independent of Seald.</p>
             <div class="feat-art">
               <div class="lock">
                 <svg viewBox="0 0 24 24"><rect x="3" y="11" width="18" height="11" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/><circle cx="12" cy="16" r="1.2" fill="currentColor"/></svg>
@@ -378,8 +355,8 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
               <li>
                 <span class="num">03</span>
                 <span class="text">
-                  <strong>eIDAS qualified timestamp</strong>
-                  <span>Issued by a third-party trusted service provider — not by Seald. Independently verifiable.</span>
+                  <strong>RFC 3161 trusted timestamp</strong>
+                  <span>Issued by an external timestamping authority — not by Seald. Independently verifiable.</span>
                 </span>
               </li>
             </ul>
@@ -417,7 +394,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
     <section class="section cta" id="cta">
       <div class="container">
         <h2 class="cta-display">Put your <span class="cta-name">name</span> to it.</h2>
-        <p>Start free. Three signs a month, forever, no credit card. Upgrade only when your contracts do.</p>
+        <p>Start with a free account during the beta. No credit card required.</p>
         <div class="hero-cta">
           <a href="/signup" class="btn btn-primary btn-lg">Start free <span class="btn-arrow">→</span></a>
           <a href="#" class="btn btn-secondary btn-lg">Talk to sales</a>
@@ -446,7 +423,6 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <li><a href="#features">Request signatures</a></li>
             <li><a href="#features">Templates</a></li>
             <li><a href="#audit">Audit trail</a></li>
-            <li><a href="#features">Mobile app</a></li>
           </ul>
         </div>
         <div class="foot-col">
@@ -462,7 +438,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
           <h4>Trust</h4>
           <ul>
             <li><a href="#">Security</a></li>
-            <li><a href="#">eIDAS compliance</a></li>
+            <li><a href="#">Standards</a></li>
             <li><a href="/verify">Verify a document</a></li>
             <li><a href="#">Privacy</a></li>
             <li><a href="#">Terms</a></li>
@@ -471,7 +447,6 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
       </div>
       <div class="foot-bottom">
         <span>© 2026 Seald, Inc. — Put your name to it.</span>
-        <span>SOC 2 Type II · ISO 27001 · eIDAS</span>
       </div>
     </div>
   </footer>

--- a/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.test.tsx
+++ b/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.test.tsx
@@ -28,11 +28,14 @@ describe('AuthBrandPanel', () => {
     expect(screen.getByText(/General Counsel, Northwind/)).toBeInTheDocument();
   });
 
-  it('renders the trust footer line', () => {
+  it('renders the trust footer line with verifiable capability claims', () => {
     renderWithTheme(<AuthBrandPanel />);
-    expect(screen.getByText(/SOC 2 Type II/)).toBeInTheDocument();
-    expect(screen.getByText(/eIDAS-qualified/)).toBeInTheDocument();
-    expect(screen.getByText(/256-bit AES/)).toBeInTheDocument();
+    // Avoid certification claims (SOC 2 / ISO) and "eIDAS-qualified" framing
+    // until those certifications exist or a QTSP is wired (T-13 in
+    // .audit/LEGAL_GAPS.md). Assert the technical-capability replacements.
+    expect(screen.getByText(/PAdES-LT/)).toBeInTheDocument();
+    expect(screen.getByText(/RFC 3161 timestamps/)).toBeInTheDocument();
+    expect(screen.getByText(/AES-256 at rest/)).toBeInTheDocument();
   });
 
   it('has no axe violations', async () => {

--- a/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.tsx
+++ b/apps/web/src/components/AuthBrandPanel/AuthBrandPanel.tsx
@@ -79,7 +79,7 @@ export const AuthBrandPanel = forwardRef<HTMLElement, AuthBrandPanelProps>((prop
 
       <TrustFooter>
         <ShieldCheck size={14} aria-hidden="true" />
-        <span>SOC 2 Type II &middot; eIDAS-qualified &middot; 256-bit AES</span>
+        <span>PAdES-LT &middot; RFC 3161 timestamps &middot; AES-256 at rest</span>
       </TrustFooter>
     </Content>
   </Root>

--- a/apps/web/src/components/DownloadMenu/DownloadMenu.stories.tsx
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.stories.tsx
@@ -17,7 +17,7 @@ const sealed = (available: boolean): DownloadMenuItem => ({
   icon: FileCheck2,
   title: 'Sealed PDF',
   description: 'Final signed document with all fields filled and certificate page.',
-  meta: available ? '5 pages · 312 KB · eIDAS QES' : 'Available once all signers complete',
+  meta: available ? '5 pages · 312 KB · PAdES-LT' : 'Available once all signers complete',
   available,
   recommended: available,
   primaryLabel: 'sealed PDF',

--- a/apps/web/src/components/DownloadMenu/DownloadMenu.test.tsx
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.test.tsx
@@ -19,7 +19,7 @@ const items: ReadonlyArray<DownloadMenuItem> = [
     icon: FileCheck2,
     title: 'Sealed PDF',
     description: 'Final signed document.',
-    meta: '5 pages · 312 KB · eIDAS QES',
+    meta: '5 pages · 312 KB · PAdES-LT',
     available: true,
     recommended: true,
     primaryLabel: 'sealed PDF',

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
@@ -751,8 +751,8 @@ export function EnvelopeDetailPage() {
               <div>
                 <strong>Audit trail</strong>
                 <Muted>
-                  This envelope uses eIDAS-qualified signatures. Every event is timestamped and
-                  cryptographically sealed.
+                  This envelope is sealed with an eIDAS-aligned advanced electronic signature
+                  (PAdES-LT). Every event is timestamped and cryptographically anchored.
                 </Muted>
                 {/* The audit PDF is produced by the sealing job, so it
                     only exists once the envelope is completed. Hide the

--- a/apps/web/src/pages/VerifyPage/VerifyPage.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.tsx
@@ -537,7 +537,7 @@ function VerifyContent({ data }: VerifyContentProps) {
                 {formatDateTime(data.envelope.completed_at ?? data.envelope.sent_at)}
               </FactVal>
               <Tag $tone={sealed ? 'success' : 'neutral'}>
-                {sealed ? 'eIDAS QTSP' : data.envelope.status}
+                {sealed ? 'PAdES-LT' : data.envelope.status}
               </Tag>
             </Fact>
 
@@ -636,13 +636,13 @@ function VerifyContent({ data }: VerifyContentProps) {
           </FooterLeft>
           <FooterRight>
             <span>
-              <Check aria-hidden /> SOC 2 Type II
+              <Check aria-hidden /> AES-256 at rest
             </span>
             <span>
-              <Check aria-hidden /> eIDAS qualified
+              <Check aria-hidden /> RFC 3161 timestamps
             </span>
             <span>
-              <Check aria-hidden /> ISO 27001
+              <Check aria-hidden /> PAdES-LT seal
             </span>
           </FooterRight>
         </Footer>


### PR DESCRIPTION
## Summary

Replaces unsupported / inaccurate legal claims across the landing
page, transactional emails, web app, and audit PDF with verifiable
technical-capability statements.

**Drivers (FTC §5 / consumer-protection exposure):**
- "SOC 2 Type II", "ISO 27001" — no audit underway, no firm engaged
- "eIDAS-qualified" / "eIDAS QTSP" / "qualified timestamp" — Seald
  produces PAdES-LT (AdES), not QES; current TSA pool (freetsa.org)
  is **not** a qualified trust service provider
- "End-to-end encrypted" — sealing keys live in AWS KMS, not on
  user devices; service is encrypted in transit + at rest
- "iOS app" / "Mobile app" — no app exists
- "3 free signs / month, forever" — pricing not finalized

**Replacement framing:**
- Landing: "PAdES-LT", "RFC 3161 trusted timestamps", "AES-256 at
  rest", "TLS 1.3 in transit", "Tamper-evident audit trail"
- Auth brand panel + envelope/verify pages + audit PDF:
  `PAdES-LT · RFC 3161 timestamps · AES-256 at rest`
- Invite email: "eIDAS-aligned advanced electronic signatures
  (PAdES-LT)" + softened binding language
- All email signoffs: `Encrypted in transit and at rest`
- Removed: iOS app card + footer link, fake animated counters
  (42000+ docs, 98% csat, 100% audit-trail), forever-free CTA promise

Tracks **T-13** (landing legal accuracy) and **T-23** (invite-email
legal framing) from `.audit/LEGAL_GAPS.md` (internal — gitignored).

## Files changed (17)
- 1 landing (`apps/landing/src/pages/index.astro`)
- 8 emails (`apps/api/src/email/templates/*/body.html`)
- 4 web surfaces (`AuthBrandPanel`, `DownloadMenu`,
  `EnvelopeDetailPage`, `VerifyPage`)
- 1 audit PDF generator (`apps/api/src/sealing/audit-pdf.tsx`)
- Tests/fixtures updated to assert new strings (rule 4.6 preserved
  — accessible queries)
- `.gitignore` adds `.audit/`

## Test plan
- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint` ✓ (0 warnings, max-warnings=0)
- [x] `pnpm --filter web vitest run` ✓ — **765/765 passing**
- [x] `pnpm --filter api test` ✓ — **393/393 passing**
- [x] `pnpm --filter landing build` ✓ — astro build success
- [ ] CI green on `main`-merged equivalent (will be validated post-merge)

## Notes
- This is the first of three planned PRs from the
  `saas-legal-advisor` skill audit; the remaining two cover
  (a) drafting Track-1 legal documents (Terms, Privacy, DPA,
  cookie policy, etc.) and (b) wiring those documents + DSAR
  intake + cookie banner into the SPA.
- Design-Guide HTML mockups (`Design-Guide/project/**`) still
  contain legacy claims; left as-is since they are reference
  material, not shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)