### PR TITLE
fix(ux): gate Google/Skip on signup consent + audit-pdf row overflow

### DIFF
--- a/apps/api/src/sealing/audit-pdf.tsx
+++ b/apps/api/src/sealing/audit-pdf.tsx
@@ -792,13 +792,27 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     paddingVertical: 6,
     paddingHorizontal: 16,
-    alignItems: 'center',
+    // Was 'center'. Switched to 'flex-start' so the IP + timestamp
+    // columns stay aligned to the top of the row when the ACTION
+    // column wraps to a second line (long labels like "ESIGN
+    // disclosure acknowledged"). Inner cells carry their own
+    // paddingTop so single-line rows still look optically centered
+    // against the 22px action chip.
+    alignItems: 'flex-start',
     borderBottomWidth: 1,
     borderBottomColor: C.ink200,
     borderBottomStyle: 'solid',
   },
   evtRowLast: { borderBottomWidth: 0 },
-  evtAction: { flex: 1.5, flexDirection: 'row', alignItems: 'center' },
+  // Column widths rebalanced 2026-05-01 — the longest action label
+  // ("ESIGN disclosure acknowledged") was overflowing the ACTION column
+  // and rendering on top of the IP column. Bumped ACTION 1.5 → 2.0 and
+  // dropped IP 1.4 → 1.1 (an IPv4 string is 15 chars max, so 1.1 is
+  // generous; IPv6 still fits because the row is `alignItems: 'flex-start'`
+  // and the Text wraps if needed). Inner `evtActionText` now carries
+  // `flex: 1` + minWidth: 0 so it shrinks to fit the column instead of
+  // pushing past it.
+  evtAction: { flex: 2.0, flexDirection: 'row', alignItems: 'flex-start', paddingRight: 8 },
   evtIco: {
     width: 22,
     height: 22,
@@ -806,11 +820,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
     marginRight: 10,
+    flexShrink: 0,
   },
-  evtActionText: { fontFamily: 'Inter', fontSize: 10, color: C.ink900, fontWeight: 500 },
-  evtIp: { flex: 1.4, fontFamily: 'JetBrainsMono', fontSize: 9, color: C.ink700 },
+  evtActionText: {
+    flex: 1,
+    minWidth: 0,
+    fontFamily: 'Inter',
+    fontSize: 10,
+    color: C.ink900,
+    fontWeight: 500,
+    lineHeight: 1.35,
+    paddingTop: 4,
+  },
+  evtIp: { flex: 1.1, fontFamily: 'JetBrainsMono', fontSize: 9, color: C.ink700, paddingTop: 6 },
   evtIpDim: { color: C.ink400 },
-  evtTs: { flex: 1.6, fontFamily: 'JetBrainsMono', fontSize: 9, color: C.ink700 },
+  evtTs: { flex: 1.4, fontFamily: 'JetBrainsMono', fontSize: 9, color: C.ink700, paddingTop: 6 },
 
   // ---- Trust bar ----
   // marginTop tightened from 14 to 8 + smaller paddings so the bar

--- a/apps/web/src/components/AuthForm/AuthForm.styles.ts
+++ b/apps/web/src/components/AuthForm/AuthForm.styles.ts
@@ -48,8 +48,14 @@ export const TosRow = styled.label`
 `;
 
 export const Checkbox = styled.input`
+  /* min-width + flex-shrink: 0 keep both checkboxes visually identical
+     even when their adjacent text wraps to a different number of lines.
+     Without these, the longer-text row's flex layout was squeezing the
+     checkbox a few px narrower, making the two rows look mismatched. */
   width: 18px;
   height: 18px;
+  min-width: 18px;
+  flex-shrink: 0;
   accent-color: ${({ theme }) => theme.color.ink[900]};
   cursor: pointer;
 `;
@@ -123,13 +129,17 @@ export const SkipButton = styled.button`
   color: ${({ theme }) => theme.color.fg[3]};
   cursor: pointer;
   border-radius: ${({ theme }) => theme.radius.sm};
-  &:hover {
+  &:hover:not(:disabled) {
     color: ${({ theme }) => theme.color.fg[1]};
     background: ${({ theme }) => theme.color.ink[100]};
   }
   &:focus-visible {
     outline: none;
     box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 `;
 

--- a/apps/web/src/components/AuthForm/AuthForm.test.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.test.tsx
@@ -151,6 +151,42 @@ describe('AuthForm', () => {
     expect(onSkip).toHaveBeenCalledTimes(1);
   });
 
+  // Regression: T-24/T-25 + ESIGN affirmative-consent. The Google + Skip
+  // bypass the password form, but on signup mode they still create / claim
+  // an account on our side, so the age-gate + ToS/Privacy attestation must
+  // gate them too. Signin mode is unaffected — the user accepted at signup.
+  it('disables "Sign up with Google" until both signup checkboxes are ticked', async () => {
+    const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
+    const google = getByRole('button', { name: /sign up with google/i });
+    expect(google).toBeDisabled();
+    await userEvent.click(getByLabelText(/agree to terms/i));
+    expect(google).toBeDisabled();
+    await userEvent.click(getByLabelText(/legal age/i));
+    expect(google).not.toBeDisabled();
+    await userEvent.click(google);
+    expect(auth.signInWithGoogle).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not gate "Continue with Google" in signin mode', () => {
+    const { getByRole } = renderWithTheme(<AuthForm mode="signin" />);
+    expect(getByRole('button', { name: /continue with google/i })).not.toBeDisabled();
+  });
+
+  it('disables Skip in signup mode until both checkboxes are ticked', async () => {
+    const onSkip = vi.fn();
+    const { getByRole, getByLabelText } = renderWithTheme(
+      <AuthForm mode="signup" onSkip={onSkip} />,
+    );
+    const skip = getByRole('button', { name: /skip — try it/i });
+    expect(skip).toBeDisabled();
+    await userEvent.click(getByLabelText(/agree to terms/i));
+    expect(skip).toBeDisabled();
+    await userEvent.click(getByLabelText(/legal age/i));
+    expect(skip).not.toBeDisabled();
+    await userEvent.click(skip);
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
   it('surfaces provider errors in a banner', async () => {
     auth.signInWithPassword.mockRejectedValueOnce(new Error('Invalid login credentials'));
     const { getByRole, getByLabelText, findByRole } = renderWithTheme(<AuthForm mode="signin" />);

--- a/apps/web/src/components/AuthForm/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.tsx
@@ -77,18 +77,27 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
 
   const strength = useMemo(() => (isSignup ? scorePassword(password) : 0), [isSignup, password]);
 
+  // The age-gate + ToS/Privacy attestation gates the password Submit. It
+  // ALSO gates Google + Skip in signup mode — both create an account on
+  // our side (Google = OAuth-claimed user, Skip = guest session bound to
+  // our Privacy Policy) so the affirmative ESIGN/GDPR consent must
+  // happen before either flow starts. Signin mode shows no checkboxes
+  // and is unaffected.
+  const signupConsented = agreed && ofAge;
+
   const valid = useMemo(() => {
     if (isForgot) return EMAIL_RE.test(email);
     if (isSignup) {
       return (
-        name.trim().length > 1 && EMAIL_RE.test(email) && password.length >= 8 && agreed && ofAge
+        name.trim().length > 1 && EMAIL_RE.test(email) && password.length >= 8 && signupConsented
       );
     }
     return EMAIL_RE.test(email) && password.length >= 1;
-  }, [isForgot, isSignup, name, email, password, agreed, ofAge]);
+  }, [isForgot, isSignup, name, email, password, signupConsented]);
 
   const handleGoogle = async (): Promise<void> => {
     if (busy) return;
+    if (isSignup && !signupConsented) return;
     setError(null);
     setBusy(true);
     try {
@@ -98,6 +107,11 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
       setError(err instanceof Error ? err.message : 'Unable to start Google sign-in.');
       setBusy(false);
     }
+  };
+
+  const handleSkip = (): void => {
+    if (isSignup && !signupConsented) return;
+    onSkip?.();
   };
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
@@ -146,6 +160,7 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
             label={isSignup ? 'Sign up with Google' : 'Continue with Google'}
             onClick={handleGoogle}
             busy={busy}
+            disabled={isSignup && !signupConsented}
           />
           <Divider label="or" />
         </>
@@ -286,7 +301,7 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
 
       {!isForgot && onSkip ? (
         <SkipRow>
-          <SkipButton type="button" onClick={onSkip}>
+          <SkipButton type="button" onClick={handleSkip} disabled={isSignup && !signupConsented}>
             Skip — try it without an account
             <Icon icon={ArrowRight} size={14} />
           </SkipButton>


### PR DESCRIPTION
## Summary
Three small UX bugs surfaced from screenshots during the Phase-7 review.

### 1. Sign up with Google bypassed the legal-age + ToS/Privacy attestation
The password Submit was already gated, but the **Google OAuth path** and the **Skip — try it without an account** path both created an account on our side without the affirmative ESIGN/GDPR consent. Both are now disabled in signup mode until the age-gate + ToS/Privacy checkboxes are ticked. Signin mode is unaffected.

### 2. Two signup checkboxes looked different sizes
The styled `<input type="checkbox">` had no `flex-shrink: 0` / `min-width`, so the longer age-gate text (3 wrapped lines) squeezed the checkbox a few px narrower than the ToS row (2 wrapped lines). Pinned to a hard 18×18 with `flex-shrink: 0`.

### 3. Audit-trail PDF row overflow
"ESIGN disclosure acknowledged" was rendering on top of the IP column. Fixed:
- `evtActionText` now carries `flex: 1, minWidth: 0` so it shrinks to its column instead of pushing past it
- Column ratios rebalanced ACTION 1.5 → 2.0, IP 1.4 → 1.1, TS 1.6 → 1.4
- `evtRow.alignItems` flipped center → flex-start so wrapped action text doesn't drag the IP/TS columns down

## Tests
3 new regression tests in `AuthForm.test.tsx` (per react-best-practices "test before fix"):
- "Sign up with Google" disabled until both signup checkboxes ticked → confirmed FAIL pre-fix, PASS post-fix
- "Continue with Google" never gated in signin mode (regression guard)
- Skip disabled until both signup checkboxes ticked → confirmed FAIL pre-fix, PASS post-fix

## Local gates
- `pnpm -r typecheck` ✓
- `pnpm -r lint` ✓
- `pnpm --filter web vitest run` 786/786 ✓
- `pnpm --filter api test` 400/400 ✓

## Test plan
- [ ] CI green on all jobs (CI / Chromatic / Playwright / Lint Meta)
- [ ] Manual: load /signup → Sign up with Google is disabled until both checkboxes ticked
- [ ] Manual: load /signup → Skip is disabled until both checkboxes ticked
- [ ] Manual: /signin → Continue with Google + Skip both work without checkboxes (no regression)
- [ ] Visual: signup page checkboxes are visually identical
- [ ] Visual: download an audit-trail PDF after T-14 and confirm "ESIGN disclosure acknowledged" no longer overlaps the IP column

🤖 Generated with [Claude Code](https://claude.com/claude-code)