### PR TITLE
feat(landing): cookie banner + GPC + DSAR intake (T-09, T-12)

### DIFF
--- a/apps/landing/src/components/CookieBanner.astro
+++ b/apps/landing/src/components/CookieBanner.astro
@@ -1,0 +1,418 @@
+---
+// CookieBanner.astro — first-party cookie/consent banner.
+//
+// Why this exists (T-09 in .audit/LEGAL_GAPS.md):
+//   - ePrivacy Art. 5(3) / EDPB 03/2022: prior, informed consent for any
+//     non-essential storage or read on the user's device.
+//   - CCPA/CPRA §7025: honor the Global Privacy Control (GPC) signal as a
+//     valid opt-out of sale/share for non-essential categories.
+//   - EDPB dark-patterns guidance: Reject must be as prominent and as easy
+//     as Accept; no pre-ticked toggles.
+//
+// Behavior:
+//   1. First visit (no `seald_consent_v1` cookie): the banner is shown.
+//      If `navigator.globalPrivacyControl === true`, every non-essential
+//      category is auto-rejected and the user is informed (see GPC notice).
+//   2. The user can: Accept all / Reject all / Customize (per-purpose).
+//      All three buttons are visually equal — no dark patterns.
+//   3. After a choice the banner hides and a `seald_consent_v1` cookie is
+//      set (max 365 days per EDPB). A `seald:consent-changed` CustomEvent
+//      fires so other scripts (e.g. analytics injectors) can react.
+//   4. The footer's "Manage cookie preferences" link calls
+//      `window.sealdConsent.show()` to reopen the banner pre-populated
+//      with the saved choices.
+//
+// The banner is server-rendered hidden (display: none) and only revealed
+// by the inline script after the cookie is read. This avoids a flash of
+// banner on returning visitors.
+---
+<aside
+  id="cookie-banner"
+  class="cookie-banner"
+  role="dialog"
+  aria-modal="false"
+  aria-labelledby="cookie-banner-title"
+  aria-describedby="cookie-banner-desc"
+  hidden
+>
+  <div class="cookie-card">
+    <h2 id="cookie-banner-title">Cookies &amp; your privacy</h2>
+    <p id="cookie-banner-desc">
+      We use first-party cookies and similar storage to keep you signed in (essential)
+      and, with your consent, to measure how the site is used so we can improve it.
+      We do not sell or share your personal information for cross-context behavioral
+      advertising. You can change your choice any time from the footer.
+    </p>
+
+    <p id="cookie-gpc-notice" class="cookie-gpc" hidden>
+      Your browser is sending a Global Privacy Control (GPC) signal. We've pre-set
+      every non-essential category to <strong>off</strong> in line with the GPC
+      regulations (CCPA §7025). You can still opt back in below.
+    </p>
+
+    <fieldset class="cookie-categories" hidden>
+      <legend class="sr-only">Cookie categories</legend>
+
+      <label class="cookie-row">
+        <input type="checkbox" name="essential" checked disabled />
+        <span class="cookie-row-text">
+          <span class="cookie-row-title">Essential</span>
+          <span class="cookie-row-desc">
+            Required for the site to work — sign-in, security, and load balancing.
+            Always on; cannot be disabled.
+          </span>
+        </span>
+      </label>
+
+      <label class="cookie-row">
+        <input type="checkbox" name="analytics" />
+        <span class="cookie-row-text">
+          <span class="cookie-row-title">Analytics</span>
+          <span class="cookie-row-desc">
+            Privacy-friendly, aggregated page-view counts (Cloudflare Web Analytics).
+            No cross-site tracking, no IP storage.
+          </span>
+        </span>
+      </label>
+
+      <label class="cookie-row">
+        <input type="checkbox" name="marketing" />
+        <span class="cookie-row-text">
+          <span class="cookie-row-title">Marketing</span>
+          <span class="cookie-row-desc">
+            We don't run any marketing trackers today. This stays off unless we add
+            something — at which point we'll re-prompt.
+          </span>
+        </span>
+      </label>
+    </fieldset>
+
+    <div class="cookie-actions">
+      <button type="button" id="cookie-reject" class="cookie-btn cookie-btn-secondary">
+        Reject all
+      </button>
+      <button type="button" id="cookie-customize" class="cookie-btn cookie-btn-secondary">
+        Customize
+      </button>
+      <button type="button" id="cookie-save" class="cookie-btn cookie-btn-primary" hidden>
+        Save preferences
+      </button>
+      <button type="button" id="cookie-accept" class="cookie-btn cookie-btn-primary">
+        Accept all
+      </button>
+    </div>
+
+    <p class="cookie-foot">
+      <a href="/legal/cookies">Cookie policy</a> ·
+      <a href="/legal/privacy">Privacy policy</a> ·
+      <a href="/dsar">Your privacy choices</a>
+    </p>
+  </div>
+</aside>
+
+<script is:inline>
+  // Self-contained vanilla JS — no framework, no dependencies. Runs on
+  // every page via BaseLayout. Exposes `window.sealdConsent` for the
+  // footer link + any subscribers.
+  (function () {
+    var COOKIE = 'seald_consent_v1';
+    var MAX_AGE_DAYS = 365;
+    var DEFAULT = { essential: true, analytics: false, marketing: false, gpc: false, ts: 0 };
+
+    function readCookie() {
+      var match = document.cookie.match(
+        new RegExp('(?:^|; )' + COOKIE + '=([^;]+)'),
+      );
+      if (!match) return null;
+      try {
+        return JSON.parse(decodeURIComponent(match[1]));
+      } catch (_e) {
+        return null;
+      }
+    }
+
+    function writeCookie(value) {
+      var encoded = encodeURIComponent(JSON.stringify(value));
+      var maxAge = MAX_AGE_DAYS * 24 * 60 * 60;
+      var secure = location.protocol === 'https:' ? '; Secure' : '';
+      document.cookie =
+        COOKIE + '=' + encoded + '; Max-Age=' + maxAge + '; Path=/; SameSite=Lax' + secure;
+    }
+
+    function isGpc() {
+      try {
+        return navigator.globalPrivacyControl === true;
+      } catch (_e) {
+        return false;
+      }
+    }
+
+    function dispatch(consent) {
+      try {
+        window.dispatchEvent(
+          new CustomEvent('seald:consent-changed', { detail: consent }),
+        );
+      } catch (_e) {
+        /* no-op for older browsers */
+      }
+    }
+
+    var banner = document.getElementById('cookie-banner');
+    if (!banner) return;
+    var fieldset = banner.querySelector('.cookie-categories');
+    var gpcNotice = banner.querySelector('#cookie-gpc-notice');
+    var saveBtn = banner.querySelector('#cookie-save');
+    var customizeBtn = banner.querySelector('#cookie-customize');
+    var acceptBtn = banner.querySelector('#cookie-accept');
+    var rejectBtn = banner.querySelector('#cookie-reject');
+    var analyticsInput = banner.querySelector('input[name="analytics"]');
+    var marketingInput = banner.querySelector('input[name="marketing"]');
+
+    function show() {
+      var stored = readCookie();
+      if (stored) {
+        if (analyticsInput) analyticsInput.checked = !!stored.analytics;
+        if (marketingInput) marketingInput.checked = !!stored.marketing;
+      } else if (isGpc()) {
+        if (gpcNotice) gpcNotice.hidden = false;
+      }
+      banner.hidden = false;
+    }
+
+    function hide() {
+      banner.hidden = true;
+      if (fieldset) fieldset.hidden = true;
+      if (saveBtn) saveBtn.hidden = true;
+      if (customizeBtn) customizeBtn.hidden = false;
+      if (acceptBtn) acceptBtn.hidden = false;
+    }
+
+    function persist(choice) {
+      var consent = {
+        essential: true,
+        analytics: !!choice.analytics,
+        marketing: !!choice.marketing,
+        gpc: isGpc(),
+        ts: Date.now(),
+      };
+      writeCookie(consent);
+      dispatch(consent);
+      hide();
+    }
+
+    if (rejectBtn) {
+      rejectBtn.addEventListener('click', function () {
+        persist({ analytics: false, marketing: false });
+      });
+    }
+    if (acceptBtn) {
+      acceptBtn.addEventListener('click', function () {
+        // GPC = strong opt-out signal. We still let the user click Accept,
+        // but we DON'T flip non-essential to true — the user must
+        // expressly opt back in via Customize → Save.
+        if (isGpc()) {
+          persist({ analytics: false, marketing: false });
+        } else {
+          persist({ analytics: true, marketing: true });
+        }
+      });
+    }
+    if (customizeBtn) {
+      customizeBtn.addEventListener('click', function () {
+        if (fieldset) fieldset.hidden = false;
+        if (saveBtn) saveBtn.hidden = false;
+        // Hide accept/customize so the user has one clear "Save" action.
+        if (acceptBtn) acceptBtn.hidden = true;
+        customizeBtn.hidden = true;
+      });
+    }
+    if (saveBtn) {
+      saveBtn.addEventListener('click', function () {
+        persist({
+          analytics: !!(analyticsInput && analyticsInput.checked),
+          marketing: !!(marketingInput && marketingInput.checked),
+        });
+      });
+    }
+
+    // Public API (used by the footer "Manage cookie preferences" link).
+    window.sealdConsent = {
+      show: show,
+      get: readCookie,
+      // Programmatic setter so future surfaces can flip a category from
+      // a settings page without re-opening the banner.
+      set: function (partial) {
+        var current = readCookie() || DEFAULT;
+        persist({
+          analytics: 'analytics' in (partial || {}) ? !!partial.analytics : !!current.analytics,
+          marketing: 'marketing' in (partial || {}) ? !!partial.marketing : !!current.marketing,
+        });
+      },
+    };
+
+    // Delegated click handler for any element marked
+    // `data-seald-cookie-prefs` — keeps inline onclick out of HTML so
+    // the page is CSP-friendly and Astro stops emitting the deprecated
+    // global `event` warning.
+    document.addEventListener('click', function (e) {
+      var target = e.target;
+      while (target && target !== document.body) {
+        if (target.dataset && 'sealdCookiePrefs' in target.dataset) {
+          e.preventDefault();
+          show();
+          return;
+        }
+        target = target.parentElement;
+      }
+    });
+
+    // First visit: show banner. Returning visitor with stored consent:
+    // dispatch the stored value once so analytics injectors can react.
+    var stored = readCookie();
+    if (!stored) {
+      show();
+    } else {
+      dispatch(stored);
+    }
+  })();
+</script>
+
+<style>
+  .cookie-banner {
+    position: fixed;
+    inset: auto 0 0 0;
+    z-index: 9000;
+    display: flex;
+    justify-content: center;
+    padding: 16px;
+    background: rgba(11, 18, 32, 0.06);
+    backdrop-filter: blur(6px);
+  }
+  .cookie-card {
+    width: min(720px, 100%);
+    background: #ffffff;
+    border: 1px solid #e2e8f0;
+    border-radius: 14px;
+    box-shadow: 0 12px 40px rgba(11, 18, 32, 0.16);
+    padding: 22px 22px 18px;
+    font-family:
+      Inter,
+      -apple-system,
+      'Segoe UI',
+      Arial,
+      sans-serif;
+    color: #0b1220;
+  }
+  .cookie-card h2 {
+    margin: 0 0 8px;
+    font-size: 16px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+  .cookie-card p {
+    margin: 0 0 12px;
+    font-size: 13.5px;
+    line-height: 1.55;
+    color: #334155;
+  }
+  .cookie-gpc {
+    background: #eef2ff;
+    border: 1px solid #c7d2fe;
+    border-radius: 10px;
+    padding: 10px 12px;
+    color: #1e293b !important;
+    font-size: 13px !important;
+  }
+  .cookie-categories {
+    border: 1px solid #e2e8f0;
+    border-radius: 10px;
+    margin: 4px 0 14px;
+    padding: 8px 10px;
+  }
+  .cookie-row {
+    display: flex;
+    gap: 10px;
+    padding: 8px 4px;
+    align-items: flex-start;
+  }
+  .cookie-row + .cookie-row {
+    border-top: 1px solid #f1f5f9;
+  }
+  .cookie-row input[type='checkbox'] {
+    margin: 4px 0 0;
+    flex-shrink: 0;
+  }
+  .cookie-row-text {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .cookie-row-title {
+    font-weight: 600;
+    font-size: 13.5px;
+  }
+  .cookie-row-desc {
+    color: #475569;
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  .cookie-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-top: 4px;
+  }
+  .cookie-btn {
+    /* Equal visual weight — no dark patterns. */
+    flex: 1 1 auto;
+    min-height: 40px;
+    border-radius: 10px;
+    border: 1px solid #0b1220;
+    font-family: inherit;
+    font-size: 13.5px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: filter 0.15s ease;
+    padding: 0 14px;
+  }
+  .cookie-btn:hover {
+    filter: brightness(0.95);
+  }
+  .cookie-btn-primary {
+    background: #0b1220;
+    color: #ffffff;
+  }
+  .cookie-btn-secondary {
+    background: #ffffff;
+    color: #0b1220;
+  }
+  .cookie-foot {
+    margin: 12px 0 0;
+    font-size: 12px !important;
+    color: #64748b !important;
+  }
+  .cookie-foot a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  @media (max-width: 480px) {
+    .cookie-actions {
+      flex-direction: column;
+    }
+    .cookie-btn {
+      width: 100%;
+    }
+  }
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -13,6 +13,7 @@
 // via props, then drop their content in the <slot/>.
 
 import '@/styles/globals.css';
+import CookieBanner from '@/components/CookieBanner.astro';
 
 export interface Props {
   title?: string;
@@ -135,21 +136,47 @@ const softwareLd = {
     <script type="application/ld+json" set:html={JSON.stringify(softwareLd)} />
 
     <!--
-      Cloudflare Web Analytics
-      ------------------------
-      Privacy-friendly, cookie-less. No banner needed. Replace the empty
-      token below with the real beacon token from the Cloudflare dashboard
-      (Analytics & Logs → Web Analytics → site config). See CLAUDE.md.
+      Cloudflare Web Analytics — gated behind cookie consent.
+      ------------------------------------------------------
+      The beacon is privacy-friendly (cookie-less, IP not stored) but it
+      still loads a third-party script and reads request metadata, so we
+      treat it as the "analytics" category and only inject the <script>
+      element after a `seald:consent-changed` event with `analytics:true`.
+      This matches our T-09 contract (ePrivacy Art. 5(3) + EDPB 03/2022).
     -->
-    <script
-      defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": ""}'
-    ></script>
+    <script is:inline data-cf-token="">
+      (function () {
+        // Capture the token from the script tag now, while
+        // document.currentScript is still defined. Inside async event
+        // handlers it's null.
+        var token =
+          (document.currentScript &&
+            document.currentScript.dataset &&
+            document.currentScript.dataset.cfToken) ||
+          '';
+        function inject() {
+          if (window.__sealdCfBeaconLoaded) return;
+          var s = document.createElement('script');
+          s.defer = true;
+          s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+          // Empty token is the current placeholder — see CLAUDE.md.
+          // The beacon script no-ops on an empty token, but wiring the
+          // gate end-to-end lets us prove consent works without leaking
+          // analytics data before consent.
+          s.setAttribute('data-cf-beacon', JSON.stringify({ token: token }));
+          document.head.appendChild(s);
+          window.__sealdCfBeaconLoaded = true;
+        }
+        window.addEventListener('seald:consent-changed', function (e) {
+          if (e && e.detail && e.detail.analytics === true) inject();
+        });
+      })();
+    </script>
   </head>
 
   <body>
     <a href="#main" class="sr-only">Skip to main content</a>
     <slot />
+    <CookieBanner />
   </body>
 </html>

--- a/apps/landing/src/pages/dsar.astro
+++ b/apps/landing/src/pages/dsar.astro
@@ -1,0 +1,272 @@
+---
+// dsar.astro — Data-subject access request / "Your privacy choices" intake page.
+//
+// Why this page exists (T-12 in .audit/LEGAL_GAPS.md):
+//   - CCPA/CPRA §7011-§7027: businesses must provide at least two methods
+//     for submitting verifiable consumer requests, including an
+//     "easy-to-find" interactive web form for opt-out of sale/share.
+//   - GDPR Art. 12: requests must be facilitated by appropriate means.
+//   - California "DNSMPI" / "Your Privacy Choices" link in the footer
+//     points here.
+//
+// First iteration is mailto-driven: the form serializes its values into
+// a structured `mailto:` URL pointed at privacy@seald.nromomentum.com.
+// T-19 will replace this with a real backend endpoint and verification
+// flow; until then the SLA holds because all intake routes through the
+// same address.
+import BaseLayout from '@/layouts/BaseLayout.astro';
+const VERSION = 'dsar_v0.1';
+---
+<BaseLayout
+  title="Your privacy choices — Seald"
+  description="Submit a privacy / data-subject request to Seald: access, deletion, correction, portability, opt-out of sale or sharing, or limit use of sensitive personal information."
+>
+  <main id="main" class="legal">
+    <article>
+      <header>
+        <section class="legal-banner">
+          <p><strong>Draft.</strong> All submissions reach our privacy team. Acknowledgement within 10 business days; resolution within 30 days (CCPA / CPRA) or one month (GDPR / UK GDPR), extensible by up to two months for genuinely complex requests with notice to you. We may need to verify your identity before acting on a request.</p>
+          <p class="meta">Version: <code>{VERSION}</code> · Last updated: <code>2026-04-30</code></p>
+        </section>
+        <h1>Your privacy choices</h1>
+        <p>Use this form to exercise rights under the GDPR, UK GDPR, CCPA / CPRA, and the U.S. state-omnibus regimes (Colorado, Connecticut, Virginia, Utah, Texas, Oregon, Montana, Iowa, Tennessee, Indiana, Delaware, New Jersey, New Hampshire, Minnesota, Maryland, Rhode Island, Kentucky, plus any others where similar laws apply). It is also the link behind the "Your Privacy Choices" / "Do Not Sell or Share My Personal Information" footer. We do not currently sell or share personal information for cross-context behavioral advertising; submitting an opt-out is still honored on a forward-looking basis.</p>
+      </header>
+
+      <section id="form">
+        <h2>1. Submit a request</h2>
+        <p>The form below opens a pre-filled email in your default mail client. We accept submissions from any reachable email; for verified-account requests please send from the email associated with your Seald account when possible.</p>
+
+        <form id="dsar-form" class="dsar-form" novalidate>
+          <div class="dsar-row">
+            <label for="dsar-name">Full name</label>
+            <input
+              id="dsar-name"
+              name="name"
+              type="text"
+              autocomplete="name"
+              required
+              aria-required="true"
+            />
+          </div>
+
+          <div class="dsar-row">
+            <label for="dsar-email">Email</label>
+            <input
+              id="dsar-email"
+              name="email"
+              type="email"
+              autocomplete="email"
+              required
+              aria-required="true"
+              aria-describedby="dsar-email-help"
+            />
+            <p id="dsar-email-help" class="dsar-help">We'll reply to this address. Use the address associated with your Seald account when possible.</p>
+          </div>
+
+          <div class="dsar-row">
+            <label for="dsar-jurisdiction">Jurisdiction</label>
+            <select id="dsar-jurisdiction" name="jurisdiction" required aria-required="true">
+              <option value="">Select…</option>
+              <option value="CCPA / CPRA (California, USA)">CCPA / CPRA (California, USA)</option>
+              <option value="GDPR (European Union)">GDPR (European Union)</option>
+              <option value="UK GDPR (United Kingdom)">UK GDPR (United Kingdom)</option>
+              <option value="US state omnibus (other than California)">US state omnibus (other than California)</option>
+              <option value="Other / I'm not sure">Other / I'm not sure</option>
+            </select>
+          </div>
+
+          <fieldset class="dsar-row dsar-fieldset">
+            <legend>Request type</legend>
+            <p class="dsar-help">Pick the option that matches what you'd like us to do. You can pick more than one.</p>
+            <label class="dsar-check"><input type="checkbox" name="type" value="access" /> Access — give me a copy of the personal data you hold about me.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="delete" /> Deletion — delete my personal data.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="correct" /> Correction — fix inaccurate personal data.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="portability" /> Portability — provide my personal data in a portable, machine-readable format.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="opt-out" /> Opt out of sale or sharing for cross-context behavioral advertising.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="limit-sensitive" /> Limit the use of my sensitive personal information.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="opt-out-profiling" /> Opt out of profiling that produces legal or similarly significant effects.</label>
+            <label class="dsar-check"><input type="checkbox" name="type" value="other" /> Other (describe below).</label>
+          </fieldset>
+
+          <div class="dsar-row">
+            <label for="dsar-details">Details (optional)</label>
+            <textarea id="dsar-details" name="details" rows="4" aria-describedby="dsar-details-help"></textarea>
+            <p id="dsar-details-help" class="dsar-help">Add any context that helps us locate the data — e.g. the email of a Seald account, document IDs, approximate dates.</p>
+          </div>
+
+          <div class="dsar-row">
+            <label for="dsar-agent">Are you an authorized agent acting on someone's behalf?</label>
+            <select id="dsar-agent" name="agent">
+              <option value="No">No, I'm submitting for myself</option>
+              <option value="Yes">Yes — I'm an authorized agent</option>
+            </select>
+            <p class="dsar-help">If yes, we'll request written authorization (CCPA §7063) before acting.</p>
+          </div>
+
+          <div class="dsar-actions">
+            <button type="submit" class="dsar-btn">Open prefilled email</button>
+            <a class="dsar-btn dsar-btn-ghost" href="mailto:privacy@seald.nromomentum.com?subject=DSAR%20request">Send empty email instead</a>
+          </div>
+          <p class="dsar-help">No personal data is sent to us until you press Send in your mail client. Nothing is stored on this page.</p>
+        </form>
+      </section>
+
+      <section id="sla">
+        <h2>2. What happens next</h2>
+        <ol>
+          <li><strong>Acknowledgement.</strong> Within 10 business days of receipt we send a written acknowledgement and, if needed, a verification request.</li>
+          <li><strong>Verification.</strong> We confirm we are talking to you (or your authorized agent). For account-tied requests we typically rely on a code sent to the email on file; for non-account requests we may need additional information.</li>
+          <li><strong>Resolution.</strong> Within 30 calendar days (CCPA / CPRA) or one calendar month (GDPR / UK GDPR) we either fulfill the request, deny it with a reason, or extend the deadline by up to 60 / 60 days for genuinely complex matters and notify you of the extension.</li>
+          <li><strong>Appeal.</strong> If you disagree with our decision you can reply to the same thread to request internal review (state-omnibus regimes). EU/UK residents may also lodge a complaint with their supervisory authority — see your local data-protection authority.</li>
+        </ol>
+      </section>
+
+      <section id="alt">
+        <h2>3. Alternative submission methods</h2>
+        <ul>
+          <li>Email <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a> directly.</li>
+          <li>Postal mail — <a href="/contact#postal">see our postal address</a>.</li>
+        </ul>
+      </section>
+
+      <section id="contact">
+        <h2>4. Questions</h2>
+        <p>Reach <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a>. See <a href="/legal/privacy">Privacy Policy</a> for a description of the personal data we process and our retention policy.</p>
+      </section>
+    </article>
+  </main>
+
+  <script is:inline>
+    (function () {
+      var form = document.getElementById('dsar-form');
+      if (!form) return;
+      form.addEventListener('submit', function (e) {
+        e.preventDefault();
+        var data = new FormData(form);
+        var name = String(data.get('name') || '').trim();
+        var email = String(data.get('email') || '').trim();
+        var juris = String(data.get('jurisdiction') || '').trim();
+        var details = String(data.get('details') || '').trim();
+        var agent = String(data.get('agent') || 'No');
+        var types = data.getAll('type').map(String);
+
+        if (!name || !email || !juris) {
+          alert('Please fill in your name, email, and jurisdiction.');
+          return;
+        }
+        if (types.length === 0) {
+          alert('Please select at least one request type.');
+          return;
+        }
+
+        var subject = 'DSAR — ' + types.join(', ');
+        var body =
+          'Submitted via the Seald privacy form (https://seald.nromomentum.com/dsar)\n\n' +
+          'Name: ' +
+          name +
+          '\n' +
+          'Email: ' +
+          email +
+          '\n' +
+          'Jurisdiction: ' +
+          juris +
+          '\n' +
+          'Authorized agent: ' +
+          agent +
+          '\n' +
+          'Request type(s): ' +
+          types.join(', ') +
+          '\n\n' +
+          'Details:\n' +
+          (details || '(none provided)') +
+          '\n';
+
+        var href =
+          'mailto:privacy@seald.nromomentum.com?subject=' +
+          encodeURIComponent(subject) +
+          '&body=' +
+          encodeURIComponent(body);
+
+        window.location.href = href;
+      });
+    })();
+  </script>
+
+  <style>
+    .dsar-form {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      margin-top: 8px;
+    }
+    .dsar-row {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+    .dsar-row label {
+      font-weight: 600;
+      font-size: 13.5px;
+    }
+    .dsar-fieldset {
+      border: 1px solid #e2e8f0;
+      border-radius: 10px;
+      padding: 12px 14px;
+      gap: 8px;
+    }
+    .dsar-fieldset legend {
+      font-weight: 600;
+      font-size: 13.5px;
+      padding: 0 4px;
+    }
+    .dsar-row input[type='text'],
+    .dsar-row input[type='email'],
+    .dsar-row select,
+    .dsar-row textarea {
+      width: 100%;
+      padding: 10px 12px;
+      font: inherit;
+      border: 1px solid #cbd5e1;
+      border-radius: 8px;
+      background: #ffffff;
+    }
+    .dsar-row textarea {
+      resize: vertical;
+      min-height: 80px;
+    }
+    .dsar-help {
+      font-size: 12.5px;
+      color: #64748b;
+      margin: 0;
+    }
+    .dsar-check {
+      display: flex;
+      gap: 8px;
+      align-items: flex-start;
+      font-weight: 400;
+      font-size: 13.5px;
+    }
+    .dsar-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 4px;
+    }
+    .dsar-btn {
+      display: inline-block;
+      padding: 10px 16px;
+      border-radius: 10px;
+      border: 1px solid #0b1220;
+      background: #0b1220;
+      color: #ffffff;
+      font-weight: 600;
+      font-size: 14px;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .dsar-btn-ghost {
+      background: #ffffff;
+      color: #0b1220;
+    }
+  </style>
+</BaseLayout>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -449,7 +449,8 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <li><a href="/legal/cookies">Cookies</a></li>
             <li><a href="/legal/dpa">DPA</a></li>
             <li><a href="/legal/aup">Acceptable use</a></li>
-            <li><a href="mailto:privacy@seald.nromomentum.com?subject=Your%20Privacy%20Choices">Your Privacy Choices</a></li>
+            <li><a href="/dsar">Your Privacy Choices</a></li>
+            <li><a href="#cookie-banner" data-seald-cookie-prefs>Manage cookie preferences</a></li>
           </ul>
         </div>
       </div>

--- a/apps/landing/src/pages/legal/cookies.astro
+++ b/apps/landing/src/pages/legal/cookies.astro
@@ -94,10 +94,18 @@ const VERSION = 'cookies_v0.1';
       <section id="control">
         <h2>5. How to control cookies</h2>
         <ul>
-          <li><strong>In Seald:</strong> click "Manage cookie preferences" in the footer to change your choice at any time.</li>
+          <li><strong>In Seald:</strong> click "Manage cookie preferences" in the footer (or use the button below) to change your choice at any time.</li>
           <li><strong>In your browser:</strong> Chrome, Firefox, Safari, Edge, and Brave all let you block or delete cookies in settings. Blocking strictly necessary cookies will break the Service.</li>
           <li><strong>Global Privacy Control:</strong> install a browser or extension that sends the GPC signal; we will treat it as an opt-out.</li>
         </ul>
+        <p>
+          <button
+            type="button"
+            data-seald-cookie-prefs
+            style="display:inline-block;padding:10px 16px;border-radius:10px;border:1px solid #0b1220;background:#0b1220;color:#ffffff;font-weight:600;font-size:14px;cursor:pointer;"
+            >Open cookie preferences</button
+          >
+        </p>
       </section>
 
       <section id="changes">

--- a/apps/landing/src/pages/legal/privacy.astro
+++ b/apps/landing/src/pages/legal/privacy.astro
@@ -117,7 +117,7 @@ const VERSION = 'privacy_v0.1';
           <li><strong>Withdraw consent</strong> at any time where consent is the lawful basis</li>
           <li><strong>Lodge a complaint</strong> with a supervisory authority — for example the Irish Data Protection Commission, the UK Information Commissioner's Office (ICO), or your local member-state authority</li>
         </ul>
-        <p>To exercise any of these rights, email <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a>. We will acknowledge within ten (10) business days and respond within one month, extendable by up to two further months for complex requests with notice. Service is free of charge unless your request is manifestly unfounded or excessive.</p>
+        <p>To exercise any of these rights, use our <a href="/dsar">privacy choices form</a> or email <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a>. We will acknowledge within ten (10) business days and respond within one month, extendable by up to two further months for complex requests with notice. Service is free of charge unless your request is manifestly unfounded or excessive.</p>
       </section>
 
       <section id="rights-us">
@@ -134,7 +134,7 @@ const VERSION = 'privacy_v0.1';
           <li><strong>Right of appeal</strong> if we deny a request (CO/CT/VA and others).</li>
           <li><strong>Right to non-retaliation</strong> for exercising any of these rights.</li>
         </ul>
-        <p>To exercise these rights, email <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a>. We will acknowledge within ten (10) business days and fulfill within forty-five (45) calendar days, extendable by up to forty-five (45) days with notice for complex requests. We may verify your identity by matching the information in your request against the information in your account. An authorized agent must provide written permission from the consumer.</p>
+        <p>To exercise these rights, use our <a href="/dsar">privacy choices form</a> or email <a href="mailto:privacy@seald.nromomentum.com">privacy@seald.nromomentum.com</a>. We will acknowledge within ten (10) business days and fulfill within forty-five (45) calendar days, extendable by up to forty-five (45) days with notice for complex requests. We may verify your identity by matching the information in your request against the information in your account. An authorized agent must provide written permission from the consumer.</p>
         <h3>8.1 Global Privacy Control</h3>
         <p>Seald honors the Global Privacy Control ("GPC") browser signal as a valid opt-out of "sale" and "sharing" under California's CCPA Regulations § 7025 and the equivalent universal-opt-out mechanisms required by Colorado and Connecticut. When we detect a GPC signal we treat it as an opt-out for the visiting browser; signed-in users can also record the choice on their account.</p>
         <h3>8.2 12-month look-back</h3>


### PR DESCRIPTION
## Summary

Closes T-09 and T-12 from `.audit/LEGAL_GAPS.md` (Phase 4 of the legal-production-readiness rollout).

- **T-09 — Cookie banner with GPC honor.** New `apps/landing/src/components/CookieBanner.astro`. Reject as easy as Accept, no pre-ticked toggles, per-purpose granularity (essential / analytics / marketing). Reads `navigator.globalPrivacyControl`; auto-rejects non-essential when GPC is on and surfaces a notice. Persists `seald_consent_v1` cookie (Max-Age = 365 days). Footer "Manage cookie preferences" link reopens the banner via a delegated `data-seald-cookie-prefs` handler. Cloudflare Insights beacon now gated behind a `seald:consent-changed` event with `analytics:true`.
- **T-12 — DSAR intake page.** New `apps/landing/src/pages/dsar.astro` with name / email / jurisdiction / multi-checkbox request type / details / authorized-agent fields. Submit opens a prefilled `mailto:privacy@seald.nromomentum.com`. Documented SLA: 10-business-day acknowledgement, 30 days CCPA/CPRA / one month GDPR resolution, extendable. Linked from the footer ("Your Privacy Choices" — replaces the previous mailto:) and from both rights sections of the Privacy Policy.

## Test plan

- [x] `pnpm -r typecheck` ✓ (0 errors / 0 warnings)
- [x] `pnpm -r lint` ✓
- [x] `pnpm --filter landing build` ✓ (12 pages, +/dsar)
- [x] Local preview — `/`, `/dsar`, `/legal/cookies`, `/legal/privacy`, `/contact`, `/legal/imprint` all return 200; banner DOM and `window.sealdConsent` API present on every page.
- [ ] Open the home page in a fresh browser → banner is visible; click Reject → banner hides, `seald_consent_v1` cookie set with `analytics:false`.
- [ ] In a browser with GPC enabled (e.g. Brave, DuckDuckGo, the GPC toggle in DDG extension): banner shows the GPC notice; Accept all → cookie still records `analytics:false`; Customize → Save lets the user opt back in.
- [ ] Footer "Manage cookie preferences" reopens the banner pre-populated with the current choices.
- [ ] `/legal/cookies` "Open cookie preferences" inline button reopens the banner.
- [ ] `/dsar` form: incomplete submit shows alert; complete submit opens mail client with the right `mailto:` URL (subject + body match the form).

🤖 Generated with [Claude Code](https://claude.com/claude-code)