### PR TITLE
feat(consent): cookie-consent banner + GPC + beacon gating (T-30)

### DIFF
--- a/apps/landing/public/scripts/cookie-consent.js
+++ b/apps/landing/public/scripts/cookie-consent.js
@@ -1,0 +1,253 @@
+/*
+ * Seald cookie-consent (T-30, /legal/cookies §4 implementation).
+ *
+ * Vanilla JS. No deps. Runs on every page of seald.nromomentum.com
+ * (both the Astro landing and the React SPA share this domain).
+ *
+ * Behaviour, in plain words:
+ *   - On first visit, show a non-blocking banner pinned to the bottom
+ *     with a Reject button shown with the same prominence as Accept
+ *     (EDPB 03/2022 dark-pattern guidelines).
+ *   - If the browser sends Global Privacy Control (CCPA Reg §7025,
+ *     CO/CT universal-opt-out), silently record a "rejected" choice
+ *     and never show the banner.
+ *   - If the visitor's choice is already on file in `seald_consent_v1`,
+ *     respect it without re-prompting.
+ *   - On "Accept", inject the Cloudflare Web Analytics beacon. The
+ *     beacon token is read from <meta name="cf-beacon-token" ...>; if
+ *     the meta is missing or empty, no beacon is loaded. (No analytics
+ *     in production until the token lands — fail closed.)
+ *   - The "Manage cookie preferences" button in the footer calls
+ *     window.SealdConsent.openBanner() to re-open the banner.
+ *
+ * Cookie:
+ *   name:   seald_consent_v1
+ *   values: "accepted" | "rejected"
+ *   attrs:  Path=/; Max-Age=31536000 (12mo, EDPB 03/2022 max);
+ *           Secure (HTTPS only); SameSite=Lax
+ *
+ * Test hooks:
+ *   - Playwright/E2E can pre-set the cookie via context.addCookies()
+ *     to suppress the banner. Or they can set
+ *     window.__SEALD_CONSENT_DISABLED = true before the script runs.
+ */
+(function () {
+  'use strict';
+
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+  if (window.SealdConsent) return; // idempotent
+  if (window.__SEALD_CONSENT_DISABLED === true) return;
+
+  var COOKIE_NAME = 'seald_consent_v1';
+  var COOKIE_MAX_AGE_S = 60 * 60 * 24 * 365; // 12 months
+  var BEACON_SRC = 'https://static.cloudflareinsights.com/beacon.min.js';
+
+  function readCookie(name) {
+    var pairs = (document.cookie || '').split(';');
+    for (var i = 0; i < pairs.length; i++) {
+      var p = pairs[i].trim();
+      if (p.indexOf(name + '=') === 0) {
+        return decodeURIComponent(p.slice(name.length + 1));
+      }
+    }
+    return null;
+  }
+
+  function writeCookie(name, value) {
+    var attrs = [
+      name + '=' + encodeURIComponent(value),
+      'Path=/',
+      'Max-Age=' + COOKIE_MAX_AGE_S,
+      'SameSite=Lax',
+    ];
+    // Secure attribute only when served over HTTPS — keeps localhost dev usable.
+    if (location.protocol === 'https:') attrs.push('Secure');
+    document.cookie = attrs.join('; ');
+  }
+
+  function gpcEnabled() {
+    return navigator && navigator.globalPrivacyControl === true;
+  }
+
+  function getBeaconToken() {
+    var meta = document.querySelector('meta[name="cf-beacon-token"]');
+    if (!meta) return '';
+    var v = meta.getAttribute('content') || '';
+    return v.trim();
+  }
+
+  function loadBeacon() {
+    var token = getBeaconToken();
+    if (!token) return; // no token configured — nothing to load
+    if (document.querySelector('script[data-seald-beacon]')) return;
+    var s = document.createElement('script');
+    s.defer = true;
+    s.src = BEACON_SRC;
+    s.setAttribute('data-cf-beacon', JSON.stringify({ token: token }));
+    s.setAttribute('data-seald-beacon', '1');
+    document.head.appendChild(s);
+  }
+
+  /* ---------- Banner DOM ---------- */
+
+  var STYLE_ID = 'seald-consent-style';
+  var ROOT_ID = 'seald-consent-banner';
+
+  function injectStyles() {
+    if (document.getElementById(STYLE_ID)) return;
+    var css =
+      '#' + ROOT_ID + '{' +
+        'position:fixed;left:16px;right:16px;bottom:16px;z-index:9999;' +
+        'max-width:560px;margin:0 auto;' +
+        'background:#0B1220;color:#F5F7FB;' +
+        'border:1px solid rgba(255,255,255,0.08);border-radius:14px;' +
+        'box-shadow:0 12px 32px rgba(11,18,32,0.32);' +
+        'padding:18px 20px;font:14px/1.5 Inter,system-ui,-apple-system,sans-serif;' +
+      '}' +
+      '#' + ROOT_ID + ' p{margin:0 0 12px 0;color:inherit;}' +
+      '#' + ROOT_ID + ' a{color:#A5B4FC;text-decoration:underline;text-underline-offset:2px;}' +
+      '#' + ROOT_ID + ' a:focus-visible{outline:2px solid #A5B4FC;outline-offset:2px;border-radius:2px;}' +
+      '#' + ROOT_ID + ' .seald-consent-actions{display:flex;flex-wrap:wrap;gap:10px;}' +
+      '#' + ROOT_ID + ' button{' +
+        'flex:1 1 auto;min-width:120px;cursor:pointer;' +
+        'padding:10px 16px;border-radius:10px;font:600 14px/1 Inter,system-ui,sans-serif;' +
+        'border:1px solid rgba(255,255,255,0.16);' +
+        'background:rgba(255,255,255,0.06);color:#F5F7FB;' +
+        'transition:background 120ms ease,border-color 120ms ease;' +
+      '}' +
+      '#' + ROOT_ID + ' button:hover{background:rgba(255,255,255,0.12);border-color:rgba(255,255,255,0.24);}' +
+      '#' + ROOT_ID + ' button:focus-visible{outline:2px solid #A5B4FC;outline-offset:2px;}' +
+      '@media (prefers-reduced-motion:reduce){#' + ROOT_ID + ' button{transition:none;}}';
+    var style = document.createElement('style');
+    style.id = STYLE_ID;
+    style.appendChild(document.createTextNode(css));
+    document.head.appendChild(style);
+  }
+
+  var bannerEl = null;
+  var lastFocusEl = null;
+
+  function buildBanner() {
+    var root = document.createElement('aside');
+    root.id = ROOT_ID;
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-modal', 'false');
+    root.setAttribute('aria-labelledby', 'seald-consent-title');
+    root.setAttribute('aria-describedby', 'seald-consent-desc');
+    root.setAttribute('data-testid', 'cookie-consent-banner');
+
+    var title = document.createElement('p');
+    title.id = 'seald-consent-title';
+    title.style.fontWeight = '600';
+    title.style.fontSize = '15px';
+    title.appendChild(document.createTextNode('Cookies on Seald'));
+
+    var desc = document.createElement('p');
+    desc.id = 'seald-consent-desc';
+    desc.appendChild(document.createTextNode(
+      'We use one privacy-friendly analytics beacon (Cloudflare Web Analytics) to count page views. ' +
+      'Strictly necessary cookies always run. See our '
+    ));
+    var link = document.createElement('a');
+    link.href = '/legal/cookies';
+    link.appendChild(document.createTextNode('Cookie Policy'));
+    desc.appendChild(link);
+    desc.appendChild(document.createTextNode(' for details.'));
+
+    var actions = document.createElement('div');
+    actions.className = 'seald-consent-actions';
+
+    var rejectBtn = document.createElement('button');
+    rejectBtn.type = 'button';
+    rejectBtn.setAttribute('data-testid', 'cookie-consent-reject');
+    rejectBtn.appendChild(document.createTextNode('Reject analytics'));
+    rejectBtn.addEventListener('click', function () { recordChoice('rejected'); });
+
+    var acceptBtn = document.createElement('button');
+    acceptBtn.type = 'button';
+    acceptBtn.setAttribute('data-testid', 'cookie-consent-accept');
+    acceptBtn.appendChild(document.createTextNode('Accept analytics'));
+    acceptBtn.addEventListener('click', function () { recordChoice('accepted'); });
+
+    actions.appendChild(rejectBtn);
+    actions.appendChild(acceptBtn);
+
+    root.appendChild(title);
+    root.appendChild(desc);
+    root.appendChild(actions);
+    return root;
+  }
+
+  function showBanner() {
+    if (bannerEl && document.body.contains(bannerEl)) return;
+    injectStyles();
+    bannerEl = buildBanner();
+    lastFocusEl = document.activeElement;
+    document.body.appendChild(bannerEl);
+    // Move focus to the first action so keyboard users can reach it.
+    var first = bannerEl.querySelector('button');
+    if (first && typeof first.focus === 'function') first.focus();
+  }
+
+  function hideBanner() {
+    if (bannerEl && bannerEl.parentNode) bannerEl.parentNode.removeChild(bannerEl);
+    bannerEl = null;
+    if (lastFocusEl && typeof lastFocusEl.focus === 'function') {
+      try { lastFocusEl.focus(); } catch (_) { /* noop */ }
+    }
+    lastFocusEl = null;
+  }
+
+  function recordChoice(choice) {
+    writeCookie(COOKIE_NAME, choice);
+    hideBanner();
+    if (choice === 'accepted') loadBeacon();
+    try {
+      window.dispatchEvent(new CustomEvent('seald:consent', { detail: { choice: choice } }));
+    } catch (_) { /* old browsers without CustomEvent ctor */ }
+  }
+
+  /* ---------- Public API ---------- */
+
+  function openBanner() {
+    // "Manage cookie preferences" — always reopen, even if a choice exists.
+    showBanner();
+  }
+
+  function getChoice() {
+    return readCookie(COOKIE_NAME); // 'accepted' | 'rejected' | null
+  }
+
+  window.SealdConsent = {
+    openBanner: openBanner,
+    getChoice: getChoice,
+    // Exposed for tests; not part of the public contract.
+    _recordChoice: recordChoice,
+  };
+
+  /* ---------- Init ---------- */
+
+  function init() {
+    var existing = getChoice();
+    if (existing === 'accepted') {
+      loadBeacon();
+      return;
+    }
+    if (existing === 'rejected') {
+      return;
+    }
+    // No prior choice on file.
+    if (gpcEnabled()) {
+      // Treat GPC as a clear opt-out; persist so the banner doesn't appear.
+      writeCookie(COOKIE_NAME, 'rejected');
+      return;
+    }
+    showBanner();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -135,17 +135,20 @@ const softwareLd = {
     <script type="application/ld+json" set:html={JSON.stringify(softwareLd)} />
 
     <!--
-      Cloudflare Web Analytics
-      ------------------------
-      Privacy-friendly, cookie-less. No banner needed. Replace the empty
-      token below with the real beacon token from the Cloudflare dashboard
-      (Analytics & Logs → Web Analytics → site config). See CLAUDE.md.
+      Cookie consent (T-30, /legal/cookies §4).
+      ----------------------------------------
+      The consent script is shared between the Astro landing and the
+      React SPA — both live on seald.nromomentum.com. It shows the
+      banner on first visit, persists the choice in `seald_consent_v1`
+      (12-month, EDPB 03/2022), honors Global Privacy Control, and only
+      injects the Cloudflare Web Analytics beacon after explicit consent.
+
+      To enable analytics in production, drop the real beacon token into
+      the meta tag below. With an empty token, no beacon is loaded even
+      after consent — fail-closed.
     -->
-    <script
-      defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": ""}'
-    ></script>
+    <meta name="cf-beacon-token" content="" />
+    <script defer src="/scripts/cookie-consent.js"></script>
   </head>
 
   <body>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -451,6 +451,16 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
             <li><a href="/legal/dpa">DPA</a></li>
             <li><a href="/legal/aup">Acceptable use</a></li>
             <li><a href="mailto:privacy@seald.nromomentum.com?subject=Your%20Privacy%20Choices">Your Privacy Choices</a></li>
+            <li>
+              <button
+                type="button"
+                class="link-button"
+                data-testid="footer-manage-cookies"
+                onclick="window.SealdConsent && window.SealdConsent.openBanner()"
+              >
+                Manage cookie preferences
+              </button>
+            </li>
           </ul>
         </div>
       </div>

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -2132,6 +2132,27 @@ footer {
   color: #fff;
   text-decoration: none;
 }
+.foot-col .link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 14px;
+  cursor: pointer;
+  transition: color 120ms;
+}
+.foot-col .link-button:hover {
+  color: #fff;
+}
+.foot-col .link-button:focus-visible {
+  outline: 2px solid rgba(165, 180, 252, 0.9);
+  outline-offset: 2px;
+  border-radius: 2px;
+  color: #fff;
+}
 .foot-bottom {
   margin-top: 56px;
   padding-top: 28px;

--- a/apps/web/e2e/cookie-consent.spec.ts
+++ b/apps/web/e2e/cookie-consent.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Cookie-consent banner behaviour (T-30, /legal/cookies §4 implementation).
+ *
+ * These tests load the SPA at `/` so the consent runtime
+ * (`/scripts/cookie-consent.js`, served in dev by the
+ * `landingScriptsBridge` Vite plugin) actually runs. Each test starts
+ * with a fresh `context` so cookies + DOM state never leak across
+ * scenarios.
+ *
+ * Why this spec lives outside the BDD fixture file:
+ *   `e2e/fixtures/test.ts` registers a `cookieConsent` auto-fixture
+ *   that disables the banner before every navigation — useful for
+ *   product flows that don't care about the banner. This spec is the
+ *   one place we *want* the real banner to appear, so we import from
+ *   `@playwright/test` directly and skip that auto-fixture.
+ *
+ * The `cf-beacon-token` meta in `apps/web/index.html` is intentionally
+ * empty in dev/test, so accept-flow tests do not assert that the
+ * Cloudflare beacon `<script>` materializes (the script bails when the
+ * token is empty, by design — fail closed). The `consent-then-beacon`
+ * test rewrites the meta value before init via `addInitScript` so we
+ * can prove the wiring works end-to-end.
+ */
+
+const BANNER = '[data-testid="cookie-consent-banner"]';
+const ACCEPT = '[data-testid="cookie-consent-accept"]';
+const REJECT = '[data-testid="cookie-consent-reject"]';
+const COOKIE_NAME = 'seald_consent_v1';
+
+async function readConsentCookie(
+  context: import('@playwright/test').BrowserContext,
+): Promise<string | null> {
+  const cookies = await context.cookies();
+  const found = cookies.find((c) => c.name === COOKIE_NAME);
+  return found ? found.value : null;
+}
+
+test.describe('cookie-consent banner (T-30)', () => {
+  test('appears on first visit when no prior choice exists', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator(BANNER)).toBeVisible();
+    // Reject button must be visually peer to Accept (EDPB 03/2022).
+    await expect(page.locator(REJECT)).toBeVisible();
+    await expect(page.locator(ACCEPT)).toBeVisible();
+  });
+
+  test('Accept persists the choice and dispatches a seald:consent event', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+    // Capture the consent custom event so we can prove the public contract.
+    const choicePromise = page.evaluate(
+      () =>
+        new Promise<string>((resolve) => {
+          window.addEventListener(
+            'seald:consent',
+            (e) => resolve((e as CustomEvent<{ choice: string }>).detail.choice),
+            { once: true },
+          );
+        }),
+    );
+    await page.locator(ACCEPT).click();
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    expect(await choicePromise).toBe('accepted');
+    expect(await readConsentCookie(context)).toBe('accepted');
+  });
+
+  test('Reject persists the choice without loading the analytics beacon', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+    await page.locator(REJECT).click();
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    expect(await readConsentCookie(context)).toBe('rejected');
+    // No CF Web Analytics beacon must be injected on reject — even with
+    // a token configured, the `loadBeacon()` path is only reachable from
+    // the accept branch.
+    expect(await page.locator('script[data-seald-beacon]').count()).toBe(0);
+  });
+
+  test('does not re-prompt on subsequent visits when a choice is on file', async ({
+    page,
+    context,
+  }) => {
+    await page.goto('/');
+    await page.locator(ACCEPT).click();
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    await page.goto('/');
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    // And the cookie still says accepted on the second load.
+    expect(await readConsentCookie(context)).toBe('accepted');
+  });
+
+  test('Global Privacy Control silently records reject and never shows the banner', async ({
+    page,
+    context,
+  }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, 'globalPrivacyControl', {
+        configurable: true,
+        get: () => true,
+      });
+    });
+    await page.goto('/');
+    // Banner must never appear; cookie must be persisted as rejected.
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    // Give the consent script a tick to write the cookie.
+    await expect.poll(() => readConsentCookie(context)).toBe('rejected');
+  });
+
+  test('Cloudflare beacon loads only after Accept and only when a token is configured', async ({
+    page,
+  }) => {
+    // Replace the empty cf-beacon-token meta value with a fake token so
+    // the script's fail-closed guard passes for this scenario only.
+    await page.addInitScript(() => {
+      const swap = (): void => {
+        const m = document.querySelector('meta[name="cf-beacon-token"]');
+        if (m) m.setAttribute('content', 'test-token-not-real');
+      };
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', swap, { once: true });
+      } else {
+        swap();
+      }
+    });
+    await page.goto('/');
+    // No beacon yet — consent has not been recorded.
+    expect(await page.locator('script[data-seald-beacon]').count()).toBe(0);
+    await page.locator(ACCEPT).click();
+    await expect(page.locator('script[data-seald-beacon]')).toHaveCount(1);
+    const beacon = page.locator('script[data-seald-beacon]').first();
+    await expect(beacon).toHaveAttribute('src', /cloudflareinsights\.com\/beacon\.min\.js/);
+    await expect(beacon).toHaveAttribute('data-cf-beacon', /test-token-not-real/);
+  });
+
+  test('Manage cookie preferences re-opens the banner from a previously closed state', async ({
+    page,
+  }) => {
+    await page.goto('/');
+    await page.locator(ACCEPT).click();
+    await expect(page.locator(BANNER)).toHaveCount(0);
+    // Public API used by the footer "Manage cookie preferences" buttons
+    // (AuthShell + landing footer).
+    await page.evaluate(() => {
+      const api = (window as unknown as { SealdConsent?: { openBanner: () => void } }).SealdConsent;
+      api?.openBanner();
+    });
+    await expect(page.locator(BANNER)).toBeVisible();
+  });
+});

--- a/apps/web/e2e/fixtures/cookieConsent.ts
+++ b/apps/web/e2e/fixtures/cookieConsent.ts
@@ -1,0 +1,56 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Cookie-consent fixture (T-30).
+ *
+ * The production site shows a consent banner on first visit (see
+ * `apps/landing/public/scripts/cookie-consent.js`). For E2E flows that
+ * are not specifically about consent UX, we want the banner to stay out
+ * of the way so it doesn't intercept clicks on the form area below.
+ *
+ * Two ways to disable it before navigation:
+ *   1. `disable(page)` — sets `window.__SEALD_CONSENT_DISABLED = true`
+ *      via `addInitScript`, so the consent script's IIFE bails before
+ *      doing any work. Use when no banner state is wanted at all.
+ *   2. `seedAccepted(page)` / `seedRejected(page)` — pre-seeds the
+ *      `seald_consent_v1` cookie so the banner does not appear and the
+ *      analytics beacon either loads or stays out, matching the chosen
+ *      branch.
+ *
+ * Both helpers must run BEFORE the first navigation; addInitScript and
+ * cookie-set-via-context are no-ops once the page is rendered.
+ */
+export class CookieConsentFixture {
+  constructor(private readonly page: Page) {}
+
+  async disable(): Promise<void> {
+    await this.page.addInitScript(() => {
+      (window as unknown as { __SEALD_CONSENT_DISABLED: boolean }).__SEALD_CONSENT_DISABLED = true;
+    });
+  }
+
+  async seedAccepted(): Promise<void> {
+    await this.seedCookie('accepted');
+  }
+
+  async seedRejected(): Promise<void> {
+    await this.seedCookie('rejected');
+  }
+
+  private async seedCookie(value: 'accepted' | 'rejected'): Promise<void> {
+    const url = new URL(this.page.url() || 'http://127.0.0.1:5173/');
+    await this.page.context().addCookies([
+      {
+        name: 'seald_consent_v1',
+        value,
+        domain: url.hostname,
+        path: '/',
+        sameSite: 'Lax',
+        secure: false,
+        httpOnly: false,
+        // Match the script's 12-month Max-Age.
+        expires: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365,
+      },
+    ]);
+  }
+}

--- a/apps/web/e2e/fixtures/test.ts
+++ b/apps/web/e2e/fixtures/test.ts
@@ -1,4 +1,5 @@
 import { test as base } from 'playwright-bdd';
+import { CookieConsentFixture } from './cookieConsent';
 import { MockedApi } from './mockedApi';
 import { SeededUserFixture } from './seededUser';
 import { SignedEnvelopeFixture } from './signedEnvelope';
@@ -42,6 +43,7 @@ import { SigningDeclinedPage } from '../pages/SigningDeclinedPage';
  * fixture resolver guarantees they're set up in the order above.
  */
 type Fixtures = {
+  cookieConsent: CookieConsentFixture;
   mockedApi: MockedApi;
   seededUser: SeededUserFixture;
   signedEnvelope: SignedEnvelopeFixture;
@@ -63,6 +65,20 @@ type Fixtures = {
 };
 
 export const test = base.extend<Fixtures>({
+  // Cookie-consent banner is force-disabled in every BDD scenario via
+  // `addInitScript` (T-30). The fixture is `auto: true` so step
+  // definitions don't have to opt in — the banner never overlays form
+  // fields the existing scenarios don't expect. Specs that *want* the
+  // banner (e.g. the dedicated cookie-consent flow) should not import
+  // from this fixture file; they import the bare `@playwright/test`.
+  cookieConsent: [
+    async ({ page }, use) => {
+      const fixture = new CookieConsentFixture(page);
+      await fixture.disable();
+      await use(fixture);
+    },
+    { auto: true },
+  ],
   // Network mocks are auto-installed before every test so step defs only
   // call `mockedApi.on(...)` to register a handler — no manual install.
   mockedApi: async ({ page }, use) => {

--- a/apps/web/e2e/signing-flow.spec.ts
+++ b/apps/web/e2e/signing-flow.spec.ts
@@ -73,6 +73,13 @@ function makeFilledTextField() {
 
 test.describe('signing flow', () => {
   test.beforeEach(async ({ page }) => {
+    // Cookie-consent banner (T-30) is on every page and would otherwise
+    // sit on top of the form during the first navigation in this spec.
+    // The hand-written specs don't use the BDD auto-fixture, so opt out
+    // explicitly via the runtime escape hatch.
+    await page.addInitScript(() => {
+      (window as unknown as { __SEALD_CONSENT_DISABLED: boolean }).__SEALD_CONSENT_DISABLED = true;
+    });
     // POST /sign/start → a session that still requires T&C accept.
     await page.route('**/sign/start', async (route: Route) => {
       await route.fulfill({

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -25,6 +25,14 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Source+Serif+4:ital,opsz,wght@0,8..60,400;0,8..60,500;0,8..60,600;1,8..60,400&family=JetBrains+Mono:wght@400;500&family=Caveat:wght@500;600;700&display=swap"
     />
     <title>Seald — Dev Harness</title>
+    <!--
+      Cookie consent (T-30). Same script as the Astro landing — both
+      apps are served from seald.nromomentum.com via Cloudflare Pages.
+      The meta token is read by /scripts/cookie-consent.js to gate the
+      Cloudflare Web Analytics beacon behind explicit consent.
+    -->
+    <meta name="cf-beacon-token" content="" />
+    <script defer src="/scripts/cookie-consent.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/components/AuthShell/AuthShell.styles.ts
+++ b/apps/web/src/components/AuthShell/AuthShell.styles.ts
@@ -47,3 +47,29 @@ export const FootRow = styled.footer`
     border-radius: 2px;
   }
 `;
+
+/**
+ * Footer-row button styled to look identical to the surrounding anchors.
+ * Used for the cookie-preferences re-opener so it visually peers with the
+ * legal links while still being a real <button> for accessibility.
+ */
+export const FootLinkButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+  &:hover,
+  &:focus-visible {
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.color.accent.base};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+`;

--- a/apps/web/src/components/AuthShell/AuthShell.test.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.test.tsx
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 import { renderWithTheme } from '../../test/renderWithTheme';
 import { AuthShell } from './AuthShell';
@@ -53,6 +54,50 @@ describe('AuthShell', () => {
     expect(foot.querySelector('a[href="/legal/terms"]')).toBeInTheDocument();
     expect(foot.querySelector('a[href="/legal/accessibility"]')).toBeInTheDocument();
     expect(foot.querySelector('a[href="/legal/responsible-disclosure"]')).toBeInTheDocument();
+  });
+
+  describe('cookie-preferences button (T-30)', () => {
+    afterEach(() => {
+      delete (window as unknown as { SealdConsent?: unknown }).SealdConsent;
+    });
+
+    it('renders the manage-cookies button next to the trust links', () => {
+      const { getByRole } = renderWithTheme(
+        <AuthShell>
+          <h1>Sign in</h1>
+        </AuthShell>,
+      );
+      const btn = getByRole('button', { name: /manage cookie preferences/i });
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute('type', 'button');
+    });
+
+    it('opens the consent banner when clicked', () => {
+      const openBanner = vi.fn();
+      (
+        window as unknown as { SealdConsent: { openBanner: () => void; getChoice: () => null } }
+      ).SealdConsent = { openBanner, getChoice: () => null };
+      const { getByRole } = renderWithTheme(
+        <AuthShell>
+          <h1>Sign in</h1>
+        </AuthShell>,
+      );
+      fireEvent.click(getByRole('button', { name: /manage cookie preferences/i }));
+      expect(openBanner).toHaveBeenCalledTimes(1);
+    });
+
+    it('no-ops gracefully when the consent runtime has not loaded yet', () => {
+      // The script tag is `defer` so SealdConsent may not exist at click time
+      // for the first tick of the page. The button must not throw.
+      const { getByRole } = renderWithTheme(
+        <AuthShell>
+          <h1>Sign in</h1>
+        </AuthShell>,
+      );
+      expect(() =>
+        fireEvent.click(getByRole('button', { name: /manage cookie preferences/i })),
+      ).not.toThrow();
+    });
   });
 
   it('renders without axe violations', async () => {

--- a/apps/web/src/components/AuthShell/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { AuthBrandPanel } from '../AuthBrandPanel';
 import type { AuthShellProps } from './AuthShell.types';
-import { FootRow, FormSide, FormWrap, Root } from './AuthShell.styles';
+import { FootLinkButton, FootRow, FormSide, FormWrap, Root } from './AuthShell.styles';
 
 /**
  * Split-screen container used by every auth page. Renders the editorial
@@ -10,11 +10,16 @@ import { FootRow, FormSide, FormWrap, Root } from './AuthShell.styles';
  * 420px wide.
  *
  * The footer row surfaces the legal/accessibility/security trust links
- * (T-17). On the production single-domain deploy these all resolve to
- * the landing-served `/legal/*` and `/.well-known/security.txt` paths.
+ * (T-17) plus the cookie-preferences re-opener (T-30). On the production
+ * single-domain deploy the legal hrefs all resolve to the landing-served
+ * `/legal/*` paths; the preferences button calls into the global
+ * `window.SealdConsent` runtime injected by `/scripts/cookie-consent.js`.
  */
 export const AuthShell = forwardRef<HTMLDivElement, AuthShellProps>((props, ref) => {
   const { children, compact = false, ...rest } = props;
+  const handleManageCookies = (): void => {
+    window.SealdConsent?.openBanner();
+  };
   return (
     <Root ref={ref} {...rest}>
       {compact ? null : <AuthBrandPanel />}
@@ -25,6 +30,13 @@ export const AuthShell = forwardRef<HTMLDivElement, AuthShellProps>((props, ref)
           <a href="/legal/terms">Terms</a>
           <a href="/legal/accessibility">Accessibility</a>
           <a href="/legal/responsible-disclosure">Report a vulnerability</a>
+          <FootLinkButton
+            type="button"
+            data-testid="footer-manage-cookies"
+            onClick={handleManageCookies}
+          >
+            Manage cookie preferences
+          </FootLinkButton>
         </FootRow>
       </FormSide>
     </Root>

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -9,3 +9,18 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+/**
+ * Cookie-consent runtime exposed by `/scripts/cookie-consent.js`
+ * (loaded from `apps/web/index.html` and the Astro landing's BaseLayout).
+ * The script sets this on `window` once it has initialised; callers must
+ * therefore null-check before invoking. See T-30 / `apps/landing/public/scripts/cookie-consent.js`.
+ */
+interface SealdConsentApi {
+  openBanner(): void;
+  getChoice(): 'accepted' | 'rejected' | null;
+}
+
+interface Window {
+  SealdConsent?: SealdConsentApi;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,6 +1,9 @@
 /// <reference types="vitest" />
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve as resolvePath } from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
 import { defineConfig } from 'vitest/config';
+import type { Plugin } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import { visualizer } from 'rollup-plugin-visualizer';
 
@@ -8,9 +11,37 @@ import { visualizer } from 'rollup-plugin-visualizer';
 // Emits `dist/stats.html` — copy into `docs/bundle/` to track deltas.
 const withVisualizer = process.env.SEALD_VISUALIZE === '1';
 
+/**
+ * Dev-only middleware that serves `/scripts/*` from the Astro landing's
+ * `public/scripts/` folder. In production both apps are merged into one
+ * Cloudflare Pages deployment so the path resolves naturally; this plugin
+ * gives the dev server (and therefore Playwright/E2E) the same behaviour
+ * without duplicating the file. Single source of truth lives in
+ * `apps/landing/public/scripts/`.
+ */
+function landingScriptsBridge(): Plugin {
+  const root = resolvePath(fileURLToPath(new URL('../landing/public/scripts', import.meta.url)));
+  return {
+    name: 'seald:landing-scripts-bridge',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (!req.url) return next();
+        const match = /^\/scripts\/([\w.-]+)(?:\?.*)?$/.exec(req.url);
+        if (!match) return next();
+        const file = resolvePath(root, match[1]!);
+        if (!file.startsWith(root) || !existsSync(file)) return next();
+        res.setHeader('content-type', 'application/javascript; charset=utf-8');
+        res.end(readFileSync(file));
+      });
+    },
+  };
+}
+
 export default defineConfig({
   plugins: [
     react(),
+    landingScriptsBridge(),
     ...(withVisualizer
       ? [
           visualizer({

--- a/cspell.json
+++ b/cspell.json
@@ -458,7 +458,9 @@
     "dsar",
     "CCPA",
     "ccpa",
-    "serialisable"
+    "serialisable",
+    "hrefs",
+    "initialised"
   ],
   "ignoreRegExpList": [
     "Base64",


### PR DESCRIPTION
## Summary

Implements the consent layer the published Cookie Policy (`/legal/cookies` §4) promises but that production currently lacks:

- **Banner** on first visit; Reject button given equal prominence to Accept (EDPB 03/2022 dark-pattern guidelines).
- **Cookie**: `seald_consent_v1` (`Path=/`, `Max-Age=12mo`, `SameSite=Lax`, `Secure` only on HTTPS — keeps localhost dev usable).
- **GPC** honored (CCPA Reg §7025, CO/CT) — silently records a reject and never shows the banner.
- **Beacon gating** — Cloudflare Web Analytics loads only after explicit Accept *and* only when `<meta name="cf-beacon-token">` is non-empty (fail closed).
- **Public API** — `window.SealdConsent.{openBanner, getChoice}` + `seald:consent` CustomEvent.
- **Footer "Manage cookie preferences"** in AuthShell (SPA) and the landing footer's Trust column re-open the banner.

## Architecture

- `apps/landing/public/scripts/cookie-consent.js` — single source of truth.
- BaseLayout (Astro) and `apps/web/index.html` (SPA) both load `/scripts/cookie-consent.js`.
- `landingScriptsBridge` Vite plugin serves `/scripts/*` from the landing public dir during SPA dev so Playwright (and the dev server) get the same file. Production already merges both apps' static assets via `deploy-cloudflare.yml`.

## Test plan

- [ ] CI: typecheck / lint / vitest (web — 783 tests) / api unit / api e2e
- [ ] CI: Playwright BDD (banner suppressed via auto-fixture)
- [ ] CI: new `cookie-consent.spec.ts` — banner appears, Accept persists + dispatches event, Reject persists + no beacon, GPC silently rejects, beacon loads only after Accept w/ token, manage-preferences re-opens banner
- [ ] Production after merge: visit `seald.nromomentum.com` in a fresh profile → banner appears
- [ ] Production: Accept → cookie set, manage-preferences re-opens
- [ ] Production: enable GPC in browser → no banner, cookie pre-set to rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)