### PR TITLE
fix(legal): close compliance gaps from phase-7 audit (#39/#40/#41/#42)

### DIFF
--- a/apps/landing/public/.well-known/security.txt
+++ b/apps/landing/public/.well-known/security.txt
@@ -12,7 +12,6 @@
 Contact: mailto:security@seald.nromomentum.com
 Contact: https://seald.nromomentum.com/legal/responsible-disclosure
 Expires: 2027-04-30T00:00:00.000Z
-Encryption: https://seald.nromomentum.com/.well-known/security-pgp-key.txt
 Preferred-Languages: en
 Canonical: https://seald.nromomentum.com/.well-known/security.txt
 Policy: https://seald.nromomentum.com/legal/responsible-disclosure

--- a/apps/landing/src/layouts/BaseLayout.astro
+++ b/apps/landing/src/layouts/BaseLayout.astro
@@ -20,6 +20,18 @@ export interface Props {
   canonical?: string;
   ogImage?: string;
   noindex?: boolean;
+  /**
+   * When `true` (the default for everything except the marketing homepage)
+   * the layout renders a small shared footer with the legal links + the
+   * "Manage cookie preferences" button. The homepage opts out via
+   * `minimalFooter={false}` because it ships its own full marketing footer
+   * that already includes the same controls — rendering both would
+   * duplicate the cookie-management entry point.
+   *
+   * Issue #39 / EDPB 03/2022 + CCPA §7026(a)(4): consent withdrawal MUST
+   * be reachable from every surface, with the same ease as giving it.
+   */
+  minimalFooter?: boolean;
 }
 
 const {
@@ -32,6 +44,7 @@ const {
   // — the link below will pick it up automatically.
   ogImage = '/og-image.svg',
   noindex = false,
+  minimalFooter = true,
 } = Astro.props;
 
 // Resolve canonical against the configured site so relative paths work.
@@ -154,5 +167,27 @@ const softwareLd = {
   <body>
     <a href="#main" class="sr-only">Skip to main content</a>
     <slot />
+    {minimalFooter ? (
+      <footer class="minimal-footer" aria-label="Legal and cookie preferences">
+        <div class="container">
+          <nav class="minimal-footer-links" aria-label="Legal links">
+            <a href="/legal/privacy">Privacy</a>
+            <a href="/legal/terms">Terms</a>
+            <a href="/legal/cookies">Cookies</a>
+            <a href="/legal/accessibility">Accessibility</a>
+            <a href="/legal/responsible-disclosure">Report a vulnerability</a>
+            <button
+              type="button"
+              class="link-button"
+              data-testid="footer-manage-cookies"
+              onclick="window.SealdConsent && window.SealdConsent.openBanner()"
+            >
+              Manage cookie preferences
+            </button>
+          </nav>
+          <p class="minimal-footer-copy">© 2026 Seald, Inc. — Put your name to it.</p>
+        </div>
+      </footer>
+    ) : null}
   </body>
 </html>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -7,6 +7,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
 <BaseLayout
   title="Seald — Put your name to it."
   description="Seald is a quieter way to sign, send, and store documents — built for the contracts you actually care about. EU-grade PAdES seals, RFC 3161 timestamps, audit trail on every page."
+  minimalFooter={false}
 >
   <!-- ===== NAV ===== -->
   <nav class="nav" id="nav">

--- a/apps/landing/src/pages/legal/cookies.astro
+++ b/apps/landing/src/pages/legal/cookies.astro
@@ -1,6 +1,6 @@
 ---
 import BaseLayout from '@/layouts/BaseLayout.astro';
-const VERSION = 'cookies_v0.1';
+const VERSION = 'cookies_v0.2';
 ---
 <BaseLayout
   title="Cookie Policy — Seald"
@@ -11,7 +11,7 @@ const VERSION = 'cookies_v0.1';
       <header>
         <section class="legal-banner">
           <p><strong>Draft — not legal advice.</strong> This document is published in good faith as Seald's working draft. It has not yet been reviewed by counsel and may change before becoming binding. If you are reviewing this on behalf of a customer, please contact <a href="mailto:legal@seald.nromomentum.com">legal@seald.nromomentum.com</a> for the countersigned production version.</p>
-          <p class="meta">Version: <code>{VERSION}</code> · Last updated: <code>2026-04-30</code></p>
+          <p class="meta">Version: <code>{VERSION}</code> · Last updated: <code>2026-05-01</code></p>
         </section>
         <h1>Cookie Policy</h1>
         <p>This page explains what cookies and similar technologies Seald, Inc. ("<strong>Seald</strong>", "we") uses on the Seald website at <a href="https://seald.nromomentum.com">seald.nromomentum.com</a> and inside the Seald e-signature web application (the "<strong>Service</strong>"), what they do, how long they last, and how you can opt out. It is meant to be read in plain English.</p>
@@ -24,6 +24,7 @@ const VERSION = 'cookies_v0.1';
 
       <section id="categories">
         <h2>2. Categories of cookies we use</h2>
+        <p>Today the Service uses only two categories: strictly necessary cookies that always run, and a single optional analytics beacon that you can accept or reject. We do not currently operate any marketing, advertising, social-media, or personalization cookies — so the choice we ask you to make is binary, not per-category. If we ever add another non-essential cookie or beacon we will update this Policy and re-prompt for consent.</p>
         <h3>2.1 Strictly necessary</h3>
         <p>These cookies are required for the Service to work. We do not ask for your consent to set them, because the law (ePrivacy Directive 2002/58/EC, Article 5(3)) treats them as strictly necessary for the service you have requested.</p>
         <h3>2.2 Analytics (privacy-friendly, consent-gated)</h3>
@@ -83,9 +84,9 @@ const VERSION = 'cookies_v0.1';
         <p>If you visit the Site from the EEA, the UK, or Switzerland, we show a consent banner before any non-essential cookie or beacon fires. Following the European Data Protection Board's Guidelines 03/2022 on dark patterns:</p>
         <ul>
           <li>The "Reject" button is shown with the same prominence as the "Accept" button.</li>
-          <li>No category is pre-ticked.</li>
-          <li>You can choose categories individually.</li>
-          <li>You can withdraw your consent at any time, with the same ease as giving it, by clicking <strong>Manage cookie preferences</strong> in the footer.</li>
+          <li>No option is pre-ticked.</li>
+          <li>The choice is binary — you can accept or reject the optional analytics beacon (see §2.2). Strictly necessary cookies always run, because they are required to deliver the Service. We do not currently operate any other non-essential category, so there is nothing else to toggle. If that ever changes we will re-prompt for consent.</li>
+          <li>You can withdraw your consent at any time, with the same ease as giving it, by clicking <strong>Manage cookie preferences</strong> in the footer of every page.</li>
           <li>Continued browsing is never treated as consent.</li>
         </ul>
         <p>We honor the Global Privacy Control browser signal as an opt-out for the analytics category, in line with California CCPA Regulations § 7025 and the universal-opt-out mechanisms required by Colorado and Connecticut.</p>

--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -2164,6 +2164,59 @@ footer {
   color: rgba(255, 255, 255, 0.5);
 }
 
+/* ===== MINIMAL FOOTER (BaseLayout, every page except /) =====
+   Issue #39 — the manage-cookies button MUST be reachable from every
+   marketing/legal/contact/dsar surface. Kept visually quiet so it does
+   not compete with page content. */
+.minimal-footer {
+  background: var(--ink-900);
+  color: rgba(255, 255, 255, 0.7);
+  padding: 32px 0;
+  margin-top: 64px;
+}
+.minimal-footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 18px 24px;
+  align-items: center;
+}
+.minimal-footer-links a {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 14px;
+  text-decoration: none;
+  transition: color 120ms;
+}
+.minimal-footer-links a:hover {
+  color: #fff;
+}
+.minimal-footer-links .link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  text-align: left;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 14px;
+  cursor: pointer;
+  transition: color 120ms;
+}
+.minimal-footer-links .link-button:hover {
+  color: #fff;
+}
+.minimal-footer-links .link-button:focus-visible,
+.minimal-footer-links a:focus-visible {
+  outline: 2px solid rgba(165, 180, 252, 0.9);
+  outline-offset: 2px;
+  border-radius: 2px;
+  color: #fff;
+}
+.minimal-footer-copy {
+  margin: 16px 0 0 0;
+  font-size: 13px;
+  color: rgba(255, 255, 255, 0.5);
+}
+
 .reveal {
   opacity: 0;
   transform: translateY(24px);

--- a/apps/web/src/features/signingFill/model/useSigningFillController.test.ts
+++ b/apps/web/src/features/signingFill/model/useSigningFillController.test.ts
@@ -32,12 +32,14 @@ const session: {
   fillField: ReturnType<typeof vi.fn>;
   setSignature: ReturnType<typeof vi.fn>;
   decline: ReturnType<typeof vi.fn>;
+  withdrawConsent: ReturnType<typeof vi.fn>;
 } = {
   fields: [],
   nextField: null,
   fillField: vi.fn(),
   setSignature: vi.fn(),
   decline: vi.fn(),
+  withdrawConsent: vi.fn(),
 };
 vi.mock('@/features/signing', async () => {
   const actual = (await vi.importActual('@/features/signing')) as Record<string, unknown>;
@@ -69,6 +71,7 @@ beforeEach(() => {
     if (f) (f as { value_text: string | null }).value_text = 'data:image/png;base64,xxx';
   });
   session.decline = vi.fn(async () => {});
+  session.withdrawConsent = vi.fn(async () => {});
 
   // jsdom's querySelector finds nothing because we don't render the
   // PDF page nodes in this hook-only test. Stub it to return a fake

--- a/apps/web/src/features/signingFill/model/useSigningFillController.ts
+++ b/apps/web/src/features/signingFill/model/useSigningFillController.ts
@@ -74,6 +74,13 @@ interface UseSigningFillControllerReturn {
   readonly handleSignatureApply: (result: SignatureCaptureResult) => Promise<void>;
   readonly handleReview: () => void;
   readonly handleDecline: () => Promise<void>;
+  /**
+   * Issue #41 — ESIGN Disclosure §3 promises a Withdraw-consent control on
+   * "the signing screen". Surfaced from the controller so both the Fill
+   * and Review pages can render the same affordance with the same audit
+   * outcome (a `consent_withdrawn` event distinct from `declined`).
+   */
+  readonly handleWithdrawConsent: () => Promise<void>;
 }
 
 /**
@@ -87,7 +94,8 @@ export function useSigningFillController({
   envelopeId,
 }: UseSigningFillControllerArgs): UseSigningFillControllerReturn {
   const navigate = useNavigate();
-  const { fillField, setSignature, decline, nextField, fields } = useSigningSession();
+  const { fillField, setSignature, decline, nextField, fields, withdrawConsent } =
+    useSigningSession();
 
   const [activeFieldId, setActiveFieldId] = useState<string | null>(null);
   const [textDrawer, setTextDrawer] = useState<TextDrawerState | null>(null);
@@ -300,6 +308,28 @@ export function useSigningFillController({
     }
   }, [busy, decline, envelopeId, navigate]);
 
+  const handleWithdrawConsent = useCallback(async (): Promise<void> => {
+    if (busy) return;
+    // Distinct from "Decline" — withdrawal of consent under ESIGN
+    // §7001(c)(1). Mirrored from SigningPrepPage so users get the same
+    // explicit warning regardless of which signing-screen step they
+    // trigger withdrawal from (issue #41).
+    // eslint-disable-next-line no-alert -- native confirm is appropriate; a custom modal is over-engineering for an irreversible signer-side terminal action.
+    const confirmed = window.confirm(
+      'Withdraw consent to sign this document electronically?\n\n' +
+        'Seald operates electronically only — withdrawing consent ends this signing request without an alternative. ' +
+        'The sender will be notified. This is recorded in the audit trail as a withdrawal (distinct from a decline).',
+    );
+    if (!confirmed) return;
+    setBusy(true);
+    try {
+      await withdrawConsent();
+      navigate(`/sign/${envelopeId}/declined`, { replace: true });
+    } catch {
+      setBusy(false);
+    }
+  }, [busy, envelopeId, navigate, withdrawConsent]);
+
   return {
     activeFieldId,
     textDrawer,
@@ -314,5 +344,6 @@ export function useSigningFillController({
     handleSignatureApply,
     handleReview,
     handleDecline,
+    handleWithdrawConsent,
   };
 }

--- a/apps/web/src/layout/AppShell.test.tsx
+++ b/apps/web/src/layout/AppShell.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { fireEvent } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { AppShell } from './AppShell';
+
+// AppShell pulls account actions via React-Query — stub the hook so the
+// shell can render without a live API. We only care about the legal/
+// cookie footer for issue #39 here.
+vi.mock('@/features/account', () => ({
+  useAccountActions: () => ({
+    exportData: vi.fn(),
+    deleteAccount: vi.fn(),
+    isExporting: false,
+    isDeleting: false,
+  }),
+}));
+
+function renderShell() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/documents']}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/documents" element={<div>doc list</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppShell legal/cookie footer (issue #39)', () => {
+  afterEach(() => {
+    delete (window as unknown as { SealdConsent?: unknown }).SealdConsent;
+  });
+
+  it('renders the legal trust links beneath the routed content', () => {
+    const { getByRole } = renderShell();
+    const footer = getByRole('contentinfo', { name: /legal and cookie preferences/i });
+    expect(footer).toBeInTheDocument();
+    expect(footer.querySelector('a[href="/legal/privacy"]')).toBeInTheDocument();
+    expect(footer.querySelector('a[href="/legal/terms"]')).toBeInTheDocument();
+    expect(footer.querySelector('a[href="/legal/cookies"]')).toBeInTheDocument();
+    expect(footer.querySelector('a[href="/legal/accessibility"]')).toBeInTheDocument();
+  });
+
+  it('renders the manage-cookies button next to the trust links', () => {
+    const { getByRole } = renderShell();
+    const btn = getByRole('button', { name: /manage cookie preferences/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute('type', 'button');
+  });
+
+  it('opens the consent banner when the manage-cookies button is clicked', () => {
+    const openBanner = vi.fn();
+    (
+      window as unknown as { SealdConsent: { openBanner: () => void; getChoice: () => null } }
+    ).SealdConsent = { openBanner, getChoice: () => null };
+    const { getByRole } = renderShell();
+    fireEvent.click(getByRole('button', { name: /manage cookie preferences/i }));
+    expect(openBanner).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops gracefully when the consent runtime has not loaded yet', () => {
+    // The cookie-consent script is `defer`-loaded; a click that beats the
+    // script must not crash the shell.
+    const { getByRole } = renderShell();
+    expect(() =>
+      fireEvent.click(getByRole('button', { name: /manage cookie preferences/i })),
+    ).not.toThrow();
+  });
+});

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -31,6 +31,76 @@ const Content = styled.main`
 `;
 
 /**
+ * Issue #39 — the legal trust links plus the cookie-preferences re-opener
+ * MUST be reachable from every authed surface, not just the AuthShell
+ * (sign-in / sign-up). EDPB 03/2022 + CCPA §7026(a)(4): consent
+ * withdrawal must be "as easy as" giving consent. Kept visually quiet
+ * (small text, neutral color) so it never competes with page chrome.
+ */
+const ShellFooter = styled.footer`
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 18px;
+  align-items: center;
+  justify-content: center;
+  padding: 14px 24px;
+  border-top: 1px solid ${({ theme }) => theme.color.border[2]};
+  background: ${({ theme }) => theme.color.paper};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  color: ${({ theme }) => theme.color.fg[3]};
+
+  a,
+  button {
+    color: inherit;
+    font-size: inherit;
+    text-decoration: none;
+  }
+
+  a:hover,
+  button:hover {
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+
+  a:focus-visible,
+  button:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.color.indigo[500]};
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+`;
+
+const ShellFooterButton = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  cursor: pointer;
+`;
+
+function ShellLegalFooter() {
+  const handleManageCookies = (): void => {
+    window.SealdConsent?.openBanner();
+  };
+  return (
+    <ShellFooter aria-label="Legal and cookie preferences">
+      <a href="/legal/privacy">Privacy</a>
+      <a href="/legal/terms">Terms</a>
+      <a href="/legal/cookies">Cookies</a>
+      <a href="/legal/accessibility">Accessibility</a>
+      <ShellFooterButton
+        type="button"
+        data-testid="footer-manage-cookies"
+        onClick={handleManageCookies}
+      >
+        Manage cookie preferences
+      </ShellFooterButton>
+    </ShellFooter>
+  );
+}
+
+/**
  * L4 layout — wraps routed pages with the shared NavBar. The NavBar's `mode`
  * follows auth state: `authed` for signed-in users, `guest` for anonymous
  * visitors who chose "Skip". Anonymous-without-skip never reach this shell
@@ -101,6 +171,7 @@ export function AppShell() {
       <Content>
         <Outlet />
       </Content>
+      <ShellLegalFooter />
     </Shell>
   );
 }

--- a/apps/web/src/pages/SigningFillPage/SigningFillPage.styles.ts
+++ b/apps/web/src/pages/SigningFillPage/SigningFillPage.styles.ts
@@ -82,6 +82,29 @@ export const DeclineBtn = styled.button`
 `;
 
 /**
+ * Issue #41 — Withdraw-consent affordance promised by the ESIGN
+ * Disclosure §3 ("withdraw your consent at any time before signing the
+ * document by clicking Withdraw consent on the signing screen"). Kept
+ * visually quieter than Decline so it does not invite accidental
+ * activation, but reachable from every signing-screen step.
+ */
+export const WithdrawBtn = styled.button`
+  height: 36px;
+  padding: 0 12px;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.color.fg[3]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  font-weight: ${({ theme }) => theme.font.weight.regular};
+  text-decoration: underline;
+  cursor: pointer;
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;
+
+/**
  * Center column: document canvas on the left, pages rail on the right.
  * `overflow: auto` on the scroll container so rail stays pinned while pages scroll.
  */

--- a/apps/web/src/pages/SigningFillPage/SigningFillPage.test.tsx
+++ b/apps/web/src/pages/SigningFillPage/SigningFillPage.test.tsx
@@ -145,6 +145,46 @@ describe('SigningFillPage', () => {
     });
   });
 
+  describe('Withdraw consent (issue #41)', () => {
+    afterEach(() => {
+      vi.spyOn(window, 'confirm').mockRestore?.();
+    });
+
+    it('renders a Withdraw consent control next to Decline on the signing screen', async () => {
+      renderFill();
+      const btn = await screen.findByRole('button', { name: /withdraw consent/i });
+      expect(btn).toBeInTheDocument();
+    });
+
+    it('confirm + click POSTs /sign/withdraw-consent and routes to /declined', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      post.mockResolvedValueOnce(
+        okResponse({ status: 'consent_withdrawn', envelope_status: 'declined' }),
+      );
+      renderFill();
+      const btn = await screen.findByRole('button', { name: /withdraw consent/i });
+      await userEvent.click(btn);
+      await waitFor(() => {
+        expect(post).toHaveBeenCalledWith('/sign/withdraw-consent', undefined, expect.any(Object));
+      });
+      await waitFor(() => {
+        // no semantic role: __pathname__ is a test-only sentinel probe (rule 4.6)
+        expect(screen.getByTestId('__pathname__').textContent).toBe(
+          `/sign/${MOCK_ENVELOPE_ID}/declined`,
+        );
+      });
+    });
+
+    it('cancelled confirm does not call the withdraw endpoint', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      renderFill();
+      const btn = await screen.findByRole('button', { name: /withdraw consent/i });
+      await userEvent.click(btn);
+      // No POSTs at all — only the GET /sign/me from the initial render fired.
+      expect(post).not.toHaveBeenCalled();
+    });
+  });
+
   it('a 413 signature upload surfaces a size-error banner (no redirect)', async () => {
     const err = Object.assign(new Error('image_too_large'), { status: 413 });
     post.mockRejectedValueOnce(err);

--- a/apps/web/src/pages/SigningFillPage/SigningFillPage.tsx
+++ b/apps/web/src/pages/SigningFillPage/SigningFillPage.tsx
@@ -35,6 +35,7 @@ import {
   RailSlot,
   ReviewBtn,
   Spacer,
+  WithdrawBtn,
 } from './SigningFillPage.styles';
 
 // Default field box dimensions when the backend didn't send explicit width/
@@ -88,6 +89,7 @@ function Content() {
     handleSignatureApply,
     handleReview,
     handleDecline,
+    handleWithdrawConsent,
   } = useSigningFillController({ envelopeId });
 
   // Zoom + scroll-spy + page rail — extracted to a reusable hook (rule 1.1).
@@ -146,6 +148,14 @@ function Content() {
         <DeclineBtn type="button" onClick={handleDecline} disabled={busy}>
           Decline
         </DeclineBtn>
+        <WithdrawBtn
+          type="button"
+          onClick={handleWithdrawConsent}
+          disabled={busy}
+          title="Withdraw consent to use electronic signatures for this document"
+        >
+          Withdraw consent
+        </WithdrawBtn>
         {!allRequiredFilled && nextField ? (
           <NextBtn type="button" onClick={handleNext}>
             <Icon icon={ArrowDown} size={14} />

--- a/apps/web/src/pages/SigningReviewPage/SigningReviewPage.test.tsx
+++ b/apps/web/src/pages/SigningReviewPage/SigningReviewPage.test.tsx
@@ -135,6 +135,51 @@ describe('SigningReviewPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/boom/i);
   });
 
+  describe('Withdraw consent (issue #41)', () => {
+    afterEach(() => {
+      vi.spyOn(window, 'confirm').mockRestore?.();
+    });
+
+    it('renders a Withdraw consent control on the review screen', async () => {
+      renderReview();
+      const btn = await screen.findByRole('button', {
+        name: /withdraw consent to sign electronically/i,
+      });
+      expect(btn).toBeInTheDocument();
+    });
+
+    it('confirm + click POSTs /sign/withdraw-consent and routes to /declined', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(true);
+      post.mockResolvedValueOnce(
+        okResponse({ status: 'consent_withdrawn', envelope_status: 'declined' }),
+      );
+      renderReview();
+      const btn = await screen.findByRole('button', {
+        name: /withdraw consent to sign electronically/i,
+      });
+      await userEvent.click(btn);
+      await waitFor(() => {
+        expect(post).toHaveBeenCalledWith('/sign/withdraw-consent', undefined, expect.any(Object));
+      });
+      await waitFor(() => {
+        // no semantic role: __pathname__ is a test-only sentinel probe (rule 4.6)
+        expect(screen.getByTestId('__pathname__').textContent).toBe(
+          `/sign/${MOCK_ENVELOPE_ID}/declined`,
+        );
+      });
+    });
+
+    it('cancelled confirm does not call the withdraw endpoint', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      renderReview();
+      const btn = await screen.findByRole('button', {
+        name: /withdraw consent to sign electronically/i,
+      });
+      await userEvent.click(btn);
+      expect(post).not.toHaveBeenCalled();
+    });
+  });
+
   it('Save as template button opens the dialog and submits the payload', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     renderReview();

--- a/apps/web/src/pages/SigningReviewPage/SigningReviewPage.tsx
+++ b/apps/web/src/pages/SigningReviewPage/SigningReviewPage.tsx
@@ -140,6 +140,30 @@ const SaveTemplateBtn = styled.button`
   }
 `;
 
+/**
+ * Issue #41 — Withdraw-consent affordance promised by ESIGN Disclosure §3.
+ * Visually quiet text link below the primary actions; mirrors the prep
+ * page's WithdrawLink so the control is reachable from every signing
+ * step (prep / fill / review).
+ */
+const WithdrawLink = styled.button`
+  margin-top: ${({ theme }) => theme.space[4]};
+  background: transparent;
+  border: none;
+  color: ${({ theme }) => theme.color.fg[3]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  font-weight: ${({ theme }) => theme.font.weight.regular};
+  text-align: center;
+  display: block;
+  width: 100%;
+  cursor: pointer;
+  text-decoration: underline;
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+`;
+
 const Toast = styled.div`
   margin-top: ${({ theme }) => theme.space[4]};
   background: ${({ theme }) => theme.color.success[50]};
@@ -229,7 +253,7 @@ function Content() {
   const navigate = useNavigate();
   const params = useParams<{ readonly envelopeId: string }>();
   const envelopeId = params.envelopeId ?? '';
-  const { envelope, fields, submit, confirmIntentToSign } = useSigningSession();
+  const { envelope, fields, submit, confirmIntentToSign, withdrawConsent } = useSigningSession();
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [saveTplOpen, setSaveTplOpen] = useState(false);
@@ -258,6 +282,30 @@ function Content() {
     () => navigate(`/sign/${envelopeId}/fill`),
     [envelopeId, navigate],
   );
+
+  const handleWithdrawConsent = useCallback(async () => {
+    if (busy) return;
+    // Same warning copy as SigningPrepPage / SigningFillPage so the
+    // consequence is identical regardless of which signing-screen step
+    // the signer triggers withdrawal from (issue #41).
+    // eslint-disable-next-line no-alert -- native confirm is appropriate; a custom modal is over-engineering for an irreversible signer-side terminal action.
+    const confirmed = window.confirm(
+      'Withdraw consent to sign this document electronically?\n\n' +
+        'Seald operates electronically only — withdrawing consent ends this signing request without an alternative. ' +
+        'The sender will be notified. This is recorded in the audit trail as a withdrawal (distinct from a decline).',
+    );
+    if (!confirmed) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await withdrawConsent();
+      navigate(`/sign/${envelopeId}/declined`, { replace: true });
+    } catch (err) {
+      setBusy(false);
+      const e = err as ApiErrorLike;
+      setError(e.message ?? 'We could not record your withdrawal right now. Please try again.');
+    }
+  }, [busy, envelopeId, navigate, withdrawConsent]);
 
   const handleSubmit = useCallback(async () => {
     if (!intentChecked) return;
@@ -342,6 +390,10 @@ function Content() {
             {busy ? 'Submitting…' : 'Sign and submit'}
           </SubmitBtn>
         </Actions>
+
+        <WithdrawLink type="button" onClick={handleWithdrawConsent} disabled={busy}>
+          Withdraw consent to sign electronically
+        </WithdrawLink>
       </Inner>
     </Page>
   );

--- a/cspell.json
+++ b/cspell.json
@@ -458,6 +458,7 @@
     "dsar",
     "CCPA",
     "ccpa",
+    "EDPB",
     "serialisable",
     "hrefs",
     "initialised"


### PR DESCRIPTION
## Summary

Closes four legal-compliance gaps surfaced by the phase-7 audit. Each
fix is a focused commit so it can be reviewed in isolation. Issue #38
(DELETE /me cascade — user-judgment policy tradeoff) is intentionally
out of scope.

| Issue | Commit | What changed |
|---|---|---|
| #39 (landing) | `566f672` | `BaseLayout.astro` gains a `minimalFooter` prop (default `true`). Every legal/contact/dsar page now ships the four trust links + Manage cookie preferences button. Homepage opts out via `minimalFooter={false}` (already has its own full marketing footer). |
| #39 (SPA) | `60946d8` | `AppShell` gets a small footer below `<Outlet/>` carrying the same legal links + cookie button. Vitest covers render, role-based reachability, openBanner click, and a no-op when the deferred `cookie-consent.js` hasn't loaded yet. |
| #40 | `a20c23a` | Cookie Policy §2/§4 rewritten — promises a binary accept/reject (matching the runtime banner) instead of "categories individually". Version bumps `cookies_v0.1` → `cookies_v0.2`, "Last updated" stamp moves to 2026-05-01. |
| #41 | `4fabfd3` | `useSigningFillController` gains `handleWithdrawConsent`. `SigningFillPage` and `SigningReviewPage` both render a quiet Withdraw-consent control. Vitest covers the new affordance on both pages (render, confirm + happy-path POST `/sign/withdraw-consent`, cancelled-confirm no-op). |
| #42 | `12d1c95` | `security.txt` drops the unresolvable `Encryption:` line (Option A from spec — safest until a real PGP key is provisioned + key-rotation runbook exists). |

## Compliance promises now kept

- EDPB 03/2022 + CCPA §7026(a)(4) — withdrawal of cookie consent is now reachable from every marketing/legal/contact/dsar surface AND every authed SPA page (was: homepage + auth shell only).
- Cookie Policy §3/§4/§5 — text matches the implemented banner (binary opt-in for the single optional category).
- ESIGN Disclosure §3 — Withdraw consent reachable on every signing-screen step (was: prep page only).
- RFC 9116 §2.5.4 — every directive in `security.txt` resolves.

## React PR review (per CLAUDE.md mandatory rule)

Invoked `seald-react-pr-review` before each web commit. Verdict on the
combined web diff:

- MUST-FIX: none
- SHOULD-FIX: `handleWithdrawConsent` is now duplicated across prep page, controller hook, and review page (rule 1.1). Recommended follow-up: extract `useWithdrawConsentFlow(envelopeId, reasonHint?)` in `apps/web/src/features/signing/`. Out of scope here to keep the compliance-fix PR small.
- NICE-TO-HAVE: none
- Gates: `pnpm -r typecheck` ✓, `pnpm -r lint` ✓, `pnpm --filter web test` ✓ (793/793), `pnpm --filter landing build` ✓ (12 pages).

## Coordination with open PRs

- **PR #47** (`feat/dsar-intake-page-t12`) — touches `apps/landing/src/pages/index.astro` (footer link to /dsar) and `apps/landing/src/pages/legal/privacy.astro` (DSAR-form links). This PR avoided those files entirely.
- **Real-PDF e2e PR** (worktree branch) — this PR did not modify `apps/web/e2e/**`.

## Test plan

- [ ] Verify the minimal footer renders on every non-homepage Astro route (`/contact`, `/legal/*`).
- [ ] Verify the homepage still renders only its full marketing footer (no duplicate).
- [ ] Verify post-auth SPA pages (`/documents`, `/sign/:id/fill`, `/sign/:id/review`) show the AppShell legal footer with the Manage cookie preferences button.
- [ ] Click "Manage cookie preferences" from a legal page and confirm the consent banner re-opens.
- [ ] Open `/sign/:id/fill` for an envelope, click Withdraw consent, confirm the dialog, verify the audit chain shows `consent_withdrawn` (NOT `declined`) and the envelope ends in `/declined`.
- [ ] Same flow on `/sign/:id/review`.
- [ ] `curl https://seald.nromomentum.com/.well-known/security.txt` — confirm no `Encryption:` line.
- [ ] Visit `/legal/cookies` and verify §2 / §4 wording matches reality (binary accept/reject) and version reads `cookies_v0.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)