### PR TITLE
feat(phase7): a11y surface + signup age gate + vulnerability disclosure (T-17/T-24/T-25)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security Policy
+
+If you believe you've found a security vulnerability in **Seald** — the
+website, the API, the signing experience, or the cryptographic seal we
+issue — please tell us. We treat security reports as the highest
+priority interrupt.
+
+## How to report
+
+- **Email:** [security@seald.nromomentum.com](mailto:security@seald.nromomentum.com)
+- **Subject line:** `Security report — <short title>`
+- **Machine-readable contact:** [`/.well-known/security.txt`](https://seald.nromomentum.com/.well-known/security.txt) per RFC 9116
+- **Full policy:** <https://seald.nromomentum.com/legal/responsible-disclosure>
+
+Please **do not** open a public GitHub Issue or Pull Request for a
+security finding. Use the private channel above and we will coordinate
+disclosure with you.
+
+## Response timelines (good-faith reports)
+
+| Stage | Target |
+|---|---|
+| Acknowledgement | within 2 business days |
+| Triage decision | within 10 business days |
+| Status updates while open | every 14 days |
+| Fix targets | Critical: 30 days · High: 60 days · Medium: 90 days · Low: best effort |
+| Public disclosure | coordinated with the reporter; default 90 days from acknowledgement |
+
+## Scope
+
+In scope:
+
+- `seald.nromomentum.com` (landing + SPA)
+- `api.seald.nromomentum.com` (Seald API)
+- The signing flow, audit trail, and Certificate of Completion
+- Cryptographic correctness of PAdES-LT seals issued by the Service
+- Authentication and account surfaces
+
+Out of scope: third-party sub-processors (report upstream),
+denial-of-service, social engineering, scanner-only output without a
+working proof of concept, missing-header style findings without an
+exploitable consequence. The full list lives in the
+[Vulnerability Disclosure Policy](https://seald.nromomentum.com/legal/responsible-disclosure).
+
+## Safe-harbor
+
+If you act in good faith and follow the rules in our
+[Vulnerability Disclosure Policy](https://seald.nromomentum.com/legal/responsible-disclosure),
+Seald will not initiate or recommend a civil claim against you, and we
+will treat your activities as authorized for the purposes of
+18 U.S.C. § 1030 (CFAA), 17 U.S.C. § 1201 (DMCA anti-circumvention) for
+technical measures protecting our systems, and applicable state
+computer-misuse laws.
+
+The safe-harbor extends only to Seald's own claims; it does not bind
+third parties. If you are unsure whether your planned testing is in
+scope, ask first — we'd rather discuss it.
+
+## What to include in your report
+
+- Description of the vulnerability and its impact
+- Reproduction steps (use a test account; redact sensitive data)
+- Any screenshots or proof of concept needed to confirm the issue
+- Your preferred contact details and whether you'd like public credit
+
+## What we ask you not to do
+
+- Don't access, modify, or destroy data that isn't yours
+- Don't exfiltrate personal data, document content, or signature material
+- Don't run automated scanners against production without prior written approval
+- Don't disclose the issue publicly until we've coordinated a fix
+
+Thank you for helping keep Seald and its users safe.

--- a/apps/landing/public/.well-known/security.txt
+++ b/apps/landing/public/.well-known/security.txt
@@ -1,0 +1,19 @@
+# Seald, Inc. — Vulnerability Disclosure Policy
+# https://datatracker.ietf.org/doc/html/rfc9116
+#
+# If you believe you've found a security issue affecting the Seald
+# Service or this website, please tell us. Reports may be submitted in
+# English. We do not currently operate a paid bug-bounty program, but we
+# acknowledge researchers who report in good faith.
+#
+# DO NOT include sensitive personal data (your own or anyone else's) in
+# your report. Include only the minimum reproduction information needed.
+
+Contact: mailto:security@seald.nromomentum.com
+Contact: https://seald.nromomentum.com/legal/responsible-disclosure
+Expires: 2027-04-30T00:00:00.000Z
+Encryption: https://seald.nromomentum.com/.well-known/security-pgp-key.txt
+Preferred-Languages: en
+Canonical: https://seald.nromomentum.com/.well-known/security.txt
+Policy: https://seald.nromomentum.com/legal/responsible-disclosure
+Hiring: https://seald.nromomentum.com/contact

--- a/apps/landing/src/pages/contact.astro
+++ b/apps/landing/src/pages/contact.astro
@@ -50,21 +50,12 @@ const VERSION = 'contact_v0.1';
 
       <section id="security">
         <h2>3. Security and vulnerability disclosure</h2>
-        <p>We welcome reports of security weaknesses. Our full Vulnerability Disclosure Policy will be published as a separate page; in the meantime, the safe-harbor terms below apply.</p>
+        <p>We welcome reports of security weaknesses. Our full <a href="/legal/responsible-disclosure">Vulnerability Disclosure Policy</a> describes scope, response timelines, and our safe-harbor commitment. A machine-readable copy of the contact information is published at <a href="/.well-known/security.txt"><code>/.well-known/security.txt</code></a> per RFC 9116.</p>
         <dl>
           <dt>Security reports</dt><dd><a href="mailto:security@seald.nromomentum.com">security@seald.nromomentum.com</a></dd>
           <dt>Subject line</dt><dd><code>Security — &lt;short title&gt;</code></dd>
-          <dt>PGP key</dt><dd><code>{`{TODO — key fingerprint}`}</code></dd>
+          <dt>PGP key</dt><dd>Available on request — see the <a href="/legal/responsible-disclosure">VDP</a></dd>
         </dl>
-        <h3>3.1 Safe-harbor</h3>
-        <p>If you make a good-faith effort to comply with this policy, we will (a) consider your research authorized, (b) work with you to understand and resolve the issue quickly, and (c) not pursue or support legal action against you. Activity that violates U.S. wire-fraud statutes or other criminal law is not protected — destroying customer data, exfiltrating data beyond the minimum needed to demonstrate the bug, or holding data for ransom are out of scope.</p>
-        <h3>3.2 Out of scope</h3>
-        <ul>
-          <li>Denial-of-service or volumetric attacks against the Service or our infrastructure providers.</li>
-          <li>Social engineering of Seald staff or customers.</li>
-          <li>Reports based solely on automated scanner output without a working proof-of-concept.</li>
-          <li>Best-practice findings on third-party services we do not operate (e.g. our DNS provider's TLS configuration).</li>
-        </ul>
       </section>
 
       <section id="abuse">

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -438,6 +438,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <li><a href="/verify">Verify a document</a></li>
             <li><a href="/legal/sub-processors">Sub-processors</a></li>
             <li><a href="/legal/accessibility">Accessibility</a></li>
+            <li><a href="/legal/responsible-disclosure">Report a vulnerability</a></li>
             <li><a href="/legal/esign-disclosure">ESIGN disclosure</a></li>
           </ul>
         </div>

--- a/apps/landing/src/pages/legal/responsible-disclosure.astro
+++ b/apps/landing/src/pages/legal/responsible-disclosure.astro
@@ -1,0 +1,111 @@
+---
+import BaseLayout from '@/layouts/BaseLayout.astro';
+const VERSION = 'responsible_disclosure_v0.1';
+---
+<BaseLayout
+  title="Vulnerability Disclosure Policy — Seald"
+  description="How to report a security vulnerability in Seald, our safe-harbor commitment, and the timelines you can expect. Draft — not legal advice."
+>
+  <main id="main" class="legal">
+    <article>
+      <header>
+        <section class="legal-banner">
+          <p><strong>Draft — not legal advice.</strong> This document is published in good faith as Seald's working draft. It has not yet been reviewed by counsel and may change before becoming binding. If you are reviewing this on behalf of a customer, please contact <a href="mailto:legal@seald.nromomentum.com">legal@seald.nromomentum.com</a> for the countersigned production version.</p>
+          <p class="meta">Version: <code>{VERSION}</code> · Last updated: <code>2026-04-30</code></p>
+        </section>
+        <h1>Vulnerability Disclosure Policy</h1>
+        <p>Seald, Inc. ("<strong>Seald</strong>", "we") welcomes security research that helps keep our customers and signers safe. This Vulnerability Disclosure Policy ("<strong>VDP</strong>") explains what is in scope, what is out of scope, the rules of engagement, the safe-harbor we offer to good-faith researchers, and how to reach us. It supplements our <a href="/legal/aup">Acceptable Use Policy</a> and our <a href="/legal/terms">Terms of Service</a>.</p>
+      </header>
+
+      <section id="how-to-report">
+        <h2>1. How to report</h2>
+        <p>Send your report to <a href="mailto:security@seald.nromomentum.com?subject=Security%20report">security@seald.nromomentum.com</a>. Use the subject line <code>Security report — &lt;short title&gt;</code>. A machine-readable copy of this contact information is published at <a href="/.well-known/security.txt"><code>/.well-known/security.txt</code></a> per RFC 9116.</p>
+        <p>Please include:</p>
+        <ul>
+          <li>A description of the vulnerability and its impact.</li>
+          <li>Reproduction steps, including any URL, payload, account, request/response, and screenshot needed to confirm the issue. Use a test account; do not use a real customer's account.</li>
+          <li>The minimum personal data necessary. Redact anything you do not need to send.</li>
+          <li>Your preferred contact details and whether you would like to be credited if we publish a write-up.</li>
+        </ul>
+        <p>If you must encrypt the report, our PGP key is available at <a href="/.well-known/security-pgp-key.txt"><code>/.well-known/security-pgp-key.txt</code></a> when published. If we do not yet have a key, please tell us and we will provide one within two (2) business days.</p>
+      </section>
+
+      <section id="response">
+        <h2>2. Our response timelines</h2>
+        <p>For reports received in good faith and following the rules below:</p>
+        <ul>
+          <li><strong>Acknowledgement</strong> — within two (2) business days.</li>
+          <li><strong>Triage decision</strong> (in scope / out of scope, severity) — within ten (10) business days.</li>
+          <li><strong>Status updates</strong> — at least every fourteen (14) days while the report is open.</li>
+          <li><strong>Fix targets</strong> — Critical: 30 days; High: 60 days; Medium: 90 days; Low: best effort. The clock starts when we accept the report.</li>
+          <li><strong>Public disclosure</strong> — coordinated with the reporter; ordinarily we ask for ninety (90) days from acknowledgement before public disclosure, with extensions for complex remediation.</li>
+        </ul>
+        <p>If we decide a report is out of scope, we will tell you why so you can decide whether to escalate.</p>
+      </section>
+
+      <section id="scope">
+        <h2>3. Scope</h2>
+        <h3>3.1 In scope</h3>
+        <ul>
+          <li><code>seald.nromomentum.com</code> (marketing site and web application surfaces).</li>
+          <li><code>api.seald.nromomentum.com</code> (the Seald API).</li>
+          <li>The signing flow at <code>seald.nromomentum.com/sign/&hellip;</code>, including the recipient signing experience, audit trail, and Certificate of Completion generation.</li>
+          <li>Cryptographic correctness of PAdES-LT seals issued by the Service.</li>
+          <li>Authentication, account, billing, and access-control surfaces.</li>
+          <li>Mobile-web rendering of the above surfaces.</li>
+        </ul>
+        <h3>3.2 Out of scope</h3>
+        <ul>
+          <li>Findings against third-party services we list as <a href="/legal/sub-processors">Sub-processors</a> — please report those upstream.</li>
+          <li>Reports that are based on output from automated scanners without a working proof of concept.</li>
+          <li>Self-XSS, social-engineering of Seald staff or customers, physical attacks on Seald or supplier facilities, denial-of-service of any kind, and rate-limit / brute-force testing without our prior written permission.</li>
+          <li>Missing security headers, cookie-attribute findings, TLS configuration scoring, banner-grab fingerprints, and similar non-impact findings unless paired with a demonstrable security consequence.</li>
+          <li>Findings that require root/jailbreak on a victim's device, or a malicious browser extension already running with the victim's full privileges.</li>
+          <li>Best-practice or hardening suggestions without an exploitable consequence (we welcome them, but they are not eligible for the safe-harbor).</li>
+        </ul>
+      </section>
+
+      <section id="rules">
+        <h2>4. Rules of engagement</h2>
+        <ul>
+          <li>Test only against accounts you control. Do not access, modify, or destroy any account, document, or signature that is not yours.</li>
+          <li>Do not exfiltrate personal data, document content, or signature material. If you accidentally encounter it, stop, delete it from your systems, and tell us in your report.</li>
+          <li>Do not run automated scanners against the production Service without our prior written permission. If you need to test at scale, contact us first and we will arrange a sandbox.</li>
+          <li>Avoid privacy violations, degradation of the Service, and disruption to other users. If your testing causes an outage, stop testing and tell us immediately.</li>
+          <li>Do not use the report contact channel for unrelated disputes, support requests, or marketing.</li>
+        </ul>
+      </section>
+
+      <section id="safe-harbor">
+        <h2>5. Safe-harbor</h2>
+        <p>If you make a good-faith effort to comply with this VDP — particularly Sections 3 (Scope) and 4 (Rules of engagement) — Seald will not initiate or recommend a civil claim against you for your security research, and we will treat your activities as authorized for purposes of the U.S. Computer Fraud and Abuse Act (18 U.S.C. § 1030), the Digital Millennium Copyright Act anti-circumvention provisions (17 U.S.C. § 1201) for technical measures protecting our systems, and applicable state computer-misuse laws.</p>
+        <p>This safe-harbor extends only to Seald's claims; it does not bind third parties (including our Sub-processors) and it does not waive any rights of any other party. If a third party initiates an action against you for activities that you conducted in compliance with this VDP, we will make our authorization known where we can.</p>
+        <p>If you are unsure whether your planned testing is consistent with this VDP, ask first at <a href="mailto:security@seald.nromomentum.com">security@seald.nromomentum.com</a>. We would rather discuss it than lose the chance to help you stay safe.</p>
+      </section>
+
+      <section id="recognition">
+        <h2>6. Recognition and rewards</h2>
+        <p>We do not currently operate a paid bug-bounty program. We acknowledge researchers in our security-changelog when a finding is fixed and the reporter consents to be named. We may, at our discretion, offer Seald swag, account credits, or a written reference.</p>
+      </section>
+
+      <section id="legal-process">
+        <h2>7. Legal process and law-enforcement requests</h2>
+        <p>Researchers who receive a subpoena, civil investigative demand, search warrant, or similar process related to a vulnerability they reported to Seald should tell us at <a href="mailto:legal@seald.nromomentum.com">legal@seald.nromomentum.com</a> as soon as the law allows so we can coordinate an appropriate response.</p>
+      </section>
+
+      <section id="changes">
+        <h2>8. Changes to this Policy</h2>
+        <p>We will update this Policy as our scope, response capacity, or safe-harbor commitments change. The version line at the top of this page reflects the latest revision. Material changes (changes to scope or safe-harbor) will be announced on the Seald blog and in our Trust Center.</p>
+      </section>
+
+      <section id="contact">
+        <h2>9. Contact</h2>
+        <dl>
+          <dt>Reports</dt><dd><a href="mailto:security@seald.nromomentum.com">security@seald.nromomentum.com</a></dd>
+          <dt>Machine-readable contact</dt><dd><a href="/.well-known/security.txt"><code>/.well-known/security.txt</code></a></dd>
+          <dt>General legal</dt><dd><a href="mailto:legal@seald.nromomentum.com">legal@seald.nromomentum.com</a></dd>
+        </dl>
+      </section>
+    </article>
+  </main>
+</BaseLayout>

--- a/apps/web/e2e/pages/SignUpPage.ts
+++ b/apps/web/e2e/pages/SignUpPage.ts
@@ -13,7 +13,10 @@ export class SignUpPage {
     await this.page.getByRole('textbox', { name: /full name/i }).fill(fullName);
     await this.page.getByRole('textbox', { name: /email/i }).fill(email);
     await this.page.getByRole('textbox', { name: /password/i }).fill(password);
-    // The signup form gates submission on a "agree to ToS" checkbox.
+    // The signup form gates submission on two checkboxes — legal-age
+    // confirmation (T-25) and ToS/Privacy agreement. Tick both before
+    // the submit button becomes enabled.
+    await this.page.getByRole('checkbox', { name: /legal age/i }).check();
     await this.page.getByRole('checkbox', { name: /agree.*terms/i }).check();
     await this.page.getByRole('button', { name: /^create account$/i }).click();
   }

--- a/apps/web/src/components/AuthForm/AuthForm.test.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.test.tsx
@@ -66,15 +66,28 @@ describe('AuthForm', () => {
     expect(auth.signInWithPassword).toHaveBeenCalledWith('ada@example.com', 'hunter2', false);
   });
 
-  it('gates signup submit on ToS checkbox', async () => {
+  it('gates signup submit on ToS + age-gate checkboxes', async () => {
     const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
     const submit = getByRole('button', { name: /create account/i });
     await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
     await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
     await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
     expect(submit).toBeDisabled();
+    // ToS alone isn't enough — age gate must also be ticked.
     await userEvent.click(getByLabelText(/agree to terms/i));
+    expect(submit).toBeDisabled();
+    await userEvent.click(getByLabelText(/legal age/i));
     expect(submit).not.toBeDisabled();
+  });
+
+  it('keeps signup submit disabled when age gate is unchecked even if ToS is checked', async () => {
+    const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
+    const submit = getByRole('button', { name: /create account/i });
+    await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
+    await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
+    await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
+    await userEvent.click(getByLabelText(/agree to terms/i));
+    expect(submit).toBeDisabled();
   });
 
   it('links the ToS row to the Terms of Service and Privacy Policy pages', () => {
@@ -105,6 +118,7 @@ describe('AuthForm', () => {
     await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
     await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
     await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
+    await userEvent.click(getByLabelText(/legal age/i));
     await userEvent.click(getByLabelText(/agree to terms/i));
     await userEvent.click(getByRole('button', { name: /create account/i }));
     expect(onNeeds).toHaveBeenCalledWith('ada@example.com');

--- a/apps/web/src/components/AuthForm/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.tsx
@@ -67,6 +67,11 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
   const [password, setPassword] = useState('');
   const [keep, setKeep] = useState(true);
   const [agreed, setAgreed] = useState(false);
+  // Age gate (T-24). Our Terms require signers to be at least 18, or
+  // 16 in jurisdictions that permit a 16-year-old to enter into binding
+  // electronic contracts (see /legal/terms §2). We capture an explicit
+  // attestation here; the legal limit lives in the Terms, not the UI.
+  const [ofAge, setOfAge] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -75,10 +80,12 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
   const valid = useMemo(() => {
     if (isForgot) return EMAIL_RE.test(email);
     if (isSignup) {
-      return name.trim().length > 1 && EMAIL_RE.test(email) && password.length >= 8 && agreed;
+      return (
+        name.trim().length > 1 && EMAIL_RE.test(email) && password.length >= 8 && agreed && ofAge
+      );
     }
     return EMAIL_RE.test(email) && password.length >= 1;
-  }, [isForgot, isSignup, name, email, password, agreed]);
+  }, [isForgot, isSignup, name, email, password, agreed, ofAge]);
 
   const handleGoogle = async (): Promise<void> => {
     if (busy) return;
@@ -196,25 +203,39 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
         )}
 
         {isSignup && (
-          <TosRow>
-            <Checkbox
-              type="checkbox"
-              checked={agreed}
-              onChange={(e) => setAgreed(e.target.checked)}
-              aria-label="Agree to Terms of Service and Privacy Policy"
-            />
-            <span>
-              I agree to Seald&apos;s{' '}
-              <a href="/legal/terms" target="_blank" rel="noopener noreferrer">
-                Terms of Service
-              </a>{' '}
-              and{' '}
-              <a href="/legal/privacy" target="_blank" rel="noopener noreferrer">
-                Privacy Policy
-              </a>
-              .
-            </span>
-          </TosRow>
+          <>
+            <TosRow>
+              <Checkbox
+                type="checkbox"
+                checked={ofAge}
+                onChange={(e) => setOfAge(e.target.checked)}
+                aria-label="Confirm I am of legal age to sign electronically"
+              />
+              <span>
+                I confirm I am at least 18 years old (or the legal age in my jurisdiction to enter
+                into binding electronic contracts).
+              </span>
+            </TosRow>
+            <TosRow>
+              <Checkbox
+                type="checkbox"
+                checked={agreed}
+                onChange={(e) => setAgreed(e.target.checked)}
+                aria-label="Agree to Terms of Service and Privacy Policy"
+              />
+              <span>
+                I agree to Seald&apos;s{' '}
+                <a href="/legal/terms" target="_blank" rel="noopener noreferrer">
+                  Terms of Service
+                </a>{' '}
+                and{' '}
+                <a href="/legal/privacy" target="_blank" rel="noopener noreferrer">
+                  Privacy Policy
+                </a>
+                .
+              </span>
+            </TosRow>
+          </>
         )}
 
         {!isSignup && !isForgot && (

--- a/apps/web/src/components/AuthShell/AuthShell.styles.ts
+++ b/apps/web/src/components/AuthShell/AuthShell.styles.ts
@@ -11,6 +11,7 @@ export const Root = styled.div`
 export const FormSide = styled.div`
   flex: 1 1 auto;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
   padding: 40px 24px;
@@ -20,4 +21,29 @@ export const FormSide = styled.div`
 export const FormWrap = styled.div`
   width: 100%;
   max-width: 420px;
+`;
+
+export const FootRow = styled.footer`
+  margin-top: 32px;
+  width: 100%;
+  max-width: 420px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px 18px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  & a {
+    color: inherit;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  & a:hover,
+  & a:focus-visible {
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+  & a:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.color.accent.base};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
 `;

--- a/apps/web/src/components/AuthShell/AuthShell.test.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.test.tsx
@@ -41,6 +41,20 @@ describe('AuthShell', () => {
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
   });
 
+  it('renders the legal/accessibility footer with all four trust links', () => {
+    const { getByRole } = renderWithTheme(
+      <AuthShell>
+        <h1>Sign in</h1>
+      </AuthShell>,
+    );
+    const foot = getByRole('contentinfo', { name: /legal and accessibility/i });
+    expect(foot).toBeInTheDocument();
+    expect(foot.querySelector('a[href="/legal/privacy"]')).toBeInTheDocument();
+    expect(foot.querySelector('a[href="/legal/terms"]')).toBeInTheDocument();
+    expect(foot.querySelector('a[href="/legal/accessibility"]')).toBeInTheDocument();
+    expect(foot.querySelector('a[href="/legal/responsible-disclosure"]')).toBeInTheDocument();
+  });
+
   it('renders without axe violations', async () => {
     const { container } = renderWithTheme(
       <AuthShell>

--- a/apps/web/src/components/AuthShell/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.tsx
@@ -1,13 +1,17 @@
 import { forwardRef } from 'react';
 import { AuthBrandPanel } from '../AuthBrandPanel';
 import type { AuthShellProps } from './AuthShell.types';
-import { FormSide, FormWrap, Root } from './AuthShell.styles';
+import { FootRow, FormSide, FormWrap, Root } from './AuthShell.styles';
 
 /**
  * Split-screen container used by every auth page. Renders the editorial
  * `AuthBrandPanel` on the left (collapsed by its own media query below 960px)
  * and the page's form content on the right, vertically centered and capped at
  * 420px wide.
+ *
+ * The footer row surfaces the legal/accessibility/security trust links
+ * (T-17). On the production single-domain deploy these all resolve to
+ * the landing-served `/legal/*` and `/.well-known/security.txt` paths.
  */
 export const AuthShell = forwardRef<HTMLDivElement, AuthShellProps>((props, ref) => {
   const { children, compact = false, ...rest } = props;
@@ -16,6 +20,12 @@ export const AuthShell = forwardRef<HTMLDivElement, AuthShellProps>((props, ref)
       {compact ? null : <AuthBrandPanel />}
       <FormSide>
         <FormWrap>{children}</FormWrap>
+        <FootRow aria-label="Legal and accessibility">
+          <a href="/legal/privacy">Privacy</a>
+          <a href="/legal/terms">Terms</a>
+          <a href="/legal/accessibility">Accessibility</a>
+          <a href="/legal/responsible-disclosure">Report a vulnerability</a>
+        </FootRow>
       </FormSide>
     </Root>
   );


### PR DESCRIPTION
## Summary

Phase 7 — accessibility surface, signup age gate, and a fully-published Vulnerability Disclosure Policy. **T-28 deferred** — its spec is ambiguous in our notes; calling it out here so the user can clarify scope on the next pass.

### T-17 — Accessibility surface
- `AuthShell` now renders a small legal/accessibility `<footer>` below the form column with **Privacy / Terms / Accessibility / Report a vulnerability**. On the production single-domain deploy these resolve to landing-served `/legal/*` paths.
- Footer text uses `theme.color.fg[3]`; visible focus-ring uses `theme.color.accent.base` so it stays axe-clean (covered by the existing AuthShell axe test).

### T-24 — Age gate on /signup
- `AuthForm` adds a second checkbox above the existing ToS row: *"I confirm I am at least 18 years old (or the legal age in my jurisdiction to enter into binding electronic contracts)."*
- Submit stays disabled until **both** the age-gate AND ToS checkboxes are ticked. The 18/16 threshold matches `/legal/terms` §2.

### T-25 — Vulnerability Disclosure Policy
- `apps/landing/public/.well-known/security.txt` — RFC 9116 contact card (Contact, Expires 2027-04-30, Encryption, Preferred-Languages, Canonical, Policy).
- `apps/landing/src/pages/legal/responsible-disclosure.astro` — full VDP with scope (in/out), rules of engagement, response timelines (ack 2bd · triage 10bd · status 14d · fix 30/60/90d), CFAA + DMCA §1201 safe-harbor, recognition, and legal-process coordination.
- Cross-linked from the landing footer Trust column and from the contact page §3.
- `SECURITY.md` at repo root so GitHub renders the security tab.

### T-28 — deferred
The four-letter task code is in our internal phase notes but the description is ambiguous (no matching surface in `/legal/*`, the auth flow, or the ESIGN UX track that I could derive from the existing T-numbering). Flagging here so the user can drop a one-line spec on the next interactive turn.

## Test plan
- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — green
- [x] `pnpm --filter api test` — **400/400** (no API code changed)
- [x] `pnpm --filter web exec vitest run` — **780/780** (+2 new AuthForm signup-gate tests, +1 AuthShell footer-links test, plus an updated existing signup test)
- [ ] CI watchdog confirms the full pipeline green (auto-dispatched after this PR opens)
- [ ] Manual QA on staging: visit `/.well-known/security.txt`, `/legal/responsible-disclosure`, the AuthShell footer on `/signin` and `/signup`, and the new age-gate row on `/signup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)