### PR TITLE
feat(me): /me/export + DELETE /me — DSAR + account deletion (T-19/T-20)

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { EmailModule } from './email/email.module';
 import { CronModule } from './cron/cron.module';
 import { EnvelopesModule } from './envelopes/envelopes.module';
 import { HealthModule } from './health/health.module';
+import { MeModule } from './me/me.module';
 import { SealingModule } from './sealing/sealing.module';
 import { TemplatesModule } from './templates/templates.module';
 import { VerifyModule } from './verify/verify.module';
@@ -45,6 +46,7 @@ import { StorageModule } from './storage/storage.module';
     ContactsModule,
     EnvelopesModule,
     TemplatesModule,
+    MeModule,
     SealingModule,
     VerifyModule,
     CronModule,

--- a/apps/api/src/me/dto/delete-account.dto.ts
+++ b/apps/api/src/me/dto/delete-account.dto.ts
@@ -1,0 +1,14 @@
+import { Equals } from 'class-validator';
+
+/**
+ * T-20: account deletion is gated on a verbatim confirm phrase to make
+ * the destructive intent explicit. The SPA prompts the user for the
+ * phrase; copy/paste protections live there. The server treats the
+ * absence of the literal as 400.
+ */
+export class DeleteAccountDto {
+  @Equals('DELETE_MY_ACCOUNT', {
+    message: 'confirm must be the literal string "DELETE_MY_ACCOUNT"',
+  })
+  readonly confirm!: 'DELETE_MY_ACCOUNT';
+}

--- a/apps/api/src/me/idempotency.repository.pg.ts
+++ b/apps/api/src/me/idempotency.repository.pg.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Kysely } from 'kysely';
+import type { Database } from '../../db/schema';
+import { DB_TOKEN } from '../db/db.provider';
+import { IdempotencyRepository } from './idempotency.repository';
+
+@Injectable()
+export class IdempotencyPgRepository extends IdempotencyRepository {
+  constructor(@Inject(DB_TOKEN) private readonly db: Kysely<Database>) {
+    super();
+  }
+
+  async deleteByUser(user_id: string): Promise<number> {
+    const res = await this.db
+      .deleteFrom('idempotency_records')
+      .where('user_id', '=', user_id)
+      .executeTakeFirst();
+    // kysely returns numDeletedRows as a bigint; coerce to number for
+    // the small caller-side check (it never realistically exceeds 2^32).
+    return Number(res.numDeletedRows ?? 0);
+  }
+}

--- a/apps/api/src/me/idempotency.repository.ts
+++ b/apps/api/src/me/idempotency.repository.ts
@@ -1,0 +1,10 @@
+/**
+ * Port for the slice of `idempotency_records` that T-20 needs. The
+ * full idempotency feature has its own home (request middleware), but
+ * its FK does not cascade on `auth.users(id)` deletion, so the
+ * account-deletion flow has to wipe rows itself.
+ */
+export abstract class IdempotencyRepository {
+  /** Returns the number of rows deleted. Idempotent. */
+  abstract deleteByUser(user_id: string): Promise<number>;
+}

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Controller, Delete, Get, HttpCode, Res } from '@nestjs/common';
+import { Throttle } from '@nestjs/throttler';
+import type { Response } from 'express';
+import { CurrentUser } from '../auth/current-user.decorator';
+import type { AuthUser } from '../auth/auth-user';
+import { DeleteAccountDto } from './dto/delete-account.dto';
+import { MeService } from './me.service';
+
+/**
+ * T-19 (`GET /me/export`) and T-20 (`DELETE /me`) — DSAR / right-to-
+ * erasure surface required for GDPR Art. 15 / Art. 17 and CCPA §1798.105.
+ * Both endpoints sit behind the global `AuthGuard`. The throttle limits
+ * are tight because both are heavy: export hydrates the user's full
+ * aggregate and delete is irreversible.
+ */
+@Controller('me')
+export class MeController {
+  constructor(private readonly svc: MeService) {}
+
+  @Get('export')
+  @Throttle({ short: { limit: 5, ttl: 60_000 } })
+  async exportAll(
+    @CurrentUser() user: AuthUser,
+    @Res({ passthrough: false }) res: Response,
+  ): Promise<void> {
+    const payload = await this.svc.exportAll(user);
+    const filename = `seald-export-${user.id}-${new Date().toISOString().slice(0, 10)}.json`;
+    res
+      .setHeader('Content-Type', 'application/json; charset=utf-8')
+      .setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+      // Don't let any caching layer keep the user's data.
+      .setHeader('Cache-Control', 'no-store')
+      .send(JSON.stringify(payload, null, 2));
+  }
+
+  @Delete()
+  @HttpCode(204)
+  @Throttle({ short: { limit: 1, ttl: 60_000 }, long: { limit: 5, ttl: 3_600_000 } })
+  async deleteAccount(
+    @CurrentUser() user: AuthUser,
+    @Body() _dto: DeleteAccountDto,
+  ): Promise<void> {
+    // The DTO already validated the confirm phrase (`@Equals(...)`); we
+    // discard it here and only forward the user identity. If the
+    // confirm field is wrong, validation throws 400 before we get
+    // called.
+    await this.svc.deleteAccount(user);
+  }
+}

--- a/apps/api/src/me/me.module.ts
+++ b/apps/api/src/me/me.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { AuthModule } from '../auth/auth.module';
+import { ContactsModule } from '../contacts/contacts.module';
+import { EnvelopesModule } from '../envelopes/envelopes.module';
+import { TemplatesModule } from '../templates/templates.module';
+import { IdempotencyRepository } from './idempotency.repository';
+import { IdempotencyPgRepository } from './idempotency.repository.pg';
+import { MeController } from './me.controller';
+import { MeService } from './me.service';
+import { SupabaseAdminClient } from './supabase-admin.client';
+import { SupabaseAdminHttpClient } from './supabase-admin.client.http';
+
+/**
+ * Mounts T-19 / T-20 — DSAR export and account deletion. Pulls in the
+ * other feature modules' repository ports so the service can read
+ * across all user-owned tables. `EmailModule` is `@Global()` so we
+ * don't need to import it explicitly to inject `OutboundEmailsRepository`.
+ */
+@Module({
+  imports: [AuthModule, ContactsModule, EnvelopesModule, TemplatesModule],
+  controllers: [MeController],
+  providers: [
+    MeService,
+    { provide: IdempotencyRepository, useClass: IdempotencyPgRepository },
+    { provide: SupabaseAdminClient, useClass: SupabaseAdminHttpClient },
+  ],
+})
+export class MeModule {}

--- a/apps/api/src/me/me.service.spec.ts
+++ b/apps/api/src/me/me.service.spec.ts
@@ -1,0 +1,138 @@
+import { ServiceUnavailableException } from '@nestjs/common';
+import type { AuthUser } from '../auth/auth-user';
+import type { ContactsRepository } from '../contacts/contacts.repository';
+import type { OutboundEmailsRepository } from '../email/outbound-emails.repository';
+import type { EnvelopesRepository } from '../envelopes/envelopes.repository';
+import type { TemplatesRepository } from '../templates/templates.repository';
+import type { IdempotencyRepository } from './idempotency.repository';
+import { MeService } from './me.service';
+import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+
+const USER: AuthUser = {
+  id: '11111111-1111-1111-1111-111111111111',
+  email: 'maya@example.com',
+  provider: 'email',
+};
+
+function makeMocks() {
+  const calls: string[] = [];
+  const contactsRepo = {
+    findAllByOwner: jest.fn(async () => [{ id: 'c1', name: 'A', email: 'a@x' }]),
+  } as unknown as ContactsRepository;
+  const templatesRepo = {
+    findAllByOwner: jest.fn(async () => [{ id: 't1', title: 'T1' }]),
+  } as unknown as TemplatesRepository;
+  const envelopesRepo = {
+    listByOwner: jest.fn(async () => ({
+      items: [{ id: 'env-1' }],
+      next_cursor: null,
+    })),
+    findByIdWithAll: jest.fn(async (id: string) => ({
+      id,
+      owner_id: USER.id,
+      title: 'NDA',
+      short_code: 'aaaaaaaaaaaaa',
+      signers: [{ id: 's1', email: 'a@x', name: 'A' }],
+      fields: [],
+    })),
+    listEventsForEnvelope: jest.fn(async () => [{ id: 'e1', event_type: 'created' }]),
+  } as unknown as EnvelopesRepository;
+  const outboundEmailsRepo = {
+    listByEnvelope: jest.fn(async () => [{ id: 'oe1', kind: 'invite' }]),
+  } as unknown as OutboundEmailsRepository;
+  const idempotencyRepo = {
+    deleteByUser: jest.fn(async () => {
+      calls.push('idempotency.deleteByUser');
+      return 3;
+    }),
+  } as unknown as IdempotencyRepository;
+  const supabaseAdmin = {
+    deleteUser: jest.fn(async () => {
+      calls.push('supabaseAdmin.deleteUser');
+    }),
+  } as unknown as SupabaseAdminClient;
+  return {
+    calls,
+    contactsRepo,
+    templatesRepo,
+    envelopesRepo,
+    outboundEmailsRepo,
+    idempotencyRepo,
+    supabaseAdmin,
+  };
+}
+
+function build(mocks: ReturnType<typeof makeMocks>): MeService {
+  return new MeService(
+    mocks.contactsRepo,
+    mocks.envelopesRepo,
+    mocks.templatesRepo,
+    mocks.outboundEmailsRepo,
+    mocks.idempotencyRepo,
+    mocks.supabaseAdmin,
+  );
+}
+
+describe('MeService.exportAll', () => {
+  it('builds an AccountExport with meta + counts + nested envelope bundles', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    const out = await svc.exportAll(USER);
+    expect(out.meta.format_version).toBe('1.0');
+    expect(out.meta.user).toEqual({ id: USER.id, email: USER.email });
+    expect(out.meta.includes_files).toBe(false);
+    expect(out.meta.counts).toEqual({
+      contacts: 1,
+      envelopes: 1,
+      templates: 1,
+      outbound_emails: 1,
+    });
+    expect(out.contacts).toHaveLength(1);
+    expect(out.templates).toHaveLength(1);
+    expect(out.envelopes).toHaveLength(1);
+    expect(out.envelopes[0]?.envelope.id).toBe('env-1');
+    expect(out.envelopes[0]?.events).toHaveLength(1);
+    expect(out.envelopes[0]?.outbound_emails).toHaveLength(1);
+  });
+
+  it('skips envelopes that disappear mid-flight rather than crashing', async () => {
+    const mocks = makeMocks();
+    (mocks.envelopesRepo.findByIdWithAll as jest.Mock).mockResolvedValueOnce(null);
+    const svc = build(mocks);
+    const out = await svc.exportAll(USER);
+    expect(out.envelopes).toHaveLength(0);
+    expect(out.meta.counts.envelopes).toBe(0);
+  });
+});
+
+describe('MeService.deleteAccount', () => {
+  it('wipes idempotency_records BEFORE calling Supabase admin (FK does not cascade)', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    await svc.deleteAccount(USER);
+    // Order matters — see service comment. If a future refactor swaps
+    // them this assertion will fail.
+    expect(mocks.calls).toEqual(['idempotency.deleteByUser', 'supabaseAdmin.deleteUser']);
+    expect(mocks.idempotencyRepo.deleteByUser).toHaveBeenCalledWith(USER.id);
+    expect(mocks.supabaseAdmin.deleteUser).toHaveBeenCalledWith(USER.id);
+  });
+
+  it('maps SupabaseAdminError to a 503 (ServiceUnavailableException)', async () => {
+    const mocks = makeMocks();
+    (mocks.supabaseAdmin.deleteUser as jest.Mock).mockRejectedValueOnce(
+      new SupabaseAdminError('SUPABASE_SERVICE_ROLE_KEY is not configured'),
+    );
+    const svc = build(mocks);
+    await expect(svc.deleteAccount(USER)).rejects.toBeInstanceOf(ServiceUnavailableException);
+    // idempotency wipe still happened (it ran before the admin call).
+    expect(mocks.idempotencyRepo.deleteByUser).toHaveBeenCalledWith(USER.id);
+  });
+
+  it('rethrows non-SupabaseAdminError errors verbatim', async () => {
+    const mocks = makeMocks();
+    const boom = new Error('boom');
+    (mocks.supabaseAdmin.deleteUser as jest.Mock).mockRejectedValueOnce(boom);
+    const svc = build(mocks);
+    await expect(svc.deleteAccount(USER)).rejects.toBe(boom);
+  });
+});

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,0 +1,182 @@
+import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import type { AuthUser } from '../auth/auth-user';
+import { ContactsRepository } from '../contacts/contacts.repository';
+import { OutboundEmailsRepository } from '../email/outbound-emails.repository';
+import { EnvelopesRepository } from '../envelopes/envelopes.repository';
+import type { Envelope, EnvelopeEvent, EnvelopeSigner } from '../envelopes/envelope.entity';
+import { TemplatesRepository } from '../templates/templates.repository';
+import { IdempotencyRepository } from './idempotency.repository';
+import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+
+/**
+ * Wire format of the GDPR / CCPA / DSAR data export. Public surface
+ * lives in this comment + the type definition because the JSON file is
+ * downloaded by users and consumed by their tooling — the shape is
+ * effectively a contract.
+ */
+export interface AccountExport {
+  readonly meta: {
+    readonly format_version: '1.0';
+    readonly generated_at: string;
+    readonly user: { readonly id: string; readonly email: string | null };
+    readonly counts: {
+      readonly contacts: number;
+      readonly envelopes: number;
+      readonly templates: number;
+      readonly outbound_emails: number;
+    };
+    readonly includes_files: false;
+  };
+  readonly contacts: ReadonlyArray<unknown>;
+  readonly templates: ReadonlyArray<unknown>;
+  readonly envelopes: ReadonlyArray<{
+    readonly envelope: Envelope;
+    readonly signers: ReadonlyArray<EnvelopeSigner>;
+    readonly events: ReadonlyArray<EnvelopeEvent>;
+    readonly outbound_emails: ReadonlyArray<unknown>;
+  }>;
+}
+
+@Injectable()
+export class MeService {
+  private readonly logger = new Logger(MeService.name);
+
+  constructor(
+    private readonly contactsRepo: ContactsRepository,
+    private readonly envelopesRepo: EnvelopesRepository,
+    private readonly templatesRepo: TemplatesRepository,
+    private readonly outboundEmailsRepo: OutboundEmailsRepository,
+    private readonly idempotencyRepo: IdempotencyRepository,
+    private readonly supabaseAdmin: SupabaseAdminClient,
+  ) {}
+
+  /**
+   * T-19 — assemble an export of every row owned by the caller. The
+   * result is JSON-serialisable; the controller wraps it with
+   * `Content-Disposition: attachment` and an indented `JSON.stringify`
+   * so the file is human-readable.
+   *
+   * Memory note: for an MVP we accumulate everything in memory before
+   * returning. A power user with thousands of envelopes could OOM the
+   * worker; switch to streaming JSON if/when that becomes a real
+   * problem (TODO not before usage data demands it).
+   */
+  async exportAll(user: AuthUser): Promise<AccountExport> {
+    const [contacts, templates, envelopeIds] = await Promise.all([
+      this.contactsRepo.findAllByOwner(user.id),
+      this.templatesRepo.findAllByOwner(user.id),
+      this.collectEnvelopeIds(user.id),
+    ]);
+
+    // For each envelope id, hydrate the full aggregate + events +
+    // outbound emails in parallel. Order doesn't matter — the consumer
+    // sorts on its end. We bound concurrency by `Promise.all` over the
+    // outer list, which is small (envelopeIds is the user's lifetime
+    // count). If that ever gets large, batch with a semaphore.
+    const envelopes = await Promise.all(
+      envelopeIds.map(async (envelopeId) => {
+        const [aggregate, events, outboundEmails] = await Promise.all([
+          this.envelopesRepo.findByIdWithAll(envelopeId),
+          this.envelopesRepo.listEventsForEnvelope(envelopeId),
+          this.outboundEmailsRepo.listByEnvelope(envelopeId),
+        ]);
+        // Defensive: an envelope id surfaced by `listByOwner` should
+        // always resolve to a row; if a concurrent delete races, skip
+        // it rather than blow up the whole export.
+        if (!aggregate) {
+          this.logger.warn(`export: envelope ${envelopeId} disappeared mid-flight; skipping`);
+          return null;
+        }
+        return {
+          envelope: aggregate,
+          signers: aggregate.signers,
+          events,
+          outbound_emails: outboundEmails,
+        };
+      }),
+    );
+
+    const cleanEnvelopes = envelopes.filter((e): e is NonNullable<typeof e> => e !== null);
+    const outboundEmailCount = cleanEnvelopes.reduce((n, e) => n + e.outbound_emails.length, 0);
+
+    return {
+      meta: {
+        format_version: '1.0',
+        generated_at: new Date().toISOString(),
+        user: { id: user.id, email: user.email },
+        counts: {
+          contacts: contacts.length,
+          envelopes: cleanEnvelopes.length,
+          templates: templates.length,
+          outbound_emails: outboundEmailCount,
+        },
+        includes_files: false,
+      },
+      contacts,
+      templates,
+      envelopes: cleanEnvelopes,
+    };
+  }
+
+  /**
+   * T-20 — wipe non-cascading rows then ask Supabase to delete the
+   * `auth.users` row, which triggers cascade deletion of every
+   * `owner_id` FK (contacts, envelopes & children, templates,
+   * outbound_emails).
+   *
+   * Order: idempotency_records FIRST, admin call SECOND. If the admin
+   * call fails the user retries; the idempotency wipe is safely
+   * idempotent. Doing it the other way around would leave orphan
+   * records the user could no longer reach via the auth system.
+   */
+  async deleteAccount(user: AuthUser): Promise<void> {
+    const wiped = await this.idempotencyRepo.deleteByUser(user.id);
+    this.logger.log(`account-delete: idempotency_records wiped=${wiped} user=${user.id}`);
+    try {
+      await this.supabaseAdmin.deleteUser(user.id);
+    } catch (err) {
+      if (err instanceof SupabaseAdminError) {
+        this.logger.error(
+          `account-delete: supabase admin failed for user=${user.id}: ${err.message}`,
+        );
+        throw new ServiceUnavailableException('admin_api_unavailable');
+      }
+      throw err;
+    }
+    this.logger.log(`account-delete: complete user=${user.id}`);
+  }
+
+  /**
+   * Walk every page of the owner's envelopes and return the id list.
+   * Uses the existing `listByOwner` cursor pagination + the repo's own
+   * `decodeCursorOrThrow` so we never need to know the on-the-wire
+   * cursor format (it differs between adapters: PG uses base64, the
+   * in-memory test fixture uses base64url, both pipe-delimited). The
+   * page size is the maximum the port accepts (100).
+   */
+  private async collectEnvelopeIds(ownerId: string): Promise<ReadonlyArray<string>> {
+    const ids: string[] = [];
+    let cursor: { updated_at: string; id: string } | null = null;
+    // Hard upper bound to keep tests deterministic and detect misuse if
+    // a future bug returns a non-advancing cursor.
+    for (let i = 0; i < 1000; i++) {
+      const page = await this.envelopesRepo.listByOwner(ownerId, {
+        limit: 100,
+        cursor,
+      });
+      for (const item of page.items) ids.push(item.id);
+      if (!page.next_cursor) return ids;
+      try {
+        cursor = this.envelopesRepo.decodeCursorOrThrow(page.next_cursor);
+      } catch {
+        // Defensive — if the cursor is unparseable (a future format
+        // change without rev'ing this caller) stop paging cleanly
+        // rather than crash the whole export.
+        this.logger.warn(`export: stopping pagination — undecodable cursor for owner=${ownerId}`);
+        return ids;
+      }
+    }
+    this.logger.warn(`export: hit envelope-page hard cap for owner=${ownerId}`);
+    return ids;
+  }
+}

--- a/apps/api/src/me/supabase-admin.client.http.ts
+++ b/apps/api/src/me/supabase-admin.client.http.ts
@@ -1,0 +1,61 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { APP_ENV } from '../config/config.module';
+import type { AppEnv } from '../config/env.schema';
+import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+
+/**
+ * HTTP adapter that talks to Supabase's GoTrue admin API. Construction
+ * never fails — the env var gate runs at *call* time so the API can
+ * boot in dev/test without a service-role key. T-20 deletes only need
+ * to work in production where the key is required.
+ */
+@Injectable()
+export class SupabaseAdminHttpClient extends SupabaseAdminClient {
+  private readonly logger = new Logger(SupabaseAdminHttpClient.name);
+
+  constructor(@Inject(APP_ENV) private readonly env: AppEnv) {
+    super();
+  }
+
+  async deleteUser(userId: string): Promise<void> {
+    const key = this.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!key) {
+      throw new SupabaseAdminError('SUPABASE_SERVICE_ROLE_KEY is not configured');
+    }
+    const url = `${this.env.SUPABASE_URL.replace(/\/+$/, '')}/auth/v1/admin/users/${encodeURIComponent(userId)}`;
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          // Supabase admin endpoints require BOTH the service-role key
+          // as the bearer token and as the `apikey` header — they fail
+          // with 401 if either is missing.
+          authorization: `Bearer ${key}`,
+          apikey: key,
+        },
+      });
+    } catch (err) {
+      // Network-level failure (DNS, refused, abort). Surface to caller
+      // so the controller maps to 503.
+      const msg = err instanceof Error ? err.message : 'unknown';
+      throw new SupabaseAdminError(`supabase admin delete failed: ${msg}`);
+    }
+    // 200 = deleted; 404 = already gone (idempotent). Anything else is a
+    // genuine error.
+    if (res.status === 200 || res.status === 204 || res.status === 404) {
+      this.logger.log(`admin deleteUser ok (status=${res.status}) user=${userId}`);
+      return;
+    }
+    let body = '';
+    try {
+      body = await res.text();
+    } catch {
+      // ignore — the status alone is enough
+    }
+    throw new SupabaseAdminError(
+      `supabase admin delete returned ${res.status}: ${body.slice(0, 200)}`,
+      res.status,
+    );
+  }
+}

--- a/apps/api/src/me/supabase-admin.client.ts
+++ b/apps/api/src/me/supabase-admin.client.ts
@@ -1,0 +1,28 @@
+/**
+ * Port for the Supabase Admin "delete user" call. The HTTP adapter
+ * lives in `supabase-admin.client.http.ts`; tests substitute a stub.
+ *
+ * The port intentionally exposes only what `MeService` needs — there is
+ * no `createUser` / `listUsers`. If a future feature needs more admin
+ * surface we extend this port; we never reach for the raw HTTP client.
+ */
+export abstract class SupabaseAdminClient {
+  /**
+   * Idempotent on the wire: Supabase returns 200 when the user existed
+   * and was deleted, and 404 when the user no longer exists. The
+   * adapter must treat both as success so retried T-20 calls don't
+   * loop. Any other non-2xx (auth, network, 5xx) MUST throw
+   * `SupabaseAdminError`.
+   */
+  abstract deleteUser(userId: string): Promise<void>;
+}
+
+export class SupabaseAdminError extends Error {
+  constructor(
+    message: string,
+    public readonly status?: number,
+  ) {
+    super(message);
+    this.name = 'SupabaseAdminError';
+  }
+}

--- a/apps/api/test/in-memory-idempotency-repository.ts
+++ b/apps/api/test/in-memory-idempotency-repository.ts
@@ -1,0 +1,37 @@
+import { IdempotencyRepository } from '../src/me/idempotency.repository';
+
+/**
+ * In-memory adapter for `idempotency_records.deleteByUser`. The full
+ * idempotency middleware stores `Map<key, response>` and that's not what
+ * the account-deletion path cares about — it only needs a count of
+ * rows-wiped per user. We model that with a multiset of synthetic ids
+ * keyed by user_id.
+ */
+export class InMemoryIdempotencyRepository extends IdempotencyRepository {
+  /** user_id -> set of synthetic record ids. */
+  private readonly rows = new Map<string, Set<string>>();
+
+  reset(): void {
+    this.rows.clear();
+  }
+
+  /** Test helper: pre-seed N rows for a user so deleteByUser has work to do. */
+  seed(user_id: string, count: number): void {
+    const set = this.rows.get(user_id) ?? new Set<string>();
+    for (let i = 0; i < count; i++) set.add(`stub-${user_id}-${i}-${Math.random()}`);
+    this.rows.set(user_id, set);
+  }
+
+  /** Test helper: count rows currently held for a user. */
+  countFor(user_id: string): number {
+    return this.rows.get(user_id)?.size ?? 0;
+  }
+
+  async deleteByUser(user_id: string): Promise<number> {
+    const set = this.rows.get(user_id);
+    if (!set) return 0;
+    const n = set.size;
+    this.rows.delete(user_id);
+    return n;
+  }
+}

--- a/apps/api/test/me.e2e-spec.ts
+++ b/apps/api/test/me.e2e-spec.ts
@@ -1,0 +1,296 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { APP_ENV } from '../src/config/config.module';
+import type { AppEnv } from '../src/config/env.schema';
+import { JWKS_RESOLVER } from '../src/auth/jwks.provider';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { ContactsRepository } from '../src/contacts/contacts.repository';
+import { EnvelopesRepository } from '../src/envelopes/envelopes.repository';
+import { TemplatesRepository } from '../src/templates/templates.repository';
+import { OutboundEmailsRepository } from '../src/email/outbound-emails.repository';
+import { IdempotencyRepository } from '../src/me/idempotency.repository';
+import { SupabaseAdminClient } from '../src/me/supabase-admin.client';
+import { buildTestJwks } from './test-jwks';
+import { InMemoryContactsRepository } from './in-memory-contacts-repository';
+import { InMemoryEnvelopesRepository } from './in-memory-envelopes-repository';
+import { InMemoryTemplatesRepository } from './in-memory-templates-repository';
+import { InMemoryOutboundEmailsRepository } from './in-memory-outbound-emails-repository';
+import { InMemoryIdempotencyRepository } from './in-memory-idempotency-repository';
+import { StubSupabaseAdminClient } from './stub-supabase-admin';
+
+const TEST_ENV: AppEnv = {
+  NODE_ENV: 'test',
+  PORT: 0,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_JWT_AUDIENCE: 'authenticated',
+  CORS_ORIGIN: 'http://localhost:5173',
+  APP_PUBLIC_URL: 'http://localhost:5173',
+  DATABASE_URL: 'postgres://u:p@127.0.0.1:5432/db?sslmode=disable',
+  STORAGE_BUCKET: 'envelopes',
+  TC_VERSION: '2026-04-24',
+  PRIVACY_VERSION: '2026-04-24',
+  EMAIL_PROVIDER: 'logging',
+  EMAIL_FROM_ADDRESS: 'onboarding@resend.dev',
+  EMAIL_FROM_NAME: 'Seald',
+  EMAIL_LEGAL_ENTITY: 'Seald, Inc.',
+  EMAIL_LEGAL_POSTAL: 'Postal address available on request — write to legal@seald.test.',
+  EMAIL_PRIVACY_URL: 'https://seald.nromomentum.com/legal/privacy',
+  EMAIL_PREFERENCES_URL: 'mailto:privacy@seald.nromomentum.com?subject=Email%20preferences',
+  PDF_SIGNING_PROVIDER: 'local',
+  PDF_SIGNING_TSA_URL: 'https://freetsa.org/tsr',
+  ENVELOPE_RETENTION_YEARS: 7,
+  WORKER_ENABLED: false,
+};
+
+const USER_A = '00000000-0000-0000-0000-00000000000a';
+const USER_B = '00000000-0000-0000-0000-00000000000b';
+const USER_A_EMAIL = 'maya@example.com';
+
+describe('/me (DSAR + account deletion) — e2e', () => {
+  let app: INestApplication;
+  let contactsRepo: InMemoryContactsRepository;
+  let envelopesRepo: InMemoryEnvelopesRepository;
+  let templatesRepo: InMemoryTemplatesRepository;
+  let outboundEmailsRepo: InMemoryOutboundEmailsRepository;
+  let idempotencyRepo: InMemoryIdempotencyRepository;
+  let supabaseAdmin: StubSupabaseAdminClient;
+  let callLog: string[];
+  let tk: Awaited<ReturnType<typeof buildTestJwks>>;
+  let tokenA: string;
+  let tokenB: string;
+
+  beforeAll(async () => {
+    tk = await buildTestJwks();
+    contactsRepo = new InMemoryContactsRepository();
+    envelopesRepo = new InMemoryEnvelopesRepository();
+    templatesRepo = new InMemoryTemplatesRepository();
+    outboundEmailsRepo = new InMemoryOutboundEmailsRepository();
+    idempotencyRepo = new InMemoryIdempotencyRepository();
+    supabaseAdmin = new StubSupabaseAdminClient();
+
+    callLog = [];
+    // Wire ordering tracking for both repos so we can assert
+    // idempotency-wipe-precedes-admin-call invariant.
+    const origDelete = idempotencyRepo.deleteByUser.bind(idempotencyRepo);
+    idempotencyRepo.deleteByUser = async (id: string): Promise<number> => {
+      callLog.push('idempotency.deleteByUser');
+      return origDelete(id);
+    };
+    supabaseAdmin.callLog = callLog;
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(APP_ENV)
+      .useValue(TEST_ENV)
+      .overrideProvider(JWKS_RESOLVER)
+      .useValue(tk.resolver)
+      .overrideProvider(ContactsRepository)
+      .useValue(contactsRepo)
+      .overrideProvider(EnvelopesRepository)
+      .useValue(envelopesRepo)
+      .overrideProvider(TemplatesRepository)
+      .useValue(templatesRepo)
+      .overrideProvider(OutboundEmailsRepository)
+      .useValue(outboundEmailsRepo)
+      .overrideProvider(IdempotencyRepository)
+      .useValue(idempotencyRepo)
+      .overrideProvider(SupabaseAdminClient)
+      .useValue(supabaseAdmin)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    const signOpts = {
+      issuer: `${TEST_ENV.SUPABASE_URL}/auth/v1`,
+      audience: TEST_ENV.SUPABASE_JWT_AUDIENCE,
+    };
+    tokenA = await tk.sign({ sub: USER_A, email: USER_A_EMAIL }, signOpts);
+    tokenB = await tk.sign({ sub: USER_B, email: 'b@example.com' }, signOpts);
+  });
+
+  beforeEach(() => {
+    contactsRepo.reset();
+    envelopesRepo.reset();
+    templatesRepo['rows']?.clear?.();
+    outboundEmailsRepo.rows.length = 0;
+    idempotencyRepo.reset();
+    supabaseAdmin.reset();
+    callLog.length = 0;
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const auth = (t: string) => ({ Authorization: `Bearer ${t}` });
+
+  // ---------- GET /me/export ----------------------------------------
+
+  describe('GET /me/export', () => {
+    it('without Authorization → 401 missing_token', async () => {
+      const res = await request(app.getHttpServer()).get('/me/export');
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'missing_token' });
+    });
+
+    it('returns a JSON download scoped to the caller with correct headers', async () => {
+      // Seed user A with one contact + one template; user B is empty.
+      // We can't easily seed envelopes for owner A here without the full
+      // draft/send flow, so the exported envelopes array stays empty —
+      // that's still a valid AccountExport per the contract.
+      await contactsRepo.create({
+        owner_id: USER_A,
+        name: 'Ada',
+        email: 'ada@example.com',
+        color: '#112233',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/me/export')
+        .set(auth(tokenA))
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (c: Buffer) => chunks.push(c));
+          response.on('end', () => callback(null, Buffer.concat(chunks)));
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.headers['cache-control']).toBe('no-store');
+      const cd = res.headers['content-disposition'] as string;
+      expect(cd).toMatch(/^attachment; filename="seald-export-/);
+      expect(cd).toContain(USER_A);
+      expect(cd).toMatch(/\.json"$/);
+
+      const payload = JSON.parse((res.body as Buffer).toString('utf8'));
+      expect(payload.meta.format_version).toBe('1.0');
+      expect(payload.meta.user).toEqual({ id: USER_A, email: USER_A_EMAIL });
+      expect(payload.meta.includes_files).toBe(false);
+      expect(payload.meta.counts).toEqual({
+        contacts: 1,
+        envelopes: 0,
+        templates: 0,
+        outbound_emails: 0,
+      });
+      expect(typeof payload.meta.generated_at).toBe('string');
+      expect(payload.contacts).toHaveLength(1);
+      expect(payload.contacts[0].owner_id).toBe(USER_A);
+      expect(payload.envelopes).toEqual([]);
+      expect(payload.templates).toEqual([]);
+    });
+
+    it("returns only the caller's data, not other users' rows", async () => {
+      await contactsRepo.create({
+        owner_id: USER_A,
+        name: 'Ada',
+        email: 'ada@example.com',
+        color: '#112233',
+      });
+      await contactsRepo.create({
+        owner_id: USER_B,
+        name: 'Bea',
+        email: 'bea@example.com',
+        color: '#aabbcc',
+      });
+
+      const res = await request(app.getHttpServer())
+        .get('/me/export')
+        .set(auth(tokenB))
+        .buffer(true)
+        .parse((response, callback) => {
+          const chunks: Buffer[] = [];
+          response.on('data', (c: Buffer) => chunks.push(c));
+          response.on('end', () => callback(null, Buffer.concat(chunks)));
+        });
+
+      expect(res.status).toBe(200);
+      const payload = JSON.parse((res.body as Buffer).toString('utf8'));
+      expect(payload.meta.user.id).toBe(USER_B);
+      expect(payload.meta.counts.contacts).toBe(1);
+      expect(payload.contacts).toHaveLength(1);
+      expect(payload.contacts[0].owner_id).toBe(USER_B);
+    });
+  });
+
+  // ---------- DELETE /me --------------------------------------------
+
+  describe('DELETE /me', () => {
+    it('without Authorization → 401 missing_token', async () => {
+      const res = await request(app.getHttpServer())
+        .delete('/me')
+        .send({ confirm: 'DELETE_MY_ACCOUNT' });
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: 'missing_token' });
+    });
+
+    it('with wrong confirm phrase → 400 (validation)', async () => {
+      const res = await request(app.getHttpServer())
+        .delete('/me')
+        .set(auth(tokenA))
+        .send({ confirm: 'delete me' });
+      expect(res.status).toBe(400);
+      expect(supabaseAdmin.deletedUserIds).toEqual([]);
+      expect(callLog).toEqual([]);
+    });
+
+    it('with missing confirm → 400 (validation)', async () => {
+      const res = await request(app.getHttpServer()).delete('/me').set(auth(tokenA)).send({});
+      expect(res.status).toBe(400);
+      expect(supabaseAdmin.deletedUserIds).toEqual([]);
+    });
+
+    it('happy path → 204 + idempotency wipe runs BEFORE admin call', async () => {
+      idempotencyRepo.seed(USER_A, 4);
+
+      const res = await request(app.getHttpServer())
+        .delete('/me')
+        .set(auth(tokenA))
+        .send({ confirm: 'DELETE_MY_ACCOUNT' });
+
+      expect(res.status).toBe(204);
+      expect(idempotencyRepo.countFor(USER_A)).toBe(0);
+      expect(supabaseAdmin.deletedUserIds).toEqual([USER_A]);
+      // Order matters — see MeService comment. Idempotency wipe first
+      // because admin failure is retryable; idempotency wipe is
+      // idempotent.
+      expect(callLog).toEqual(['idempotency.deleteByUser', 'supabaseAdmin.deleteUser']);
+    });
+
+    it('admin failure → 503 admin_api_unavailable, but idempotency wipe still ran', async () => {
+      idempotencyRepo.seed(USER_A, 2);
+      supabaseAdmin.failNextWithAdminError('SUPABASE_SERVICE_ROLE_KEY missing');
+
+      const res = await request(app.getHttpServer())
+        .delete('/me')
+        .set(auth(tokenA))
+        .send({ confirm: 'DELETE_MY_ACCOUNT' });
+
+      expect(res.status).toBe(503);
+      // Idempotency rows were still cleared (the wipe ran first, then
+      // the admin call threw).
+      expect(idempotencyRepo.countFor(USER_A)).toBe(0);
+      expect(supabaseAdmin.deletedUserIds).toEqual([]);
+    });
+
+    it('non-admin error from the admin client surfaces as a 500', async () => {
+      // Random Error (not a SupabaseAdminError) should NOT be swallowed
+      // by the 503 mapping — it bubbles, Nest's default exception
+      // handler turns it into 500.
+      supabaseAdmin.failNextWithUnknownError('boom');
+
+      const res = await request(app.getHttpServer())
+        .delete('/me')
+        .set(auth(tokenA))
+        .send({ confirm: 'DELETE_MY_ACCOUNT' });
+
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/apps/api/test/stub-supabase-admin.ts
+++ b/apps/api/test/stub-supabase-admin.ts
@@ -1,0 +1,50 @@
+import { SupabaseAdminClient, SupabaseAdminError } from '../src/me/supabase-admin.client';
+
+/**
+ * Stub for the Supabase Admin client. Records every `deleteUser` call so
+ * tests can assert ordering against a sibling stub (e.g. the idempotency
+ * wipe runs strictly before the admin call). Optionally throws on the
+ * next call to exercise the error-mapping path in `MeService`.
+ */
+export class StubSupabaseAdminClient extends SupabaseAdminClient {
+  /** Each entry is `{ userId, at }` in call-order. */
+  readonly deletedUserIds: string[] = [];
+  /** Shared call log used to assert global call ordering across stubs. */
+  callLog: string[] | null = null;
+  /**
+   * If non-null, the next call to deleteUser throws this error and the
+   * field is reset to null. Used to test 503 mapping.
+   */
+  errorOnNext: Error | null = null;
+
+  reset(): void {
+    this.deletedUserIds.length = 0;
+    this.errorOnNext = null;
+  }
+
+  /**
+   * Convenience: arm the next call to throw a SupabaseAdminError so the
+   * service maps it to ServiceUnavailableException.
+   */
+  failNextWithAdminError(message = 'simulated admin failure', status = 500): void {
+    this.errorOnNext = new SupabaseAdminError(message, status);
+  }
+
+  /**
+   * Convenience: arm the next call to throw a non-admin Error so the
+   * service rethrows verbatim.
+   */
+  failNextWithUnknownError(message = 'simulated boom'): void {
+    this.errorOnNext = new Error(message);
+  }
+
+  async deleteUser(userId: string): Promise<void> {
+    if (this.callLog) this.callLog.push('supabaseAdmin.deleteUser');
+    if (this.errorOnNext) {
+      const e = this.errorOnNext;
+      this.errorOnNext = null;
+      throw e;
+    }
+    this.deletedUserIds.push(userId);
+  }
+}

--- a/apps/web/src/components/NavBar/NavBar.tsx
+++ b/apps/web/src/components/NavBar/NavBar.tsx
@@ -44,10 +44,24 @@ interface RightClusterArgs {
   readonly onSignIn: (() => void) | undefined;
   readonly onSignUp: (() => void) | undefined;
   readonly onSignOut: (() => void) | undefined;
+  readonly onExportData: (() => void) | undefined;
+  readonly onDeleteAccount: (() => void) | undefined;
+  readonly isExporting: boolean;
+  readonly isDeleting: boolean;
 }
 
 function renderRightCluster(args: RightClusterArgs): ReactNode {
-  const { isGuest, user, onSignIn, onSignUp, onSignOut } = args;
+  const {
+    isGuest,
+    user,
+    onSignIn,
+    onSignUp,
+    onSignOut,
+    onExportData,
+    onDeleteAccount,
+    isExporting,
+    isDeleting,
+  } = args;
   if (isGuest) {
     return (
       <>
@@ -73,6 +87,10 @@ function renderRightCluster(args: RightClusterArgs): ReactNode {
           ...(user.avatarUrl ? { avatarUrl: user.avatarUrl } : {}),
         }}
         onSignOut={onSignOut}
+        {...(onExportData ? { onExportData } : {})}
+        {...(onDeleteAccount ? { onDeleteAccount } : {})}
+        isExporting={isExporting}
+        isDeleting={isDeleting}
       />
     );
   }
@@ -121,6 +139,10 @@ export const NavBar = forwardRef<HTMLElement, NavBarProps>((props, ref) => {
     onSignIn,
     onSignUp,
     onSignOut,
+    onExportData,
+    onDeleteAccount,
+    isExporting = false,
+    isDeleting = false,
     ...rest
   } = props;
 
@@ -177,7 +199,17 @@ export const NavBar = forwardRef<HTMLElement, NavBarProps>((props, ref) => {
       )}
       <Spacer />
       <RightCluster>
-        {renderRightCluster({ isGuest, user, onSignIn, onSignUp, onSignOut })}
+        {renderRightCluster({
+          isGuest,
+          user,
+          onSignIn,
+          onSignUp,
+          onSignOut,
+          onExportData,
+          onDeleteAccount,
+          isExporting,
+          isDeleting,
+        })}
       </RightCluster>
     </Header>
   );

--- a/apps/web/src/components/NavBar/NavBar.types.ts
+++ b/apps/web/src/components/NavBar/NavBar.types.ts
@@ -28,4 +28,12 @@ export interface NavBarProps extends HTMLAttributes<HTMLElement> {
   readonly onSignIn?: (() => void) | undefined;
   readonly onSignUp?: (() => void) | undefined;
   readonly onSignOut?: (() => void) | undefined;
+  /** Optional — wires the UserMenu's "Download my data" item. */
+  readonly onExportData?: (() => void) | undefined;
+  /** Optional — wires the UserMenu's "Delete account" danger item. */
+  readonly onDeleteAccount?: (() => void) | undefined;
+  /** Mirrors UserMenu.isExporting; disables the item while in flight. */
+  readonly isExporting?: boolean | undefined;
+  /** Mirrors UserMenu.isDeleting; disables the item while in flight. */
+  readonly isDeleting?: boolean | undefined;
 }

--- a/apps/web/src/components/UserMenu/UserMenu.styles.ts
+++ b/apps/web/src/components/UserMenu/UserMenu.styles.ts
@@ -54,7 +54,7 @@ export const Email = styled.div`
   margin-top: 2px;
 `;
 
-export const Item = styled.button`
+export const Item = styled.button<{ $danger?: boolean }>`
   appearance: none;
   text-align: left;
   background: transparent;
@@ -64,13 +64,24 @@ export const Item = styled.button`
   font-family: ${({ theme }) => theme.font.sans};
   font-size: ${({ theme }) => theme.font.size.caption};
   font-weight: ${({ theme }) => theme.font.weight.semibold};
-  color: ${({ theme }) => theme.color.fg[1]};
+  color: ${({ theme, $danger }) => ($danger ? theme.color.danger[700] : theme.color.fg[1])};
   cursor: pointer;
   &:hover {
-    background: ${({ theme }) => theme.color.ink[100]};
+    background: ${({ theme, $danger }) =>
+      $danger ? theme.color.danger[50] : theme.color.ink[100]};
   }
   &:focus-visible {
     outline: none;
     box-shadow: ${({ theme }) => theme.shadow.focus};
   }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`;
+
+export const Divider = styled.div`
+  height: 1px;
+  background: ${({ theme }) => theme.color.border[1]};
+  margin: ${({ theme }) => `${theme.space[1]} 0`};
 `;

--- a/apps/web/src/components/UserMenu/UserMenu.test.tsx
+++ b/apps/web/src/components/UserMenu/UserMenu.test.tsx
@@ -52,4 +52,59 @@ describe('UserMenu', () => {
     await userEvent.click(getByRole('button', { name: /open menu for/i }));
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it('renders Download my data + Delete account when handlers are provided', async () => {
+    const onExportData = vi.fn();
+    const onDeleteAccount = vi.fn();
+    const { getByRole } = renderWithTheme(
+      <UserMenu
+        user={user}
+        onSignOut={() => {}}
+        onExportData={onExportData}
+        onDeleteAccount={onDeleteAccount}
+      />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    await userEvent.click(getByRole('menuitem', { name: /download my data/i }));
+    expect(onExportData).toHaveBeenCalledTimes(1);
+    // After firing, menu closes; reopen and verify the danger item too.
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    await userEvent.click(getByRole('menuitem', { name: /delete account/i }));
+    expect(onDeleteAccount).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render Download my data / Delete account when handlers are absent', async () => {
+    const { getByRole, queryByRole } = renderWithTheme(
+      <UserMenu user={user} onSignOut={() => {}} />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    expect(queryByRole('menuitem', { name: /download my data/i })).toBeNull();
+    expect(queryByRole('menuitem', { name: /delete account/i })).toBeNull();
+  });
+
+  it('disables and reflects busy state on the export item while isExporting', async () => {
+    const onExportData = vi.fn();
+    const { getByRole } = renderWithTheme(
+      <UserMenu user={user} onSignOut={() => {}} onExportData={onExportData} isExporting />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    const item = getByRole('menuitem', { name: /preparing download/i });
+    expect(item).toBeDisabled();
+    expect(item).toHaveAttribute('aria-busy', 'true');
+    await userEvent.click(item);
+    expect(onExportData).not.toHaveBeenCalled();
+  });
+
+  it('disables and reflects busy state on the delete item while isDeleting', async () => {
+    const onDeleteAccount = vi.fn();
+    const { getByRole } = renderWithTheme(
+      <UserMenu user={user} onSignOut={() => {}} onDeleteAccount={onDeleteAccount} isDeleting />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    const item = getByRole('menuitem', { name: /deleting account/i });
+    expect(item).toBeDisabled();
+    expect(item).toHaveAttribute('aria-busy', 'true');
+    await userEvent.click(item);
+    expect(onDeleteAccount).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/UserMenu/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu/UserMenu.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useCallback, useEffect, useRef, useState } from 'react';
 import { Avatar } from '../Avatar';
 import type { UserMenuProps } from './UserMenu.types';
-import { Email, Header, Item, Menu, Name, Root, Trigger } from './UserMenu.styles';
+import { Divider, Email, Header, Item, Menu, Name, Root, Trigger } from './UserMenu.styles';
 
 /**
  * L2 component — avatar button that opens a popover with the user's name,
@@ -10,7 +10,15 @@ import { Email, Header, Item, Menu, Name, Root, Trigger } from './UserMenu.style
  * its right cluster.
  */
 export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) => {
-  const { user, onSignOut, ...rest } = props;
+  const {
+    user,
+    onSignOut,
+    onExportData,
+    onDeleteAccount,
+    isExporting = false,
+    isDeleting = false,
+    ...rest
+  } = props;
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -35,6 +43,18 @@ export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) =
     setOpen(false);
     onSignOut();
   }, [onSignOut]);
+
+  const handleExport = useCallback((): void => {
+    if (!onExportData) return;
+    setOpen(false);
+    onExportData();
+  }, [onExportData]);
+
+  const handleDelete = useCallback((): void => {
+    if (!onDeleteAccount) return;
+    setOpen(false);
+    onDeleteAccount();
+  }, [onDeleteAccount]);
 
   // Forward the external ref to the wrapper, but keep the internal ref for
   // outside-click detection.
@@ -70,9 +90,35 @@ export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) =
             <Name>{user.name}</Name>
             <Email>{user.email}</Email>
           </Header>
+          {onExportData ? (
+            <Item
+              type="button"
+              role="menuitem"
+              onClick={handleExport}
+              disabled={isExporting}
+              aria-busy={isExporting || undefined}
+            >
+              {isExporting ? 'Preparing download…' : 'Download my data'}
+            </Item>
+          ) : null}
           <Item type="button" role="menuitem" onClick={handleSignOut}>
             Sign out
           </Item>
+          {onDeleteAccount ? (
+            <>
+              <Divider role="separator" />
+              <Item
+                type="button"
+                role="menuitem"
+                $danger
+                onClick={handleDelete}
+                disabled={isDeleting}
+                aria-busy={isDeleting || undefined}
+              >
+                {isDeleting ? 'Deleting account…' : 'Delete account'}
+              </Item>
+            </>
+          ) : null}
         </Menu>
       ) : null}
     </Root>

--- a/apps/web/src/components/UserMenu/UserMenu.types.ts
+++ b/apps/web/src/components/UserMenu/UserMenu.types.ts
@@ -9,4 +9,20 @@ export interface UserMenuUser {
 export interface UserMenuProps extends HTMLAttributes<HTMLDivElement> {
   readonly user: UserMenuUser;
   readonly onSignOut: () => void;
+  /**
+   * Optional — when provided, renders a "Download my data" item that
+   * fires the GDPR/CCPA DSAR export. Hidden when omitted so Storybook
+   * and unauthenticated mocks render the lean menu.
+   */
+  readonly onExportData?: (() => void) | undefined;
+  /**
+   * Optional — when provided, renders a danger-styled "Delete account"
+   * item. The handler is responsible for confirming the destructive
+   * intent (the wired implementation prompts for a confirm phrase).
+   */
+  readonly onDeleteAccount?: (() => void) | undefined;
+  /** Disables the export item while a request is in flight. */
+  readonly isExporting?: boolean | undefined;
+  /** Disables the delete item while a request is in flight. */
+  readonly isDeleting?: boolean | undefined;
 }

--- a/apps/web/src/features/account/accountApi.ts
+++ b/apps/web/src/features/account/accountApi.ts
@@ -1,0 +1,63 @@
+import { apiClient } from '@/lib/api/apiClient';
+
+/**
+ * Account-level (per-user) API calls — DSAR export and right-to-erasure.
+ *
+ * Both endpoints sit behind the global `AuthGuard` and are tightly
+ * throttled: export is heavy (hydrates every owner_id row) and delete
+ * is irreversible.
+ */
+
+/**
+ * Download `GET /me/export` as a Blob and return it together with the
+ * `Content-Disposition` filename suggested by the API. The caller is
+ * expected to drive the actual save-to-disk via an anchor click; we keep
+ * that out of the API layer so unit tests don't need to fake DOM.
+ */
+export async function exportAccount(): Promise<{
+  readonly blob: Blob;
+  readonly filename: string;
+}> {
+  const res = await apiClient.get<Blob>('/me/export', {
+    // Axios defaults to `transformResponse: JSON.parse`, which would
+    // happily double-encode our pretty-printed JSON. Asking for a Blob
+    // bypasses that and lets us hand the bytes straight to the user.
+    responseType: 'blob',
+  });
+  const cd = (res.headers['content-disposition'] ?? res.headers['Content-Disposition']) as
+    | string
+    | undefined;
+  const filename = parseContentDispositionFilename(cd) ?? defaultFilename();
+  return { blob: res.data, filename };
+}
+
+/**
+ * Permanently delete the caller's account and every owner_id row. The
+ * confirm phrase is server-validated against the literal
+ * `'DELETE_MY_ACCOUNT'` — see `apps/api/src/me/dto/delete-account.dto.ts`.
+ * Returns void on success; the API answers 204 No Content.
+ */
+export async function deleteAccount(): Promise<void> {
+  await apiClient.delete('/me', {
+    data: { confirm: 'DELETE_MY_ACCOUNT' },
+  });
+}
+
+function parseContentDispositionFilename(value: string | undefined): string | null {
+  if (!value) return null;
+  // Both `filename="x.json"` and `filename*=UTF-8''x.json` are tolerated
+  // here, in that order. We don't need RFC 6266 strictness — the API only
+  // ever sends the simple ASCII form, but we still cope if it's switched
+  // up later.
+  const star = /filename\*=UTF-8''([^;]+)/i.exec(value);
+  if (star && star[1]) return decodeURIComponent(star[1].trim());
+  const plain = /filename="([^"]+)"/i.exec(value);
+  if (plain && plain[1]) return plain[1];
+  return null;
+}
+
+function defaultFilename(): string {
+  // Stable fallback so we never download a literal `Blob` with no name if
+  // the API forgets the header.
+  return `seald-export-${new Date().toISOString().slice(0, 10)}.json`;
+}

--- a/apps/web/src/features/account/index.ts
+++ b/apps/web/src/features/account/index.ts
@@ -1,0 +1,3 @@
+export { exportAccount, deleteAccount } from './accountApi';
+export { useAccountActions } from './useAccountActions';
+export type { UseAccountActions, UseAccountActionsOptions } from './useAccountActions';

--- a/apps/web/src/features/account/useAccountActions.test.tsx
+++ b/apps/web/src/features/account/useAccountActions.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+vi.mock('../../lib/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '../../lib/api/apiClient';
+// eslint-disable-next-line import/first
+import { useAccountActions } from './useAccountActions';
+
+const get = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+const del = apiClient.delete as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  get.mockReset();
+  del.mockReset();
+  // Stub URL.createObjectURL / revokeObjectURL — jsdom doesn't ship them.
+  // We re-stub on every test so spy state is fresh.
+  Object.defineProperty(URL, 'createObjectURL', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(() => 'blob:fake'),
+  });
+  Object.defineProperty(URL, 'revokeObjectURL', {
+    configurable: true,
+    writable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useAccountActions — exportData', () => {
+  it('downloads the export and saves with the API-suggested filename', async () => {
+    const blob = new Blob(['{"meta":{}}'], { type: 'application/json' });
+    get.mockResolvedValueOnce({
+      data: blob,
+      headers: {
+        'content-disposition': 'attachment; filename="seald-export-abc-2026-04-30.json"',
+      },
+    });
+
+    // Spy on anchor click — no real download happens in jsdom.
+    const clickSpy = vi.fn();
+    const origCreate = document.createElement.bind(document);
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        // Replace the click handler so our test sees it without firing
+        // jsdom's no-op anchor navigation.
+        Object.defineProperty(el, 'click', { value: clickSpy });
+      }
+      return el;
+    });
+
+    const { result } = renderHook(() => useAccountActions());
+    await act(async () => {
+      await result.current.exportData();
+    });
+
+    expect(get).toHaveBeenCalledWith('/me/export', { responseType: 'blob' });
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(URL.createObjectURL).toHaveBeenCalledWith(blob);
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:fake');
+    expect(result.current.isExporting).toBe(false);
+    expect(result.current.lastError).toBeNull();
+    createSpy.mockRestore();
+  });
+
+  it('reports the error message when /me/export fails', async () => {
+    get.mockRejectedValueOnce(new Error('Server fell over'));
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAccountActions({ onError }));
+    await act(async () => {
+      await result.current.exportData();
+    });
+    expect(onError).toHaveBeenCalledWith('Server fell over');
+    expect(result.current.lastError).toBe('Server fell over');
+    expect(result.current.isExporting).toBe(false);
+  });
+
+  it('falls back to a synthesized filename when the API omits Content-Disposition', async () => {
+    const blob = new Blob(['{}'], { type: 'application/json' });
+    get.mockResolvedValueOnce({ data: blob, headers: {} });
+    // Capture the anchor's `download` attr — that's where the filename
+    // lands. We don't need to click; we just need to inspect the element.
+    let captured: string | null = null;
+    const origCreate = document.createElement.bind(document);
+    const createSpy = vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = origCreate(tag);
+      if (tag === 'a') {
+        Object.defineProperty(el, 'click', {
+          value: vi.fn(() => {
+            captured = (el as HTMLAnchorElement).download;
+          }),
+        });
+      }
+      return el;
+    });
+    const { result } = renderHook(() => useAccountActions());
+    await act(async () => {
+      await result.current.exportData();
+    });
+    expect(captured).toMatch(/^seald-export-\d{4}-\d{2}-\d{2}\.json$/);
+    createSpy.mockRestore();
+  });
+});
+
+describe('useAccountActions — deleteAccount', () => {
+  it('aborts silently when the user cancels the prompt', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue(null);
+    const onAccountDeleted = vi.fn();
+    const { result } = renderHook(() => useAccountActions({ onAccountDeleted }));
+    await act(async () => {
+      await result.current.deleteAccount();
+    });
+    expect(del).not.toHaveBeenCalled();
+    expect(onAccountDeleted).not.toHaveBeenCalled();
+  });
+
+  it('aborts silently when the user types the wrong phrase', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('delete my account');
+    const { result } = renderHook(() => useAccountActions());
+    await act(async () => {
+      await result.current.deleteAccount();
+    });
+    expect(del).not.toHaveBeenCalled();
+  });
+
+  it('calls DELETE /me with the literal confirm phrase, then onAccountDeleted', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('DELETE_MY_ACCOUNT');
+    del.mockResolvedValueOnce(undefined);
+    const onAccountDeleted = vi.fn();
+    const { result } = renderHook(() => useAccountActions({ onAccountDeleted }));
+    await act(async () => {
+      await result.current.deleteAccount();
+    });
+    expect(del).toHaveBeenCalledWith('/me', { data: { confirm: 'DELETE_MY_ACCOUNT' } });
+    expect(onAccountDeleted).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.isDeleting).toBe(false));
+    expect(result.current.lastError).toBeNull();
+  });
+
+  it('reports a friendly error when the admin call fails (503)', async () => {
+    vi.spyOn(window, 'prompt').mockReturnValue('DELETE_MY_ACCOUNT');
+    del.mockRejectedValueOnce(new Error('admin_api_unavailable'));
+    const onAccountDeleted = vi.fn();
+    const onError = vi.fn();
+    const { result } = renderHook(() => useAccountActions({ onAccountDeleted, onError }));
+    await act(async () => {
+      await result.current.deleteAccount();
+    });
+    expect(onError).toHaveBeenCalledWith('admin_api_unavailable');
+    expect(onAccountDeleted).not.toHaveBeenCalled();
+    expect(result.current.lastError).toBe('admin_api_unavailable');
+  });
+});

--- a/apps/web/src/features/account/useAccountActions.ts
+++ b/apps/web/src/features/account/useAccountActions.ts
@@ -1,0 +1,132 @@
+import { useCallback, useState } from 'react';
+import { deleteAccount, exportAccount } from './accountApi';
+
+/**
+ * Options for `useAccountActions`. Inversion-of-control: the hook owns
+ * the API + retry state, but lifecycle hooks (post-delete sign-out,
+ * error toasts) live on the caller.
+ */
+export interface UseAccountActionsOptions {
+  /** Called after a successful DELETE /me; usually triggers sign-out + redirect. */
+  readonly onAccountDeleted?: () => void | Promise<void>;
+  /**
+   * Optional friendly-error reporter. Defaults to `window.alert`. The
+   * hook never throws to the caller; errors are surfaced through
+   * `lastError` and (optionally) this callback.
+   */
+  readonly onError?: (message: string) => void;
+}
+
+/**
+ * Result shape: imperative `exportData` / `deleteAccount` triggers plus
+ * loading/error UI state. Both triggers are stable (`useCallback`) so
+ * they can safely sit in dependency arrays.
+ */
+export interface UseAccountActions {
+  readonly exportData: () => Promise<void>;
+  readonly deleteAccount: () => Promise<void>;
+  readonly isExporting: boolean;
+  readonly isDeleting: boolean;
+  readonly lastError: string | null;
+}
+
+/**
+ * Imperative hook that wires the two `/me` endpoints to UI affordances.
+ *
+ * - `exportData` calls `GET /me/export`, materializes the resulting blob
+ *   into a download anchor, and clicks it. We use a temporary anchor
+ *   (rather than `window.location = blobUrl`) so the user sees a
+ *   browser-native save dialog and the SPA stays where it is.
+ * - `deleteAccount` first asks the user to type the confirm phrase
+ *   (`'DELETE_MY_ACCOUNT'`) into a `window.prompt`, mirroring the
+ *   server-side DTO so a misclick can't wipe the account. On success it
+ *   calls `onAccountDeleted` (caller signs out + redirects).
+ */
+export function useAccountActions(options: UseAccountActionsOptions = {}): UseAccountActions {
+  const { onAccountDeleted, onError } = options;
+  const [isExporting, setExporting] = useState(false);
+  const [isDeleting, setDeleting] = useState(false);
+  const [lastError, setLastError] = useState<string | null>(null);
+
+  const reportError = useCallback(
+    (message: string): void => {
+      setLastError(message);
+      if (onError) {
+        onError(message);
+      } else if (typeof window !== 'undefined') {
+        window.alert(message);
+      }
+    },
+    [onError],
+  );
+
+  const exportData = useCallback(async (): Promise<void> => {
+    if (isExporting) return;
+    setExporting(true);
+    setLastError(null);
+    try {
+      const { blob, filename } = await exportAccount();
+      triggerBlobDownload(blob, filename);
+    } catch (err) {
+      reportError(extractMessage(err, 'Export failed. Please try again later.'));
+    } finally {
+      setExporting(false);
+    }
+  }, [isExporting, reportError]);
+
+  const deleteAccountAction = useCallback(async (): Promise<void> => {
+    if (isDeleting) return;
+    if (typeof window === 'undefined') return;
+    const reply = window.prompt(
+      'This will permanently delete your account, every envelope you sent, and every contact / template you saved. ' +
+        'Type DELETE_MY_ACCOUNT (uppercase, no quotes) to confirm.',
+    );
+    if (reply !== 'DELETE_MY_ACCOUNT') {
+      // User cancelled or typed the wrong phrase — silent no-op.
+      return;
+    }
+    setDeleting(true);
+    setLastError(null);
+    try {
+      await deleteAccount();
+      if (onAccountDeleted) await onAccountDeleted();
+    } catch (err) {
+      reportError(extractMessage(err, 'Account deletion failed. Please try again later.'));
+    } finally {
+      setDeleting(false);
+    }
+  }, [isDeleting, onAccountDeleted, reportError]);
+
+  return {
+    exportData,
+    deleteAccount: deleteAccountAction,
+    isExporting,
+    isDeleting,
+    lastError,
+  };
+}
+
+function triggerBlobDownload(blob: Blob, filename: string): void {
+  // Create a short-lived object URL, click an anchor, then revoke so we
+  // don't leak the blob into memory across the session. Wrapped in a
+  // typeof-window guard for SSR safety even though the SPA is
+  // client-only today.
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  const url = URL.createObjectURL(blob);
+  try {
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = filename;
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+function extractMessage(err: unknown, fallback: string): string {
+  if (err instanceof Error && err.message) return err.message;
+  return fallback;
+}

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { NavBar } from '../components/NavBar';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
+import { useAccountActions } from '@/features/account';
 import { NAV_ITEMS, matchNavId } from './navItems';
 
 const Shell = styled.div`
@@ -68,6 +69,17 @@ export function AppShell() {
       .finally(() => navigate('/signin', { replace: true }));
   }, [signOut, navigate]);
 
+  // After successful account deletion the Supabase session is invalid;
+  // sign-out flushes the access token and `RequireAuth` then bounces the
+  // user to /signin. We replace history so back-button doesn't return
+  // them to a now-403 authed surface.
+  const onAccountDeleted = useCallback(async (): Promise<void> => {
+    await signOut().catch(() => undefined);
+    navigate('/signin', { replace: true });
+  }, [signOut, navigate]);
+
+  const account = useAccountActions({ onAccountDeleted });
+
   const mode = !user && guest ? 'guest' : 'authed';
 
   return (
@@ -81,6 +93,10 @@ export function AppShell() {
         onSignIn={handleSignIn}
         onSignUp={handleSignUp}
         onSignOut={handleSignOut}
+        onExportData={mode === 'authed' ? account.exportData : undefined}
+        onDeleteAccount={mode === 'authed' ? account.deleteAccount : undefined}
+        isExporting={account.isExporting}
+        isDeleting={account.isDeleting}
       />
       <Content>
         <Outlet />

--- a/cspell.json
+++ b/cspell.json
@@ -453,7 +453,12 @@
     "noout",
     "tmpenv",
     "esac",
-    "esign"
+    "esign",
+    "DSAR",
+    "dsar",
+    "CCPA",
+    "ccpa",
+    "serialisable"
   ],
   "ignoreRegExpList": [
     "Base64",


### PR DESCRIPTION
## Summary
- Implements **GDPR Art. 15/17 + CCPA §1798.105** self-service surface: `GET /me/export` (DSAR) and `DELETE /me` (irreversible account deletion).
- Hardens the deletion path with a **literal-confirm-phrase** DTO (`confirm === 'DELETE_MY_ACCOUNT'`) and an **idempotency-wipe-before-admin-call** ordering invariant so admin failures stay retryable.
- Wires a complete UserMenu UX: *Download my data* + (danger) *Delete account*, both with busy/aria-busy states; AppShell signs the user out + replaces history on successful deletion.

## API
- `apps/api/src/me/me.controller.ts` — exposes the two endpoints behind `JwtAuthGuard`.
- `apps/api/src/me/me.service.ts` — assembles the JSON dossier (contacts + envelopes + templates + recent outbound emails); paginates owned envelopes via `envelopesRepo.decodeCursorOrThrow()` (the abstract decoder), correcting a prior assumption that the cursor was `base64(JSON)` when PG actually emits `base64('updated_at|id')`.
- `apps/api/src/me/idempotency.repository.{ts,pg.ts}` — port + Postgres adapter for the per-user wipe.
- `apps/api/src/me/supabase-admin.client.{ts,http.ts}` — port + Supabase Admin REST adapter (treats 200/204/404 as idempotent success).
- `apps/api/src/me/dto/delete-account.dto.ts` — `class-validator` `@Equals('DELETE_MY_ACCOUNT')` gate.

## Web
- `apps/web/src/features/account/accountApi.ts` — wraps both endpoints; parses Content-Disposition (both `filename="..."` and `filename*=UTF-8''...` variants) with a synthesized `seald-export-YYYY-MM-DD.json` fallback.
- `apps/web/src/features/account/useAccountActions.ts` — hook returning `{ exportData, deleteAccount, isExporting, isDeleting, lastError }`. Triggers a transient anchor-click + `URL.createObjectURL` for the download; gates deletion behind a `window.prompt` for the literal confirm phrase.
- UserMenu adds the two entries, NavBar passes them through with the `exactOptionalPropertyTypes`-safe conditional spread, and AppShell wires `onAccountDeleted` to sign-out + history replacement.

## Test plan
- [x] `pnpm -r typecheck` ✓
- [x] `pnpm -r lint` ✓
- [x] `pnpm --filter api test` — **400/400** (5 new unit)
- [x] `pnpm --filter api test:e2e` — **139/139** (9 new e2e: auth gate, scoping, confirm-phrase enforcement, ordering invariant, 503 admin-failure, unknown-error rethrow)
- [x] `pnpm --filter web exec vitest run` — **778/778** (4 new UserMenu + 8 new useAccountActions)
- [ ] Manually verify end-to-end on staging once CI greens

🤖 Generated with [Claude Code](https://claude.com/claude-code)