### PR TITLE
fix(privacy): preserve sealed envelopes on user delete + bundle P1 hardening (#38/#43/#44/#45/#46)

### DIFF
--- a/apps/api/db/migrations/0012_preserve_envelopes_on_user_delete.sql
+++ b/apps/api/db/migrations/0012_preserve_envelopes_on_user_delete.sql
@@ -1,0 +1,89 @@
+-- 0012_preserve_envelopes_on_user_delete.sql
+-- Issues #38 / #43 — preserve sealed envelopes when an account is deleted.
+--
+-- The original FKs on `envelopes.owner_id` and `templates.owner_id` were
+-- declared `on delete cascade`. That choice optimised for GDPR Art. 17
+-- ("right to erasure") in the simplest case, but it creates a real legal
+-- problem: ESIGN Act §7001(d) AND eIDAS Art. 25(2) AND most state-level
+-- contract-law statutes require that a cryptographically-sealed signed
+-- record be retained for the full statutory window (typically 6-7 years
+-- from the contract's date) — independently of whether the parties later
+-- choose to delete their auth records. GDPR Art. 17(3)(b/e) explicitly
+-- carves out exactly this case: erasure does not apply when "processing
+-- is necessary for compliance with a legal obligation" or "for the
+-- establishment, exercise or defence of legal claims."
+--
+-- The fix:
+--   1. Drop the cascade on `envelopes.owner_id`. Re-add as
+--      `on delete set null` so a future raw delete from `auth.users`
+--      detaches rather than destroys the envelope. The application
+--      service (MeService.deleteAccount) will explicitly null the
+--      column on the non-draft rows BEFORE asking Supabase to delete
+--      the user, so the FK never actually fires the SET NULL path
+--      against sealed records — but the safety net catches manual
+--      `delete from auth.users` invocations too.
+--   2. Drop the cascade on `templates.owner_id`. Re-add as
+--      `on delete cascade` (templates are user-private working state,
+--      not statutory records — they can vanish). The application
+--      service hard-deletes them explicitly first so the cascade is
+--      a redundant safety net.
+--   3. Create `public.deleted_user_tombstones` — a small bookkeeping
+--      table that records which `auth.users.id`s were retired plus the
+--      SHA-256 hash of their email at the moment of deletion. We
+--      cannot ALTER `auth.users` from app migrations (the schema is
+--      Supabase-owned), so this shadow table is the application-level
+--      equivalent of the brief's `users.deleted_at` / `users.email_hash`
+--      columns. The hash is purely a forensic breadcrumb — not a PII
+--      lookup index — so a future signer who shares the same email
+--      cannot be linked to the tombstoned account.
+--
+-- Idempotent: every alter/create is guarded with IF EXISTS / IF NOT
+-- EXISTS where Postgres allows it. Re-running the migration on a
+-- partially-applied schema is safe.
+
+begin;
+
+-- 1) Envelopes — drop cascade, re-add as set null.
+--    The constraint name is the Postgres default for a single-column FK:
+--    `<table>_<column>_fkey`. We tolerate either that name OR an explicit
+--    earlier rename so re-running on a hand-patched DB doesn't crash.
+alter table public.envelopes
+  drop constraint if exists envelopes_owner_id_fkey;
+
+alter table public.envelopes
+  add constraint envelopes_owner_id_fkey
+  foreign key (owner_id)
+  references auth.users(id)
+  on delete set null;
+
+-- The column was `not null` at create time. Relax to `null` so the
+-- service-layer detach path (`update envelopes set owner_id = null
+-- where ...`) and the FK SET NULL safety net both succeed.
+alter table public.envelopes
+  alter column owner_id drop not null;
+
+-- 2) Templates — drop the legacy cascade, re-add explicitly. Keeping
+--    cascade for templates is fine because they are working state, not
+--    statutory records. The service still hard-deletes them first.
+alter table public.templates
+  drop constraint if exists templates_owner_id_fkey;
+
+alter table public.templates
+  add constraint templates_owner_id_fkey
+  foreign key (owner_id)
+  references auth.users(id)
+  on delete cascade;
+
+-- 3) Tombstone table. PK is the user_id so re-running the deletion is
+--    idempotent (an upsert with no-op on conflict would also work but
+--    we don't need it; the service guards against double-runs).
+create table if not exists public.deleted_user_tombstones (
+  user_id    uuid        primary key,
+  email_hash text        not null check (char_length(email_hash) = 64),
+  deleted_at timestamptz not null default now()
+);
+
+comment on table public.deleted_user_tombstones is
+  'Issue #38: forensic breadcrumb of deleted accounts. Records the user id and the SHA-256 hash of the email at deletion time so support can correlate "who used to own this preserved envelope?" without retaining the email itself. The original auth.users row is gone by the time this table is read.';
+
+commit;

--- a/apps/api/db/schema.ts
+++ b/apps/api/db/schema.ts
@@ -11,6 +11,18 @@ export interface Database {
   idempotency_records: IdempotencyRecordsTable;
   email_webhooks: EmailWebhooksTable;
   templates: TemplatesTable;
+  // Migration 0012 — bookkeeping for deleted accounts. See the migration
+  // header for the GDPR Art. 17(3)(b/e) carve-out rationale.
+  deleted_user_tombstones: DeletedUserTombstonesTable;
+}
+
+export interface DeletedUserTombstonesTable {
+  user_id: string;
+  email_hash: string;
+  // Updatable on conflict: a re-run of the deletion path (e.g. after a
+  // transient Supabase failure left the tombstone but not the auth-row
+  // removal) refreshes the timestamp via `recordDeletion`'s upsert.
+  deleted_at: ColumnType<Date, string | undefined, string | undefined>;
 }
 
 export type TemplateFieldTypeDb = 'signature' | 'initial' | 'date' | 'text' | 'checkbox';
@@ -109,7 +121,14 @@ export type JobStatusDb = 'pending' | 'running' | 'done' | 'failed';
 
 export interface EnvelopesTable {
   id: Generated<string>;
-  owner_id: string;
+  // Migration 0012 — relaxed to nullable. The application service
+  // detaches `owner_id` (sets it to NULL) on non-draft envelopes during
+  // account deletion so the sealed record survives auth.users deletion;
+  // the FK was also flipped from `on delete cascade` to `on delete set
+  // null` as a safety net for raw deletes that bypass the service.
+  // Drafts and templates are still hard-deleted, so a NULL owner_id
+  // implies "preserved sealed record from a deleted account".
+  owner_id: string | null;
   title: string;
   short_code: string;
   status: ColumnType<EnvelopeStatusDb, EnvelopeStatusDb | undefined, EnvelopeStatusDb | undefined>;

--- a/apps/api/src/auth/supabase-jwt.strategy.spec.ts
+++ b/apps/api/src/auth/supabase-jwt.strategy.spec.ts
@@ -41,41 +41,46 @@ describe('SupabaseJwtStrategy', () => {
     strategy = new SupabaseJwtStrategy(makeEnv(), tk.resolver);
   });
 
+  // Canonical UUIDs — Supabase always issues these as `sub`, and the
+  // strategy now enforces UUID-shape at the boundary (issue #44).
+  const UUID_1 = '11111111-1111-4111-8111-111111111111';
+  const UUID_2 = '22222222-2222-4222-8222-222222222222';
+
   it('accepts a valid token and returns AuthUser', async () => {
     const token = await tk.sign(
       {
-        sub: 'user-1',
+        sub: UUID_1,
         email: 'a@b.com',
         app_metadata: { provider: 'google' },
       },
       { issuer: ISSUER, audience: AUDIENCE },
     );
     const user = await strategy.validate(token);
-    expect(user).toEqual({ id: 'user-1', email: 'a@b.com', provider: 'google' });
+    expect(user).toEqual({ id: UUID_1, email: 'a@b.com', provider: 'google' });
   });
 
   it('returns email=null and provider=null when claims are absent', async () => {
-    const token = await tk.sign({ sub: 'user-2' }, { issuer: ISSUER, audience: AUDIENCE });
+    const token = await tk.sign({ sub: UUID_2 }, { issuer: ISSUER, audience: AUDIENCE });
     const user = await strategy.validate(token);
-    expect(user).toEqual({ id: 'user-2', email: null, provider: null });
+    expect(user).toEqual({ id: UUID_2, email: null, provider: null });
   });
 
   it('rejects wrong issuer', async () => {
     const token = await tk.sign(
-      { sub: 'u' },
+      { sub: UUID_1 },
       { issuer: 'https://evil.example/auth/v1', audience: AUDIENCE },
     );
     await expect(strategy.validate(token)).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
   it('rejects wrong audience', async () => {
-    const token = await tk.sign({ sub: 'u' }, { issuer: ISSUER, audience: 'other' });
+    const token = await tk.sign({ sub: UUID_1 }, { issuer: ISSUER, audience: 'other' });
     await expect(strategy.validate(token)).rejects.toBeInstanceOf(UnauthorizedException);
   });
 
   it('rejects expired token', async () => {
     const token = await tk.sign(
-      { sub: 'u' },
+      { sub: UUID_1 },
       { issuer: ISSUER, audience: AUDIENCE, expiresIn: '-1s' },
     );
     await expect(strategy.validate(token)).rejects.toMatchObject({
@@ -92,9 +97,30 @@ describe('SupabaseJwtStrategy', () => {
 
   it('rejects bad signature (different key)', async () => {
     const other = await buildTestJwks();
-    const token = await other.sign({ sub: 'u' }, { issuer: ISSUER, audience: AUDIENCE });
+    const token = await other.sign({ sub: UUID_1 }, { issuer: ISSUER, audience: AUDIENCE });
     await expect(strategy.validate(token)).rejects.toMatchObject({
       message: expect.stringMatching(/invalid_token/),
     });
+  });
+
+  it('rejects non-UUID sub (issue #44 — defense against header injection)', async () => {
+    // A misconfigured / hostile issuer could place a `"` byte in `sub`,
+    // which used to flow verbatim into Content-Disposition. Reject at
+    // the boundary so downstream callers can trust the shape — strict
+    // 8-4-4-4-12 hex, anything else 401s.
+    for (const badSub of [
+      'user-1', // legacy non-UUID
+      '../../../etc/passwd',
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"; filename="evil.txt',
+      '11111111-1111-4111-8111-11111111111', // 1 char short
+      'gggggggg-gggg-gggg-gggg-gggggggggggg', // non-hex
+      '11111111_1111_4111_8111_111111111111', // wrong separator
+      '', // empty (already covered by the missing-sub branch but good belt+braces)
+    ]) {
+      const token = await tk.sign({ sub: badSub }, { issuer: ISSUER, audience: AUDIENCE });
+      await expect(strategy.validate(token)).rejects.toMatchObject({
+        message: expect.stringMatching(/invalid_token/),
+      });
+    }
   });
 });

--- a/apps/api/src/auth/supabase-jwt.strategy.ts
+++ b/apps/api/src/auth/supabase-jwt.strategy.ts
@@ -5,6 +5,18 @@ import type { AppEnv } from '../config/env.schema';
 import { JWKS_RESOLVER } from './jwks.provider';
 import type { AuthUser } from './auth-user';
 
+/**
+ * Hyphenated 8-4-4-4-12 hex token (RFC 4122 UUID shape). We deliberately
+ * accept any version + any variant nibble — Supabase issues v4 today,
+ * but tightening the regex would (a) lock us out of a future migration
+ * to v7 (time-sortable) and (b) reject the synthetic all-zero/all-`a`
+ * fixtures used pervasively in our e2e suite. The defense-in-depth goal
+ * (issue #44) is to forbid quote / semicolon / CR / LF / `..` bytes
+ * before they reach `Content-Disposition` or log lines — the strict hex
+ * shape achieves that without policing UUID semantics.
+ */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 @Injectable()
 export class SupabaseJwtStrategy {
   private readonly issuer: string;
@@ -35,6 +47,16 @@ export class SupabaseJwtStrategy {
 
     const sub = payload.sub;
     if (typeof sub !== 'string' || sub.length === 0) {
+      throw new UnauthorizedException('invalid_token');
+    }
+    // Defense-in-depth (issue #44): the `sub` claim flows verbatim into
+    // log lines, the `Content-Disposition` filename of the DSAR export,
+    // and SQL `where owner_id = $1` parameters. Supabase always issues
+    // UUIDs here, but a misconfigured / hostile issuer could land a
+    // shell- or header-meaningful byte. Reject anything that isn't a
+    // canonical RFC 4122 UUID at the boundary so downstream callers can
+    // assume the invariant.
+    if (!UUID_RE.test(sub)) {
       throw new UnauthorizedException('invalid_token');
     }
 

--- a/apps/api/src/contacts/contacts.repository.pg.ts
+++ b/apps/api/src/contacts/contacts.repository.pg.ts
@@ -119,4 +119,12 @@ export class ContactsPgRepository extends ContactsRepository {
       .executeTakeFirst();
     return (res?.numDeletedRows ?? 0n) > 0n;
   }
+
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    const res = await this.db
+      .deleteFrom('contacts')
+      .where('owner_id', '=', owner_id)
+      .executeTakeFirst();
+    return Number(res?.numDeletedRows ?? 0n);
+  }
 }

--- a/apps/api/src/contacts/contacts.repository.ts
+++ b/apps/api/src/contacts/contacts.repository.ts
@@ -24,6 +24,15 @@ export abstract class ContactsRepository {
   abstract findOneByOwner(owner_id: string, id: string): Promise<Contact | null>;
   abstract update(owner_id: string, id: string, patch: UpdateContactPatch): Promise<Contact | null>;
   abstract delete(owner_id: string, id: string): Promise<boolean>;
+
+  /**
+   * Issue #38 — bulk-delete every contact owned by `owner_id`. Used by
+   * MeService.deleteAccount; contacts are working state with no
+   * statutory retention requirement, so we hard-delete them. Returns
+   * the row count actually deleted. Idempotent (returns 0 when none
+   * existed).
+   */
+  abstract deleteAllByOwner(owner_id: string): Promise<number>;
 }
 
 /**

--- a/apps/api/src/contacts/contacts.service.spec.ts
+++ b/apps/api/src/contacts/contacts.service.spec.ts
@@ -49,6 +49,16 @@ class FakeRepo extends ContactsRepository {
     this.store.delete(id);
     return true;
   }
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    let n = 0;
+    for (const [id, c] of [...this.store]) {
+      if (c.owner_id === owner_id) {
+        this.store.delete(id);
+        n++;
+      }
+    }
+    return n;
+  }
 }
 
 describe('ContactsService', () => {

--- a/apps/api/src/envelopes/envelopes.repository.pg.ts
+++ b/apps/api/src/envelopes/envelopes.repository.pg.ts
@@ -437,6 +437,28 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
     }));
   }
 
+  // Issue #46 — exposes the raw image paths (excluded from the domain
+  // Signer for wire-contract hygiene) to the DSAR export so signed-URL
+  // generation can attach short-TTL fetch handles for each capture.
+  async listSignerImagePaths(envelope_id: string): Promise<
+    ReadonlyArray<{
+      readonly signer_id: string;
+      readonly signature_image_path: string | null;
+      readonly initials_image_path: string | null;
+    }>
+  > {
+    const rows = await this.db
+      .selectFrom('envelope_signers')
+      .select(['id', 'signature_image_path', 'initials_image_path'])
+      .where('envelope_id', '=', envelope_id)
+      .execute();
+    return rows.map((r) => ({
+      signer_id: r.id,
+      signature_image_path: r.signature_image_path,
+      initials_image_path: r.initials_image_path,
+    }));
+  }
+
   // Decode helper exposed for the service layer — keeps base64 format internal
   // to the adapter. Not part of the port because cursors are a repo concern.
   decodeCursorOrThrow(cursor: string): { updated_at: string; id: string } {

--- a/apps/api/src/envelopes/envelopes.repository.pg.ts
+++ b/apps/api/src/envelopes/envelopes.repository.pg.ts
@@ -459,6 +459,130 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
     }));
   }
 
+  /**
+   * Issues #38 / #43 — atomic account-deletion purge.
+   *
+   * Wraps every step in a single transaction so a partial failure (e.g.
+   * a unique-violation race on the audit chain) rolls back and the
+   * caller can retry. The rationale for the four steps is documented on
+   * the port; this implementation keeps the SQL narrow enough to audit.
+   *
+   * NOTE: signer-row anonymization uses a placeholder email of
+   * `<email_hash>@deleted.invalid` (RFC 2606 reserved TLD) so the row
+   * remains valid for any downstream renderer while carrying zero PII.
+   */
+  async purgeOwnedDataForAccountDeletion(input: {
+    readonly owner_id: string;
+    readonly email: string | null;
+    readonly email_hash: string;
+  }): Promise<{
+    readonly drafts_deleted: number;
+    readonly envelopes_preserved: number;
+    readonly signers_anonymized: number;
+    readonly retention_events_appended: number;
+  }> {
+    return this.db.transaction().execute(async (trx) => {
+      // 1. Hard-delete drafts. They have no statutory retention — they
+      //    were never sent, never signed, never sealed. Cascades on
+      //    envelope_signers / envelope_fields / envelope_events handle
+      //    the children.
+      const draftsDel = await trx
+        .deleteFrom('envelopes')
+        .where('owner_id', '=', input.owner_id)
+        .where('status', '=', 'draft')
+        .executeTakeFirst();
+      const drafts_deleted = Number(draftsDel?.numDeletedRows ?? 0n);
+
+      // 2. Enumerate the survivors (everything that wasn't a draft).
+      const preservedRows = await trx
+        .selectFrom('envelopes')
+        .select(['id'])
+        .where('owner_id', '=', input.owner_id)
+        .execute();
+      const preservedIds = preservedRows.map((r) => r.id);
+      const envelopes_preserved = preservedIds.length;
+
+      let signers_anonymized = 0;
+      let retention_events_appended = 0;
+      if (preservedIds.length > 0) {
+        // 2a. Anonymize signer rows whose email matches the deleted
+        //     user's email (case-insensitive). The owner of an envelope
+        //     is also frequently a signer on it, so this scrub catches
+        //     any self-signed copy. Other signers' rows are untouched
+        //     — their consent to participate stands.
+        const placeholderEmail = `${input.email_hash}@deleted.invalid`;
+        if (input.email !== null && input.email !== undefined) {
+          // envelope_signers has no `updated_at` column (audit-grade
+          // immutable signer rows); the `created_at` is the only
+          // timestamp. Anonymization is intentionally a content-only
+          // patch — the row identity stays put.
+          const sigUpd = await trx
+            .updateTable('envelope_signers')
+            .set({
+              name: 'Deleted user',
+              email: placeholderEmail,
+            })
+            .where('envelope_id', 'in', preservedIds)
+            .where(sql`lower(email)`, '=', input.email.toLowerCase())
+            .executeTakeFirst();
+          signers_anonymized = Number(sigUpd?.numUpdatedRows ?? 0n);
+        }
+
+        // 2b. Append retention_deleted to each preserved envelope's
+        //     audit chain. Done inside the same trx so the chain head
+        //     read for `prev_event_hash` is consistent. We hash the
+        //     latest existing row using the canonical-JSON helper —
+        //     same algorithm as appendEvent (S.6).
+        for (const envelopeId of preservedIds) {
+          const latest = await trx
+            .selectFrom('envelope_events')
+            .selectAll()
+            .where('envelope_id', '=', envelopeId)
+            .orderBy('created_at', 'desc')
+            .orderBy('id', 'desc')
+            .limit(1)
+            .executeTakeFirst();
+          const prevHash = latest ? eventHash(toEventDomain(latest)) : null;
+          await trx
+            .insertInto('envelope_events')
+            .values({
+              envelope_id: envelopeId,
+              signer_id: null,
+              actor_kind: 'system',
+              event_type: 'retention_deleted',
+              ip: null,
+              user_agent: null,
+              metadata: JSON.stringify({
+                reason: 'account_deletion',
+                email_hash: input.email_hash,
+              }),
+              prev_event_hash: prevHash,
+            })
+            .executeTakeFirstOrThrow();
+          retention_events_appended++;
+        }
+
+        // 2c. Detach owner. Migration 0012 relaxed `owner_id` to
+        //     nullable + flipped the FK to ON DELETE SET NULL, so this
+        //     UPDATE is the application-level equivalent that gives us
+        //     the same outcome without depending on Supabase's
+        //     `auth.users` row removal happening transactionally.
+        await trx
+          .updateTable('envelopes')
+          .set({ owner_id: null, updated_at: new Date().toISOString() })
+          .where('owner_id', '=', input.owner_id)
+          .execute();
+      }
+
+      return {
+        drafts_deleted,
+        envelopes_preserved,
+        signers_anonymized,
+        retention_events_appended,
+      };
+    });
+  }
+
   // Decode helper exposed for the service layer — keeps base64 format internal
   // to the adapter. Not part of the port because cursors are a repo concern.
   decodeCursorOrThrow(cursor: string): { updated_at: string; id: string } {

--- a/apps/api/src/envelopes/envelopes.repository.ts
+++ b/apps/api/src/envelopes/envelopes.repository.ts
@@ -375,6 +375,44 @@ export abstract class EnvelopesRepository {
   // InvalidCursorError on malformed input. Lives on the port so the service
   // layer doesn't need to know the cursor encoding format.
   abstract decodeCursorOrThrow(cursor: string): { updated_at: string; id: string };
+
+  /**
+   * Issues #38 / #43 — atomic account-deletion purge for the
+   * envelopes aggregate. Run inside a single repository call so the
+   * adapter can wrap it in a transaction; partial failures must roll
+   * back so the user can retry.
+   *
+   * Steps:
+   *   1. Hard-delete every envelope where `owner_id = $1 AND status =
+   *      'draft'`. Drafts have no statutory retention requirement.
+   *   2. For every non-draft envelope (sealed, awaiting_others,
+   *      sealing, declined, expired, canceled) owned by the user:
+   *        a. Anonymize signer rows whose `email` (case-insensitive)
+   *           matches `email` — replace name with "Deleted user" and
+   *           email with `email_hash + "@deleted.invalid"` so the
+   *           audit chain is preserved but the PII is gone.
+   *        b. Append a `retention_deleted` event to the audit chain so
+   *           verifiers can see when and why the owner was scrubbed.
+   *           The event_type already exists in the enum (added by the
+   *           original schema author for exactly this purpose).
+   *        c. NULL the envelope's `owner_id` so the envelope survives
+   *           the upcoming `auth.users` deletion. Migration 0012
+   *           relaxed the column to nullable + flipped the FK to ON
+   *           DELETE SET NULL as a belt-and-braces.
+   *
+   * Returns counts so the service can log + assert on them. Anonymized
+   * signer rows are counted across all preserved envelopes.
+   */
+  abstract purgeOwnedDataForAccountDeletion(input: {
+    readonly owner_id: string;
+    readonly email: string | null;
+    readonly email_hash: string;
+  }): Promise<{
+    readonly drafts_deleted: number;
+    readonly envelopes_preserved: number;
+    readonly signers_anonymized: number;
+    readonly retention_events_appended: number;
+  }>;
 }
 
 /**

--- a/apps/api/src/envelopes/envelopes.repository.ts
+++ b/apps/api/src/envelopes/envelopes.repository.ts
@@ -354,6 +354,23 @@ export abstract class EnvelopesRepository {
     readonly audit_file_path: string | null;
   } | null>;
 
+  /**
+   * Issue #46 — for the `/me/export` payload we need to surface signer
+   * artifact paths (drawn signature image and drawn initials image)
+   * alongside the envelope so the user can download the original raster
+   * captures, not just the burned-in PDF. The shape stays internal
+   * (image paths are not in the public Signer wire contract) so callers
+   * must explicitly opt-in by calling this method. Order is unspecified;
+   * key by `signer_id`.
+   */
+  abstract listSignerImagePaths(envelope_id: string): Promise<
+    ReadonlyArray<{
+      readonly signer_id: string;
+      readonly signature_image_path: string | null;
+      readonly initials_image_path: string | null;
+    }>
+  >;
+
   // Cursor helper — decode the opaque cursor returned by listByOwner. Throws
   // InvalidCursorError on malformed input. Lives on the port so the service
   // layer doesn't need to know the cursor encoding format.

--- a/apps/api/src/envelopes/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/envelopes.service.spec.ts
@@ -200,6 +200,16 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
     }));
   }
 
+  async listSignerImagePaths(envelope_id: string) {
+    const env = this.envelopes.get(envelope_id);
+    if (!env) return [];
+    return env.signers.map((s) => ({
+      signer_id: s.id,
+      signature_image_path: null,
+      initials_image_path: null,
+    }));
+  }
+
   async updateDraftMetadata(
     owner_id: string,
     envelope_id: string,

--- a/apps/api/src/envelopes/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/envelopes.service.spec.ts
@@ -76,6 +76,16 @@ class FakeContactsRepo extends ContactsRepository {
     this.store.delete(id);
     return true;
   }
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    let n = 0;
+    for (const [id, c] of [...this.store]) {
+      if (c.owner_id === owner_id) {
+        this.store.delete(id);
+        n++;
+      }
+    }
+    return n;
+  }
 }
 
 /**
@@ -208,6 +218,19 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
       signature_image_path: null,
       initials_image_path: null,
     }));
+  }
+
+  async purgeOwnedDataForAccountDeletion(_input: {
+    readonly owner_id: string;
+    readonly email: string | null;
+    readonly email_hash: string;
+  }) {
+    return {
+      drafts_deleted: 0,
+      envelopes_preserved: 0,
+      signers_anonymized: 0,
+      retention_events_appended: 0,
+    };
   }
 
   async updateDraftMetadata(

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -23,19 +23,30 @@ export class MeController {
     @CurrentUser() user: AuthUser,
     @Res({ passthrough: false }) res: Response,
   ): Promise<void> {
-    const payload = await this.svc.exportAll(user);
     const filename = `seald-export-${user.id}-${new Date().toISOString().slice(0, 10)}.json`;
-    res
-      .setHeader('Content-Type', 'application/json; charset=utf-8')
-      // RFC 6266 / RFC 5987 Content-Disposition (issue #44 defense-in-
-      // depth). The `sub` claim is already UUID-validated at the JWT
-      // strategy boundary so the interpolation is safe today, but we
-      // still emit `filename*=UTF-8''<encoded>` so a regression in the
-      // validator can't reopen the header-injection vector.
-      .setHeader('Content-Disposition', buildContentDisposition(filename))
-      // Don't let any caching layer keep the user's data.
-      .setHeader('Cache-Control', 'no-store')
-      .send(JSON.stringify(payload, null, 2));
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    // RFC 6266 / RFC 5987 Content-Disposition (issue #44 defense-in-
+    // depth). The `sub` claim is already UUID-validated at the JWT
+    // strategy boundary so the interpolation is safe today, but we
+    // still emit `filename*=UTF-8''<encoded>` so a regression in the
+    // validator can't reopen the header-injection vector.
+    res.setHeader('Content-Disposition', buildContentDisposition(filename));
+    // Don't let any caching layer keep the user's data.
+    res.setHeader('Cache-Control', 'no-store');
+
+    // Issue #45 — stream envelopes in batches instead of materializing
+    // the whole aggregate. Peak heap is bounded by one batch
+    // (~5 MB at default settings), independent of how many envelopes the
+    // caller owns. Backpressure is honored automatically because the
+    // service uses an async generator behind `Readable.from`.
+    const stream = await this.svc.exportAllStream(user);
+    stream.on('error', (err) => {
+      // Once headers are flushed we can't change the status code; the
+      // safest signal to the client is to abort the connection. The
+      // truncated JSON will fail to parse and they will retry.
+      res.destroy(err);
+    });
+    stream.pipe(res);
   }
 
   @Delete()

--- a/apps/api/src/me/me.controller.ts
+++ b/apps/api/src/me/me.controller.ts
@@ -27,7 +27,12 @@ export class MeController {
     const filename = `seald-export-${user.id}-${new Date().toISOString().slice(0, 10)}.json`;
     res
       .setHeader('Content-Type', 'application/json; charset=utf-8')
-      .setHeader('Content-Disposition', `attachment; filename="${filename}"`)
+      // RFC 6266 / RFC 5987 Content-Disposition (issue #44 defense-in-
+      // depth). The `sub` claim is already UUID-validated at the JWT
+      // strategy boundary so the interpolation is safe today, but we
+      // still emit `filename*=UTF-8''<encoded>` so a regression in the
+      // validator can't reopen the header-injection vector.
+      .setHeader('Content-Disposition', buildContentDisposition(filename))
       // Don't let any caching layer keep the user's data.
       .setHeader('Cache-Control', 'no-store')
       .send(JSON.stringify(payload, null, 2));
@@ -46,4 +51,24 @@ export class MeController {
     // called.
     await this.svc.deleteAccount(user);
   }
+}
+
+/**
+ * Build an RFC 6266 `Content-Disposition` value with both an ASCII
+ * `filename=` parameter (quoted, with any `\` and `"` escaped) and an
+ * RFC 5987 `filename*=UTF-8''<percent-encoded>` extension. Modern
+ * browsers prefer `filename*` and ignore the ASCII fallback. By
+ * percent-encoding the entire filename via `encodeURIComponent` we
+ * guarantee no quote, semicolon, CR, or LF can ever escape the header
+ * value — closing the issue #44 injection vector at the response layer
+ * regardless of upstream validation.
+ */
+export function buildContentDisposition(filename: string): string {
+  // ASCII fallback: strip non-ASCII, escape backslash + double-quote.
+  const ascii = filename.replace(/[^\x20-\x7e]/g, '_').replace(/[\\"]/g, '\\$&');
+  // RFC 5987: percent-encode everything outside the attr-char set. The
+  // built-in `encodeURIComponent` is a strict superset of attr-char
+  // safety (it escapes `,`, `;`, `=`, `*`, etc. that RFC 5987 reserves).
+  const utf8 = encodeURIComponent(filename);
+  return `attachment; filename="${ascii}"; filename*=UTF-8''${utf8}`;
 }

--- a/apps/api/src/me/me.module.ts
+++ b/apps/api/src/me/me.module.ts
@@ -9,6 +9,8 @@ import { MeController } from './me.controller';
 import { MeService } from './me.service';
 import { SupabaseAdminClient } from './supabase-admin.client';
 import { SupabaseAdminHttpClient } from './supabase-admin.client.http';
+import { TombstonesRepository } from './tombstones.repository';
+import { TombstonesPgRepository } from './tombstones.repository.pg';
 
 /**
  * Mounts T-19 / T-20 — DSAR export and account deletion. Pulls in the
@@ -23,6 +25,7 @@ import { SupabaseAdminHttpClient } from './supabase-admin.client.http';
     MeService,
     { provide: IdempotencyRepository, useClass: IdempotencyPgRepository },
     { provide: SupabaseAdminClient, useClass: SupabaseAdminHttpClient },
+    { provide: TombstonesRepository, useClass: TombstonesPgRepository },
   ],
 })
 export class MeModule {}

--- a/apps/api/src/me/me.service.spec.ts
+++ b/apps/api/src/me/me.service.spec.ts
@@ -1,8 +1,10 @@
 import { ServiceUnavailableException } from '@nestjs/common';
+import { Readable } from 'node:stream';
 import type { AuthUser } from '../auth/auth-user';
 import type { ContactsRepository } from '../contacts/contacts.repository';
 import type { OutboundEmailsRepository } from '../email/outbound-emails.repository';
 import type { EnvelopesRepository } from '../envelopes/envelopes.repository';
+import type { StorageService } from '../storage/storage.service';
 import type { TemplatesRepository } from '../templates/templates.repository';
 import type { IdempotencyRepository } from './idempotency.repository';
 import { MeService } from './me.service';
@@ -36,6 +38,21 @@ function makeMocks() {
       fields: [],
     })),
     listEventsForEnvelope: jest.fn(async () => [{ id: 'e1', event_type: 'created' }]),
+    // Issue #46 — surfaces the file paths the export attaches signed
+    // URLs to. Default returns one of each; tests override to exercise
+    // the null-degrades-cleanly path and the storage-failure path.
+    getFilePaths: jest.fn(async () => ({
+      original_file_path: 'env/env-1/original.pdf',
+      sealed_file_path: 'env/env-1/sealed.pdf',
+      audit_file_path: 'env/env-1/audit.pdf',
+    })),
+    listSignerImagePaths: jest.fn(async () => [
+      {
+        signer_id: 's1',
+        signature_image_path: 'env/env-1/sigs/s1.png',
+        initials_image_path: 'env/env-1/sigs/s1-initials.png',
+      },
+    ]),
   } as unknown as EnvelopesRepository;
   const outboundEmailsRepo = {
     listByEnvelope: jest.fn(async () => [{ id: 'oe1', kind: 'invite' }]),
@@ -51,6 +68,13 @@ function makeMocks() {
       calls.push('supabaseAdmin.deleteUser');
     }),
   } as unknown as SupabaseAdminClient;
+  // Default storage stub returns a deterministic signed URL per path so
+  // tests can assert wiring; failure mode is opt-in via mockRejectedValueOnce.
+  const storage = {
+    createSignedUrl: jest.fn(
+      async (path: string, ttl: number) => `https://signed.test/${path}?ttl=${ttl}`,
+    ),
+  } as unknown as StorageService;
   return {
     calls,
     contactsRepo,
@@ -59,6 +83,7 @@ function makeMocks() {
     outboundEmailsRepo,
     idempotencyRepo,
     supabaseAdmin,
+    storage,
   };
 }
 
@@ -70,7 +95,15 @@ function build(mocks: ReturnType<typeof makeMocks>): MeService {
     mocks.outboundEmailsRepo,
     mocks.idempotencyRepo,
     mocks.supabaseAdmin,
+    mocks.storage,
   );
+}
+
+/** Drain a Readable JSON stream to a parsed object. */
+async function drainStream(stream: Readable): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const c of stream) chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(String(c)));
+  return JSON.parse(Buffer.concat(chunks).toString('utf8'));
 }
 
 describe('MeService.exportAll', () => {
@@ -80,7 +113,8 @@ describe('MeService.exportAll', () => {
     const out = await svc.exportAll(USER);
     expect(out.meta.format_version).toBe('1.0');
     expect(out.meta.user).toEqual({ id: USER.id, email: USER.email });
-    expect(out.meta.includes_files).toBe(false);
+    // Issue #46 — flipped to true now that storage URLs are attached.
+    expect(out.meta.includes_files).toBe(true);
     expect(out.meta.counts).toEqual({
       contacts: 1,
       envelopes: 1,
@@ -102,6 +136,75 @@ describe('MeService.exportAll', () => {
     const out = await svc.exportAll(USER);
     expect(out.envelopes).toHaveLength(0);
     expect(out.meta.counts.envelopes).toBe(0);
+  });
+
+  // Issue #46 — every storage path on the envelope row plus every signer
+  // image path becomes a 1-hour signed URL on the envelope's `files`
+  // block. Null paths (e.g. an unsealed draft) emit `null` URLs without
+  // a warning.
+  it('attaches signed URLs for every envelope/signer storage path with 1h TTL', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    const out = await svc.exportAll(USER);
+    const files = out.envelopes[0]?.files;
+    expect(files?.original_pdf_url).toBe('https://signed.test/env/env-1/original.pdf?ttl=3600');
+    expect(files?.sealed_pdf_url).toBe('https://signed.test/env/env-1/sealed.pdf?ttl=3600');
+    expect(files?.audit_pdf_url).toBe('https://signed.test/env/env-1/audit.pdf?ttl=3600');
+    expect(files?.signers).toHaveLength(1);
+    expect(files?.signers[0]).toEqual({
+      signer_id: 's1',
+      signature_image_url: 'https://signed.test/env/env-1/sigs/s1.png?ttl=3600',
+      initials_image_url: 'https://signed.test/env/env-1/sigs/s1-initials.png?ttl=3600',
+    });
+    expect(mocks.storage.createSignedUrl).toHaveBeenCalledWith('env/env-1/sealed.pdf', 60 * 60);
+  });
+
+  it('emits null URLs without warnings when a storage path is absent', async () => {
+    const mocks = makeMocks();
+    (mocks.envelopesRepo.getFilePaths as jest.Mock).mockResolvedValueOnce({
+      original_file_path: 'env/env-1/original.pdf',
+      sealed_file_path: null, // not yet sealed
+      audit_file_path: null, // no audit yet
+    });
+    (mocks.envelopesRepo.listSignerImagePaths as jest.Mock).mockResolvedValueOnce([
+      { signer_id: 's1', signature_image_path: null, initials_image_path: null },
+    ]);
+    const svc = build(mocks);
+    const out = await svc.exportAll(USER);
+    const files = out.envelopes[0]?.files;
+    expect(files?.original_pdf_url).toBe('https://signed.test/env/env-1/original.pdf?ttl=3600');
+    expect(files?.sealed_pdf_url).toBeNull();
+    expect(files?.audit_pdf_url).toBeNull();
+    expect(files?.signers[0]?.signature_image_url).toBeNull();
+    expect(files?.signers[0]?.initials_image_url).toBeNull();
+    // Storage was only invoked for the path that actually existed.
+    expect(mocks.storage.createSignedUrl).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('MeService.exportAllStream', () => {
+  // Issue #46 — failed signed-URL generation must surface as a
+  // `meta.warnings[]` entry keyed by the failing storage path; the URL
+  // field degrades to null and the rest of the export continues.
+  it('surfaces storage failures in warnings[] without aborting the stream', async () => {
+    const mocks = makeMocks();
+    (mocks.storage.createSignedUrl as jest.Mock).mockImplementation(async (path: string) => {
+      if (path === 'env/env-1/sealed.pdf') throw new Error('storage_sign_failed_500: bucket gone');
+      return `https://signed.test/${path}`;
+    });
+    const svc = build(mocks);
+    const stream = await svc.exportAllStream(USER);
+    const payload = (await drainStream(stream)) as {
+      meta: { includes_files: boolean };
+      envelopes: ReadonlyArray<{ files: { sealed_pdf_url: string | null } }>;
+      warnings: ReadonlyArray<{ code: string; detail: string }>;
+    };
+    expect(payload.meta.includes_files).toBe(true);
+    expect(payload.envelopes[0]?.files.sealed_pdf_url).toBeNull();
+    expect(payload.warnings).toHaveLength(1);
+    expect(payload.warnings[0]?.code).toBe('storage_url_failed');
+    expect(payload.warnings[0]?.detail).toContain('env/env-1/sealed.pdf');
+    expect(payload.warnings[0]?.detail).toContain('bucket gone');
   });
 });
 

--- a/apps/api/src/me/me.service.spec.ts
+++ b/apps/api/src/me/me.service.spec.ts
@@ -1,4 +1,5 @@
 import { ServiceUnavailableException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { AuthUser } from '../auth/auth-user';
 import type { ContactsRepository } from '../contacts/contacts.repository';
@@ -9,6 +10,7 @@ import type { TemplatesRepository } from '../templates/templates.repository';
 import type { IdempotencyRepository } from './idempotency.repository';
 import { MeService } from './me.service';
 import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+import type { TombstonesRepository } from './tombstones.repository';
 
 const USER: AuthUser = {
   id: '11111111-1111-1111-1111-111111111111',
@@ -20,9 +22,17 @@ function makeMocks() {
   const calls: string[] = [];
   const contactsRepo = {
     findAllByOwner: jest.fn(async () => [{ id: 'c1', name: 'A', email: 'a@x' }]),
+    deleteAllByOwner: jest.fn(async () => {
+      calls.push('contacts.deleteAllByOwner');
+      return 1;
+    }),
   } as unknown as ContactsRepository;
   const templatesRepo = {
     findAllByOwner: jest.fn(async () => [{ id: 't1', title: 'T1' }]),
+    deleteAllByOwner: jest.fn(async () => {
+      calls.push('templates.deleteAllByOwner');
+      return 1;
+    }),
   } as unknown as TemplatesRepository;
   const envelopesRepo = {
     listByOwner: jest.fn(async () => ({
@@ -53,6 +63,18 @@ function makeMocks() {
         initials_image_path: 'env/env-1/sigs/s1-initials.png',
       },
     ]),
+    // Issues #38/#43 — atomic envelopes purge for account deletion.
+    // Default returns realistic counts so call-order assertions work
+    // without each test rewiring it.
+    purgeOwnedDataForAccountDeletion: jest.fn(async () => {
+      calls.push('envelopes.purgeOwnedDataForAccountDeletion');
+      return {
+        drafts_deleted: 2,
+        envelopes_preserved: 3,
+        signers_anonymized: 4,
+        retention_events_appended: 3,
+      };
+    }),
   } as unknown as EnvelopesRepository;
   const outboundEmailsRepo = {
     listByEnvelope: jest.fn(async () => [{ id: 'oe1', kind: 'invite' }]),
@@ -68,6 +90,11 @@ function makeMocks() {
       calls.push('supabaseAdmin.deleteUser');
     }),
   } as unknown as SupabaseAdminClient;
+  const tombstonesRepo = {
+    recordDeletion: jest.fn(async () => {
+      calls.push('tombstones.recordDeletion');
+    }),
+  } as unknown as TombstonesRepository;
   // Default storage stub returns a deterministic signed URL per path so
   // tests can assert wiring; failure mode is opt-in via mockRejectedValueOnce.
   const storage = {
@@ -84,6 +111,7 @@ function makeMocks() {
     idempotencyRepo,
     supabaseAdmin,
     storage,
+    tombstonesRepo,
   };
 }
 
@@ -96,8 +124,11 @@ function build(mocks: ReturnType<typeof makeMocks>): MeService {
     mocks.idempotencyRepo,
     mocks.supabaseAdmin,
     mocks.storage,
+    mocks.tombstonesRepo,
   );
 }
+
+const EXPECTED_EMAIL_HASH = createHash('sha256').update(USER.email!.toLowerCase()).digest('hex');
 
 /** Drain a Readable JSON stream to a parsed object. */
 async function drainStream(stream: Readable): Promise<unknown> {
@@ -209,15 +240,86 @@ describe('MeService.exportAllStream', () => {
 });
 
 describe('MeService.deleteAccount', () => {
-  it('wipes idempotency_records BEFORE calling Supabase admin (FK does not cascade)', async () => {
+  it('runs the soft-delete pipeline in the legally-required order', async () => {
     const mocks = makeMocks();
     const svc = build(mocks);
     await svc.deleteAccount(USER);
-    // Order matters — see service comment. If a future refactor swaps
-    // them this assertion will fail.
-    expect(mocks.calls).toEqual(['idempotency.deleteByUser', 'supabaseAdmin.deleteUser']);
+    // Order matters — see MeService.deleteAccount docstring.
+    //   1. idempotency wipe (FK doesn't cascade)
+    //   2. contacts hard-delete (working state)
+    //   3. templates hard-delete (working state)
+    //   4. envelopes purge (drafts deleted, sealed preserved + anonymized)
+    //   5. tombstone recorded BEFORE supabase admin so a partial
+    //      failure still leaves a forensic breadcrumb
+    //   6. supabase admin call last
+    expect(mocks.calls).toEqual([
+      'idempotency.deleteByUser',
+      'contacts.deleteAllByOwner',
+      'templates.deleteAllByOwner',
+      'envelopes.purgeOwnedDataForAccountDeletion',
+      'tombstones.recordDeletion',
+      'supabaseAdmin.deleteUser',
+    ]);
     expect(mocks.idempotencyRepo.deleteByUser).toHaveBeenCalledWith(USER.id);
+    expect(mocks.contactsRepo.deleteAllByOwner).toHaveBeenCalledWith(USER.id);
+    expect(mocks.templatesRepo.deleteAllByOwner).toHaveBeenCalledWith(USER.id);
     expect(mocks.supabaseAdmin.deleteUser).toHaveBeenCalledWith(USER.id);
+  });
+
+  it('records a tombstone with sha256(lowercase(email)) before supabase admin', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    await svc.deleteAccount(USER);
+    expect(mocks.tombstonesRepo.recordDeletion).toHaveBeenCalledWith({
+      user_id: USER.id,
+      email_hash: EXPECTED_EMAIL_HASH,
+    });
+    // tombstone runs strictly before the supabase admin call so a
+    // partial failure still leaves a forensic record.
+    const tombstoneIdx = mocks.calls.indexOf('tombstones.recordDeletion');
+    const supabaseIdx = mocks.calls.indexOf('supabaseAdmin.deleteUser');
+    expect(tombstoneIdx).toBeGreaterThan(-1);
+    expect(supabaseIdx).toBeGreaterThan(tombstoneIdx);
+  });
+
+  it('lower-cases the email before hashing so case-variants tombstone identically', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    await svc.deleteAccount({ ...USER, email: 'MAYA@Example.COM' });
+    expect(mocks.tombstonesRepo.recordDeletion).toHaveBeenCalledWith({
+      user_id: USER.id,
+      email_hash: EXPECTED_EMAIL_HASH,
+    });
+  });
+
+  it('preserves sealed envelopes by calling the purge port, not a cascade', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    await svc.deleteAccount(USER);
+    // The purge port is what guarantees sealed envelopes survive.
+    // ESIGN §7001(d) / GDPR Art. 17(3)(b/e) compliance hinges on this
+    // call existing — if a future refactor drops it, the test fails.
+    expect(mocks.envelopesRepo.purgeOwnedDataForAccountDeletion).toHaveBeenCalledWith({
+      owner_id: USER.id,
+      email: USER.email,
+      email_hash: EXPECTED_EMAIL_HASH,
+    });
+  });
+
+  it('hashes empty string when AuthUser.email is null (defensive)', async () => {
+    const mocks = makeMocks();
+    const svc = build(mocks);
+    const expectedNullHash = createHash('sha256').update('').digest('hex');
+    await svc.deleteAccount({ ...USER, email: null });
+    expect(mocks.tombstonesRepo.recordDeletion).toHaveBeenCalledWith({
+      user_id: USER.id,
+      email_hash: expectedNullHash,
+    });
+    expect(mocks.envelopesRepo.purgeOwnedDataForAccountDeletion).toHaveBeenCalledWith({
+      owner_id: USER.id,
+      email: null,
+      email_hash: expectedNullHash,
+    });
   });
 
   it('maps SupabaseAdminError to a 503 (ServiceUnavailableException)', async () => {
@@ -227,8 +329,12 @@ describe('MeService.deleteAccount', () => {
     );
     const svc = build(mocks);
     await expect(svc.deleteAccount(USER)).rejects.toBeInstanceOf(ServiceUnavailableException);
-    // idempotency wipe still happened (it ran before the admin call).
+    // Every preceding step ran (they're all idempotent so retry is safe).
     expect(mocks.idempotencyRepo.deleteByUser).toHaveBeenCalledWith(USER.id);
+    expect(mocks.contactsRepo.deleteAllByOwner).toHaveBeenCalledWith(USER.id);
+    expect(mocks.templatesRepo.deleteAllByOwner).toHaveBeenCalledWith(USER.id);
+    expect(mocks.envelopesRepo.purgeOwnedDataForAccountDeletion).toHaveBeenCalled();
+    expect(mocks.tombstonesRepo.recordDeletion).toHaveBeenCalled();
   });
 
   it('rethrows non-SupabaseAdminError errors verbatim', async () => {

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { Readable } from 'node:stream';
 import type { AuthUser } from '../auth/auth-user';
 import { ContactsRepository } from '../contacts/contacts.repository';
 import { OutboundEmailsRepository } from '../email/outbound-emails.repository';
@@ -7,6 +8,23 @@ import type { Envelope, EnvelopeEvent, EnvelopeSigner } from '../envelopes/envel
 import { TemplatesRepository } from '../templates/templates.repository';
 import { IdempotencyRepository } from './idempotency.repository';
 import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+
+/**
+ * Hard cap on how many envelopes the inline streaming export will emit.
+ * Above this we serve a stub payload that points the caller at the
+ * (not-yet-built) async-job pivot — see issue #45 follow-up. 100k * a
+ * few KB per envelope keeps a single inline export under ~1 GB on the
+ * wire, which the browser can hold but still completes in minutes.
+ */
+const EXPORT_INLINE_ENVELOPE_CAP = 100_000;
+
+/**
+ * Page size for streaming envelope hydration. Each batch is the unit of
+ * peak memory — at 500 envelopes * ~10 KB hydrated each that's ~5 MB
+ * resident, which fits comfortably even on the smallest worker
+ * instance. Lower means more round-trips; higher means more peak heap.
+ */
+const EXPORT_STREAM_BATCH_SIZE = 500;
 
 /**
  * Wire format of the GDPR / CCPA / DSAR data export. Public surface
@@ -37,6 +55,24 @@ export interface AccountExport {
   }>;
 }
 
+/**
+ * Wire shape for the streaming variant. Identical to `AccountExport`
+ * apart from two fields we can only know at end-of-stream:
+ * `meta_tail.outbound_emails` (the cumulative count) and `warnings[]`
+ * (any envelopes that disappeared mid-flight or any cap-truncation
+ * notice). Clients reconcile by reading both `meta.counts.outbound_emails`
+ * (which will be `null` in the streamed form) and `meta_tail`.
+ */
+export interface AccountExportStreamed extends Omit<AccountExport, 'meta'> {
+  readonly meta: Omit<AccountExport['meta'], 'counts'> & {
+    readonly counts: Omit<AccountExport['meta']['counts'], 'outbound_emails'> & {
+      readonly outbound_emails: number | null;
+    };
+  };
+  readonly meta_tail: { readonly outbound_emails: number };
+  readonly warnings: ReadonlyArray<{ readonly code: string; readonly detail: string }>;
+}
+
 @Injectable()
 export class MeService {
   private readonly logger = new Logger(MeService.name);
@@ -51,15 +87,11 @@ export class MeService {
   ) {}
 
   /**
-   * T-19 — assemble an export of every row owned by the caller. The
-   * result is JSON-serialisable; the controller wraps it with
-   * `Content-Disposition: attachment` and an indented `JSON.stringify`
-   * so the file is human-readable.
-   *
-   * Memory note: for an MVP we accumulate everything in memory before
-   * returning. A power user with thousands of envelopes could OOM the
-   * worker; switch to streaming JSON if/when that becomes a real
-   * problem (TODO not before usage data demands it).
+   * T-19 — assemble an export of every row owned by the caller as an
+   * in-memory `AccountExport`. Useful for unit tests and small accounts
+   * where the wire shape needs to be inspected as a single object. For
+   * the controller path use `exportAllStream` instead — it bounds peak
+   * memory to one batch (issue #45).
    */
   async exportAll(user: AuthUser): Promise<AccountExport> {
     const [contacts, templates, envelopeIds] = await Promise.all([
@@ -116,6 +148,126 @@ export class MeService {
       templates,
       envelopes: cleanEnvelopes,
     };
+  }
+
+  /**
+   * T-19 streaming variant (issue #45). Returns a `Readable` that emits
+   * a single valid JSON document of the same `AccountExport` shape as
+   * `exportAll`, but hydrates envelopes in batches of
+   * `EXPORT_STREAM_BATCH_SIZE` instead of all-at-once. Peak heap is
+   * bounded by one batch (~5 MB at default settings), regardless of how
+   * many envelopes the caller owns.
+   *
+   * Above `EXPORT_INLINE_ENVELOPE_CAP` envelopes we still emit a valid
+   * JSON document but truncate the `envelopes` array and surface a
+   * `meta.warnings[]` entry explaining the cap. A future PR will pivot
+   * those callers to an async-job export emailed to them.
+   *
+   * Wire shape (key order is fixed for a stable contract):
+   *   { "meta": {...}, "contacts": [...], "templates": [...],
+   *     "envelopes": [ {...}, {...}, ... ] }
+   *
+   * `meta.counts` is computed before emission so it sits at the top of
+   * the document; `meta.warnings` is emitted last because warnings are
+   * accumulated during the stream walk (e.g. an envelope that races a
+   * delete after its id was listed).
+   */
+  async exportAllStream(user: AuthUser): Promise<Readable> {
+    const [contacts, templates, envelopeIds] = await Promise.all([
+      this.contactsRepo.findAllByOwner(user.id),
+      this.templatesRepo.findAllByOwner(user.id),
+      this.collectEnvelopeIds(user.id),
+    ]);
+
+    const truncated = envelopeIds.length > EXPORT_INLINE_ENVELOPE_CAP;
+    const inlineIds = truncated ? envelopeIds.slice(0, EXPORT_INLINE_ENVELOPE_CAP) : envelopeIds;
+    const warnings: Array<{ readonly code: string; readonly detail: string }> = [];
+    if (truncated) {
+      warnings.push({
+        code: 'envelope_cap_exceeded',
+        detail: `Inline export capped at ${EXPORT_INLINE_ENVELOPE_CAP} envelopes; ${envelopeIds.length - EXPORT_INLINE_ENVELOPE_CAP} omitted. Contact support for an async export.`,
+      });
+    }
+
+    // We don't know `outbound_emails` count until each envelope is
+    // hydrated. Stream the meta-counts using the inline-envelope length
+    // and a `null` outbound-emails count (clients infer from the
+    // envelopes array). This keeps the document streamable without a
+    // second pass over the DB.
+    const meta = {
+      format_version: '1.0' as const,
+      generated_at: new Date().toISOString(),
+      user: { id: user.id, email: user.email },
+      counts: {
+        contacts: contacts.length,
+        envelopes: inlineIds.length,
+        templates: templates.length,
+        // Filled in at the end of the stream — emitted in `meta_tail`.
+        outbound_emails: null as number | null,
+      },
+      includes_files: false as const,
+    };
+
+    const repo = this.envelopesRepo;
+    const outRepo = this.outboundEmailsRepo;
+    const logger = this.logger;
+    let outboundEmailCount = 0;
+
+    // We use an async generator + Readable.from so backpressure is
+    // honored: when the response socket fills, the generator pauses
+    // automatically.
+    async function* generate(): AsyncGenerator<string, void, unknown> {
+      yield '{';
+      yield `"meta":${JSON.stringify(meta)},`;
+      yield `"contacts":${JSON.stringify(contacts)},`;
+      yield `"templates":${JSON.stringify(templates)},`;
+      yield '"envelopes":[';
+
+      let first = true;
+      for (let offset = 0; offset < inlineIds.length; offset += EXPORT_STREAM_BATCH_SIZE) {
+        const batch = inlineIds.slice(offset, offset + EXPORT_STREAM_BATCH_SIZE);
+        // Hydrate the batch in parallel — bounded by batch size, not
+        // total envelopes, so peak memory stays flat.
+        const hydrated = await Promise.all(
+          batch.map(async (envelopeId) => {
+            const [aggregate, events, outboundEmails] = await Promise.all([
+              repo.findByIdWithAll(envelopeId),
+              repo.listEventsForEnvelope(envelopeId),
+              outRepo.listByEnvelope(envelopeId),
+            ]);
+            if (!aggregate) {
+              logger.warn(`export: envelope ${envelopeId} disappeared mid-flight; skipping`);
+              warnings.push({
+                code: 'envelope_disappeared',
+                detail: `envelope ${envelopeId} was deleted between id-listing and hydration`,
+              });
+              return null;
+            }
+            return {
+              envelope: aggregate,
+              signers: aggregate.signers,
+              events,
+              outbound_emails: outboundEmails,
+            };
+          }),
+        );
+        for (const item of hydrated) {
+          if (item === null) continue;
+          outboundEmailCount += item.outbound_emails.length;
+          yield (first ? '' : ',') + JSON.stringify(item);
+          first = false;
+        }
+      }
+
+      yield '],';
+      // Tail meta — outbound_emails count is now known. Clients
+      // tolerant to the null sentinel get the final value here.
+      yield `"meta_tail":${JSON.stringify({ outbound_emails: outboundEmailCount })},`;
+      yield `"warnings":${JSON.stringify(warnings)}`;
+      yield '}';
+    }
+
+    return Readable.from(generate());
   }
 
   /**

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -5,6 +5,7 @@ import { ContactsRepository } from '../contacts/contacts.repository';
 import { OutboundEmailsRepository } from '../email/outbound-emails.repository';
 import { EnvelopesRepository } from '../envelopes/envelopes.repository';
 import type { Envelope, EnvelopeEvent, EnvelopeSigner } from '../envelopes/envelope.entity';
+import { StorageService } from '../storage/storage.service';
 import { TemplatesRepository } from '../templates/templates.repository';
 import { IdempotencyRepository } from './idempotency.repository';
 import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
@@ -27,6 +28,34 @@ const EXPORT_INLINE_ENVELOPE_CAP = 100_000;
 const EXPORT_STREAM_BATCH_SIZE = 500;
 
 /**
+ * Issue #46 — TTL on every signed Storage URL we attach to the export.
+ * One hour is long enough for a user to download every artifact in a
+ * single sitting (an export with thousands of envelopes might run a
+ * `wget --recursive` for many minutes), short enough that the URL
+ * effectively expires before the user could share it. The Supabase REST
+ * `/object/sign` endpoint accepts seconds.
+ */
+const EXPORT_SIGNED_URL_TTL_SECONDS = 60 * 60;
+
+/**
+ * Wire shape of the per-envelope `files` block in the export. Each key
+ * is `null` when either (a) the artifact does not exist (e.g. the
+ * envelope is a draft so there is no sealed PDF yet) or (b) the storage
+ * call failed — in case (b) a corresponding entry is appended to
+ * `warnings[]` so the consumer knows to retry.
+ */
+export interface EnvelopeExportFiles {
+  readonly original_pdf_url: string | null;
+  readonly sealed_pdf_url: string | null;
+  readonly audit_pdf_url: string | null;
+  readonly signers: ReadonlyArray<{
+    readonly signer_id: string;
+    readonly signature_image_url: string | null;
+    readonly initials_image_url: string | null;
+  }>;
+}
+
+/**
  * Wire format of the GDPR / CCPA / DSAR data export. Public surface
  * lives in this comment + the type definition because the JSON file is
  * downloaded by users and consumed by their tooling — the shape is
@@ -43,7 +72,11 @@ export interface AccountExport {
       readonly templates: number;
       readonly outbound_emails: number;
     };
-    readonly includes_files: false;
+    // Issue #46 — true once the export attaches short-TTL signed URLs
+    // for every storage object alongside the row data. Consumers that
+    // see `includes_files: false` should not expect `files` blocks on
+    // the envelope bundles (legacy callers / downgraded responses).
+    readonly includes_files: boolean;
   };
   readonly contacts: ReadonlyArray<unknown>;
   readonly templates: ReadonlyArray<unknown>;
@@ -52,6 +85,12 @@ export interface AccountExport {
     readonly signers: ReadonlyArray<EnvelopeSigner>;
     readonly events: ReadonlyArray<EnvelopeEvent>;
     readonly outbound_emails: ReadonlyArray<unknown>;
+    // Issue #46 — attached when `meta.includes_files` is true. Each URL
+    // is independently nullable: missing artifacts (drafts have no
+    // sealed PDF; non-drawn signers have no signature image) emit
+    // `null` without a warning, while storage failures emit `null` AND
+    // surface a `warnings[]` entry keyed by storage path.
+    readonly files: EnvelopeExportFiles;
   }>;
 }
 
@@ -84,7 +123,75 @@ export class MeService {
     private readonly outboundEmailsRepo: OutboundEmailsRepository,
     private readonly idempotencyRepo: IdempotencyRepository,
     private readonly supabaseAdmin: SupabaseAdminClient,
+    // Issue #46 — used to mint short-TTL signed URLs for every storage
+    // artifact attached to the export (sealed PDF, audit PDF, original
+    // PDF, signer signature/initials images).
+    private readonly storage: StorageService,
   ) {}
+
+  /**
+   * Issue #46 — produce signed Storage URLs for every artifact attached
+   * to a single envelope bundle. Failures degrade gracefully: the URL
+   * field is set to `null` and a warning is appended so the caller can
+   * retry. We never let one bad object abort the whole export.
+   *
+   * `null` storage paths (e.g. an audit PDF that hasn't been generated
+   * yet) emit `null` URLs WITHOUT a warning — those are expected absent
+   * artifacts, not failures.
+   */
+  private async signEnvelopeArtifacts(
+    envelopeId: string,
+    signers: ReadonlyArray<EnvelopeSigner>,
+    warnings: Array<{ readonly code: string; readonly detail: string }>,
+  ): Promise<EnvelopeExportFiles> {
+    const filePaths = await this.envelopesRepo.getFilePaths(envelopeId);
+    const signerImages = await this.envelopesRepo.listSignerImagePaths(envelopeId);
+
+    const signOne = async (path: string | null | undefined): Promise<string | null> => {
+      if (!path) return null;
+      try {
+        return await this.storage.createSignedUrl(path, EXPORT_SIGNED_URL_TTL_SECONDS);
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        warnings.push({
+          code: 'storage_url_failed',
+          detail: `envelope ${envelopeId} object ${path}: ${detail}`,
+        });
+        return null;
+      }
+    };
+
+    const [originalUrl, sealedUrl, auditUrl] = await Promise.all([
+      signOne(filePaths?.original_file_path),
+      signOne(filePaths?.sealed_file_path),
+      signOne(filePaths?.audit_file_path),
+    ]);
+
+    // Order signer URLs to match `signers[]` so consumers can join by
+    // index — but also key by signer_id since order is best-effort.
+    const imagesById = new Map(signerImages.map((s) => [s.signer_id, s] as const));
+    const signerFiles = await Promise.all(
+      signers.map(async (s) => {
+        const paths = imagesById.get(s.id);
+        const [signatureUrl, initialsUrl] = await Promise.all([
+          signOne(paths?.signature_image_path),
+          signOne(paths?.initials_image_path),
+        ]);
+        return {
+          signer_id: s.id,
+          signature_image_url: signatureUrl,
+          initials_image_url: initialsUrl,
+        };
+      }),
+    );
+
+    return {
+      original_pdf_url: originalUrl,
+      sealed_pdf_url: sealedUrl,
+      audit_pdf_url: auditUrl,
+      signers: signerFiles,
+    };
+  }
 
   /**
    * T-19 — assemble an export of every row owned by the caller as an
@@ -101,10 +208,12 @@ export class MeService {
     ]);
 
     // For each envelope id, hydrate the full aggregate + events +
-    // outbound emails in parallel. Order doesn't matter — the consumer
-    // sorts on its end. We bound concurrency by `Promise.all` over the
-    // outer list, which is small (envelopeIds is the user's lifetime
-    // count). If that ever gets large, batch with a semaphore.
+    // outbound emails + signed-URL-bearing files in parallel. Order
+    // doesn't matter — the consumer sorts on its end. We bound
+    // concurrency by `Promise.all` over the outer list, which is small
+    // (envelopeIds is the user's lifetime count). If that ever gets
+    // large, batch with a semaphore.
+    const warnings: Array<{ readonly code: string; readonly detail: string }> = [];
     const envelopes = await Promise.all(
       envelopeIds.map(async (envelopeId) => {
         const [aggregate, events, outboundEmails] = await Promise.all([
@@ -119,17 +228,30 @@ export class MeService {
           this.logger.warn(`export: envelope ${envelopeId} disappeared mid-flight; skipping`);
           return null;
         }
+        const files = await this.signEnvelopeArtifacts(envelopeId, aggregate.signers, warnings);
         return {
           envelope: aggregate,
           signers: aggregate.signers,
           events,
           outbound_emails: outboundEmails,
+          files,
         };
       }),
     );
 
     const cleanEnvelopes = envelopes.filter((e): e is NonNullable<typeof e> => e !== null);
     const outboundEmailCount = cleanEnvelopes.reduce((n, e) => n + e.outbound_emails.length, 0);
+    if (warnings.length > 0) {
+      // The non-streamed path doesn't have a place to surface warnings
+      // in the wire shape (it's frozen for backward compat), so we log
+      // them and keep going. The streaming path attaches them to
+      // `warnings[]`. If a consumer needs storage failure visibility
+      // they should use /me/export (streaming) which is the controller
+      // path; `exportAll` is for tests + small accounts.
+      this.logger.warn(
+        `export: ${warnings.length} storage URL warning(s) for user=${user.id}; first=${warnings[0]?.detail ?? ''}`,
+      );
+    }
 
     return {
       meta: {
@@ -142,7 +264,7 @@ export class MeService {
           templates: templates.length,
           outbound_emails: outboundEmailCount,
         },
-        includes_files: false,
+        includes_files: true,
       },
       contacts,
       templates,
@@ -205,12 +327,16 @@ export class MeService {
         // Filled in at the end of the stream — emitted in `meta_tail`.
         outbound_emails: null as number | null,
       },
-      includes_files: false as const,
+      // Issue #46 — streamed exports always attempt to attach signed
+      // URLs. Per-object failures degrade to `null` URL + a `warnings[]`
+      // entry; they never abort the stream.
+      includes_files: true as const,
     };
 
     const repo = this.envelopesRepo;
     const outRepo = this.outboundEmailsRepo;
     const logger = this.logger;
+    const signArtifacts = this.signEnvelopeArtifacts.bind(this);
     let outboundEmailCount = 0;
 
     // We use an async generator + Readable.from so backpressure is
@@ -243,11 +369,15 @@ export class MeService {
               });
               return null;
             }
+            // Sign storage artifacts after hydration so we have the
+            // signer ids; failures append to `warnings` but don't abort.
+            const files = await signArtifacts(envelopeId, aggregate.signers, warnings);
             return {
               envelope: aggregate,
               signers: aggregate.signers,
               events,
               outbound_emails: outboundEmails,
+              files,
             };
           }),
         );

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
+import { createHash } from 'node:crypto';
 import { Readable } from 'node:stream';
 import type { AuthUser } from '../auth/auth-user';
 import { ContactsRepository } from '../contacts/contacts.repository';
@@ -9,6 +10,7 @@ import { StorageService } from '../storage/storage.service';
 import { TemplatesRepository } from '../templates/templates.repository';
 import { IdempotencyRepository } from './idempotency.repository';
 import { SupabaseAdminClient, SupabaseAdminError } from './supabase-admin.client';
+import { TombstonesRepository } from './tombstones.repository';
 
 /**
  * Hard cap on how many envelopes the inline streaming export will emit.
@@ -127,6 +129,11 @@ export class MeService {
     // artifact attached to the export (sealed PDF, audit PDF, original
     // PDF, signer signature/initials images).
     private readonly storage: StorageService,
+    // Issues #38 / #43 — forensic breadcrumb for deleted accounts. We
+    // record `(user_id, sha256(lowercase(email)))` BEFORE asking Supabase
+    // to delete the auth row so a partial failure still leaves us with a
+    // record of who used to own the preserved sealed envelopes.
+    private readonly tombstonesRepo: TombstonesRepository,
   ) {}
 
   /**
@@ -401,19 +408,73 @@ export class MeService {
   }
 
   /**
-   * T-20 — wipe non-cascading rows then ask Supabase to delete the
-   * `auth.users` row, which triggers cascade deletion of every
-   * `owner_id` FK (contacts, envelopes & children, templates,
-   * outbound_emails).
+   * T-20 / Issues #38 / #43 — DSAR-compliant account deletion that
+   * preserves cryptographically-sealed records.
    *
-   * Order: idempotency_records FIRST, admin call SECOND. If the admin
-   * call fails the user retries; the idempotency wipe is safely
-   * idempotent. Doing it the other way around would leave orphan
-   * records the user could no longer reach via the auth system.
+   * GDPR Art. 17(3)(b/e) explicitly carves out exactly this case: the
+   * "right to erasure" does not apply to records held for compliance
+   * with a legal obligation, or for the establishment / exercise /
+   * defence of legal claims. ESIGN §7001(d) AND eIDAS Art. 25(2) AND
+   * most state-level contract-law statutes require that a sealed signed
+   * record be retained for the full statutory window (typically 6-7
+   * years) — independently of whether the parties later choose to
+   * delete their auth records.
+   *
+   * Execution order is intentional:
+   *   1. Wipe `idempotency_records` (FK does NOT cascade — left over,
+   *      these would be orphans the user could never reach again).
+   *   2. Hard-delete contacts (working state, no statutory retention).
+   *   3. Hard-delete templates (working state).
+   *   4. Atomic envelopes purge:
+   *        a. Hard-delete drafts.
+   *        b. For every non-draft (sealed/awaiting/declined/expired/
+   *           canceled) envelope: anonymize signer rows that match
+   *           the deleted user's email, append a `retention_deleted`
+   *           audit event (chain stays intact), and NULL `owner_id`
+   *           so the row survives Supabase's auth.users delete.
+   *   5. Record a tombstone `(user_id, sha256(lowercase(email)))`
+   *      BEFORE asking Supabase to delete the auth row. If Supabase
+   *      then fails we still have a forensic breadcrumb of who used
+   *      to own the preserved envelopes, and the tombstone upsert is
+   *      idempotent so a retry won't duplicate.
+   *   6. Ask Supabase to delete the `auth.users` row. The FK on
+   *      envelopes is now `ON DELETE SET NULL` (migration 0012) as a
+   *      belt-and-braces — if anyone bypasses this service path the
+   *      sealed envelopes still survive.
+   *
+   * If the Supabase call fails we map to 503 — the user can retry; all
+   * preceding steps are idempotent.
    */
   async deleteAccount(user: AuthUser): Promise<void> {
+    const emailHash = createHash('sha256')
+      .update((user.email ?? '').toLowerCase())
+      .digest('hex');
+
     const wiped = await this.idempotencyRepo.deleteByUser(user.id);
     this.logger.log(`account-delete: idempotency_records wiped=${wiped} user=${user.id}`);
+
+    const contactsDeleted = await this.contactsRepo.deleteAllByOwner(user.id);
+    this.logger.log(`account-delete: contacts deleted=${contactsDeleted} user=${user.id}`);
+
+    const templatesDeleted = await this.templatesRepo.deleteAllByOwner(user.id);
+    this.logger.log(`account-delete: templates deleted=${templatesDeleted} user=${user.id}`);
+
+    const purge = await this.envelopesRepo.purgeOwnedDataForAccountDeletion({
+      owner_id: user.id,
+      email: user.email,
+      email_hash: emailHash,
+    });
+    this.logger.log(
+      `account-delete: envelopes drafts_deleted=${purge.drafts_deleted} preserved=${purge.envelopes_preserved} signers_anonymized=${purge.signers_anonymized} retention_events=${purge.retention_events_appended} user=${user.id}`,
+    );
+
+    // Tombstone BEFORE the admin call — see method docstring step 5.
+    await this.tombstonesRepo.recordDeletion({
+      user_id: user.id,
+      email_hash: emailHash,
+    });
+    this.logger.log(`account-delete: tombstone recorded user=${user.id}`);
+
     try {
       await this.supabaseAdmin.deleteUser(user.id);
     } catch (err) {

--- a/apps/api/src/me/tombstones.repository.pg.ts
+++ b/apps/api/src/me/tombstones.repository.pg.ts
@@ -1,0 +1,32 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Kysely } from 'kysely';
+import { sql } from 'kysely';
+import type { Database } from '../../db/schema';
+import { DB_TOKEN } from '../db/db.provider';
+import { TombstonesRepository } from './tombstones.repository';
+
+@Injectable()
+export class TombstonesPgRepository extends TombstonesRepository {
+  constructor(@Inject(DB_TOKEN) private readonly db: Kysely<Database>) {
+    super();
+  }
+
+  async recordDeletion(input: {
+    readonly user_id: string;
+    readonly email_hash: string;
+  }): Promise<void> {
+    await this.db
+      .insertInto('deleted_user_tombstones')
+      .values({
+        user_id: input.user_id,
+        email_hash: input.email_hash,
+      })
+      .onConflict((oc) =>
+        oc.column('user_id').doUpdateSet({
+          email_hash: input.email_hash,
+          deleted_at: sql<string>`now()`,
+        }),
+      )
+      .execute();
+  }
+}

--- a/apps/api/src/me/tombstones.repository.ts
+++ b/apps/api/src/me/tombstones.repository.ts
@@ -1,0 +1,18 @@
+/**
+ * Issues #38 / #43 — write-side port for the `deleted_user_tombstones`
+ * table created in migration 0012. Kept tiny on purpose: MeService is
+ * the only caller, and the table is append-only forensic bookkeeping
+ * (no read API needed today).
+ */
+export abstract class TombstonesRepository {
+  /**
+   * Record that an account was deleted. `email_hash` MUST be the
+   * lowercase SHA-256 hex digest of the user's email at the time of
+   * deletion. Idempotent — re-runs of the deletion path overwrite the
+   * timestamp but never throw.
+   */
+  abstract recordDeletion(input: {
+    readonly user_id: string;
+    readonly email_hash: string;
+  }): Promise<void>;
+}

--- a/apps/api/src/templates/templates.repository.pg.ts
+++ b/apps/api/src/templates/templates.repository.pg.ts
@@ -115,6 +115,14 @@ export class TemplatesPgRepository extends TemplatesRepository {
     return (res?.numDeletedRows ?? 0n) > 0n;
   }
 
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    const res = await this.db
+      .deleteFrom('templates')
+      .where('owner_id', '=', owner_id)
+      .executeTakeFirst();
+    return Number(res?.numDeletedRows ?? 0n);
+  }
+
   async incrementUseCount(owner_id: string, id: string): Promise<Template | null> {
     const now = new Date().toISOString();
     const row = await this.db

--- a/apps/api/src/templates/templates.repository.ts
+++ b/apps/api/src/templates/templates.repository.ts
@@ -65,4 +65,14 @@ export abstract class TemplatesRepository {
    * attached or the template is missing/owned-elsewhere.
    */
   abstract getExamplePdfPath(owner_id: string, id: string): Promise<string | null>;
+
+  /**
+   * Issue #38 — bulk-delete every template owned by `owner_id`. Used by
+   * MeService.deleteAccount; templates are working state, not statutory
+   * records. Returns the row count actually deleted. Idempotent.
+   * Note: the example_pdf_path object in Storage is NOT cleaned up by
+   * this call — caller is responsible for removing those out-of-band
+   * (or letting Storage GC reap orphans on the next sweep).
+   */
+  abstract deleteAllByOwner(owner_id: string): Promise<number>;
 }

--- a/apps/api/test/auth.e2e-spec.ts
+++ b/apps/api/test/auth.e2e-spec.ts
@@ -71,7 +71,7 @@ describe('Auth (e2e)', () => {
 
   it('GET /me with expired token returns 401 token_expired', async () => {
     const token = await tk.sign(
-      { sub: 'u1' },
+      { sub: '00000000-0000-4000-8000-000000000001' },
       { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE, expiresIn: '-1s' },
     );
     const res = await request(app.getHttpServer())
@@ -83,14 +83,18 @@ describe('Auth (e2e)', () => {
 
   it('GET /me with valid token returns the user', async () => {
     const token = await tk.sign(
-      { sub: 'u1', email: 'a@b.com', app_metadata: { provider: 'google' } },
+      {
+        sub: '00000000-0000-4000-8000-000000000001',
+        email: 'a@b.com',
+        app_metadata: { provider: 'google' },
+      },
       { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE },
     );
     await request(app.getHttpServer())
       .get('/me')
       .set('Authorization', `Bearer ${token}`)
       .expect(200)
-      .expect({ id: 'u1', email: 'a@b.com', provider: 'google' });
+      .expect({ id: '00000000-0000-4000-8000-000000000001', email: 'a@b.com', provider: 'google' });
   });
 
   it('CORS preflight from allowed origin succeeds', async () => {

--- a/apps/api/test/contacts.e2e-spec.ts
+++ b/apps/api/test/contacts.e2e-spec.ts
@@ -84,7 +84,7 @@ describe('Contacts — auth contract (e2e)', () => {
 
   it('GET /contacts with expired token → 401 token_expired', async () => {
     const token = await tk.sign(
-      { sub: 'user-1' },
+      { sub: '00000000-0000-4000-8000-000000000001' },
       {
         issuer: `${TEST_ENV.SUPABASE_URL}/auth/v1`,
         audience: TEST_ENV.SUPABASE_JWT_AUDIENCE,

--- a/apps/api/test/in-memory-contacts-repository.ts
+++ b/apps/api/test/in-memory-contacts-repository.ts
@@ -74,4 +74,15 @@ export class InMemoryContactsRepository extends ContactsRepository {
     this.rows.delete(id);
     return true;
   }
+
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    let count = 0;
+    for (const [id, row] of this.rows) {
+      if (row.owner_id === owner_id) {
+        this.rows.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
 }

--- a/apps/api/test/in-memory-envelopes-repository.ts
+++ b/apps/api/test/in-memory-envelopes-repository.ts
@@ -197,6 +197,21 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
     });
   }
 
+  // Issue #46 — mirror of the PG branch so /me/export tests can exercise
+  // the storage-URL path against an in-memory fixture.
+  async listSignerImagePaths(envelope_id: string) {
+    const env = this.envelopes.get(envelope_id);
+    if (!env) return [];
+    return env.signers.map((s) => {
+      const meta = this.signerMeta.get(s.id);
+      return {
+        signer_id: s.id,
+        signature_image_path: meta?.signature_image_path ?? null,
+        initials_image_path: meta?.initials_image_path ?? null,
+      };
+    });
+  }
+
   async updateDraftMetadata(
     owner_id: string,
     envelope_id: string,

--- a/apps/api/test/in-memory-envelopes-repository.ts
+++ b/apps/api/test/in-memory-envelopes-repository.ts
@@ -773,4 +773,80 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
       throw new InvalidCursorError();
     }
   }
+
+  /**
+   * Issues #38 / #43 — mirror of the PG transactional purge. The
+   * in-memory store has no transactions; we just execute the steps in
+   * order. Tests pin counts to assert the algorithm.
+   */
+  async purgeOwnedDataForAccountDeletion(input: {
+    readonly owner_id: string;
+    readonly email: string | null;
+    readonly email_hash: string;
+  }): Promise<{
+    readonly drafts_deleted: number;
+    readonly envelopes_preserved: number;
+    readonly signers_anonymized: number;
+    readonly retention_events_appended: number;
+  }> {
+    let drafts_deleted = 0;
+    for (const [id, env] of [...this.envelopes]) {
+      if (env.owner_id === input.owner_id && env.status === 'draft') {
+        this.envelopes.delete(id);
+        // Best-effort cascade for parallel maps so tests reflect FK
+        // cascades the real DB performs.
+        this.events.splice(
+          0,
+          this.events.length,
+          ...this.events.filter((e) => e.envelope_id !== id),
+        );
+        drafts_deleted++;
+      }
+    }
+
+    const preserved = [...this.envelopes.values()].filter((e) => e.owner_id === input.owner_id);
+    const envelopes_preserved = preserved.length;
+
+    const placeholderEmail = `${input.email_hash}@deleted.invalid`;
+    let signers_anonymized = 0;
+    let retention_events_appended = 0;
+
+    for (const env of preserved) {
+      const nextSigners = env.signers.map((s) => {
+        if (
+          input.email !== null &&
+          input.email !== undefined &&
+          s.email.toLowerCase() === input.email.toLowerCase()
+        ) {
+          signers_anonymized++;
+          return { ...s, name: 'Deleted user', email: placeholderEmail };
+        }
+        return s;
+      });
+
+      // Append retention_deleted via the existing chain helper so the
+      // hash continues unbroken.
+      await this.appendEvent({
+        envelope_id: env.id,
+        actor_kind: 'system',
+        event_type: 'retention_deleted',
+        metadata: { reason: 'account_deletion', email_hash: input.email_hash },
+      });
+      retention_events_appended++;
+
+      this.envelopes.set(env.id, {
+        ...env,
+        owner_id: null,
+        signers: nextSigners,
+        updated_at: new Date().toISOString(),
+      });
+    }
+
+    return {
+      drafts_deleted,
+      envelopes_preserved,
+      signers_anonymized,
+      retention_events_appended,
+    };
+  }
 }

--- a/apps/api/test/in-memory-templates-repository.ts
+++ b/apps/api/test/in-memory-templates-repository.ts
@@ -82,6 +82,18 @@ export class InMemoryTemplatesRepository extends TemplatesRepository {
     return true;
   }
 
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    let count = 0;
+    for (const [id, row] of this.rows) {
+      if (row.owner_id === owner_id) {
+        this.rows.delete(id);
+        this.examplePaths.delete(id);
+        count++;
+      }
+    }
+    return count;
+  }
+
   async incrementUseCount(owner_id: string, id: string): Promise<Template | null> {
     const existing = this.rows.get(id);
     if (!existing || existing.owner_id !== owner_id) return null;

--- a/apps/api/test/me-export.e2e-spec.ts
+++ b/apps/api/test/me-export.e2e-spec.ts
@@ -1,0 +1,185 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { APP_ENV } from '../src/config/config.module';
+import type { AppEnv } from '../src/config/env.schema';
+import { JWKS_RESOLVER } from '../src/auth/jwks.provider';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+import { ContactsRepository } from '../src/contacts/contacts.repository';
+import { EnvelopesRepository } from '../src/envelopes/envelopes.repository';
+import { TemplatesRepository } from '../src/templates/templates.repository';
+import { OutboundEmailsRepository } from '../src/email/outbound-emails.repository';
+import { IdempotencyRepository } from '../src/me/idempotency.repository';
+import { SupabaseAdminClient } from '../src/me/supabase-admin.client';
+import { buildTestJwks } from './test-jwks';
+import { InMemoryContactsRepository } from './in-memory-contacts-repository';
+import { InMemoryEnvelopesRepository } from './in-memory-envelopes-repository';
+import { InMemoryTemplatesRepository } from './in-memory-templates-repository';
+import { InMemoryOutboundEmailsRepository } from './in-memory-outbound-emails-repository';
+import { InMemoryIdempotencyRepository } from './in-memory-idempotency-repository';
+import { StubSupabaseAdminClient } from './stub-supabase-admin';
+
+/**
+ * Issue #45 — `/me/export` must stream envelopes in batches instead of
+ * materializing the whole aggregate in memory. This e2e seeds N
+ * envelopes for one user, drains the response, and asserts:
+ *
+ *   1. The status + Content-Type + RFC 6266 Content-Disposition are
+ *      correct (streaming doesn't break the wire contract).
+ *   2. The streamed JSON is well-formed and contains every envelope.
+ *   3. Peak heap measured *while the stream is mid-flight* stays well
+ *      below "load everything at once" (the assertion is loose — we
+ *      just need to prove the streaming path is exercised, not target
+ *      a specific MB number, because GC noise on small CI workers is
+ *      high).
+ */
+
+const TEST_ENV: AppEnv = {
+  NODE_ENV: 'test',
+  PORT: 0,
+  SUPABASE_URL: 'https://example.supabase.co',
+  SUPABASE_JWT_AUDIENCE: 'authenticated',
+  CORS_ORIGIN: 'http://localhost:5173',
+  APP_PUBLIC_URL: 'http://localhost:5173',
+  DATABASE_URL: 'postgres://u:p@127.0.0.1:5432/db?sslmode=disable',
+  STORAGE_BUCKET: 'envelopes',
+  TC_VERSION: '2026-04-24',
+  PRIVACY_VERSION: '2026-04-24',
+  EMAIL_PROVIDER: 'logging',
+  EMAIL_FROM_ADDRESS: 'onboarding@resend.dev',
+  EMAIL_FROM_NAME: 'Seald',
+  EMAIL_LEGAL_ENTITY: 'Seald, Inc.',
+  EMAIL_LEGAL_POSTAL: 'Postal address available on request — write to legal@seald.test.',
+  EMAIL_PRIVACY_URL: 'https://seald.nromomentum.com/legal/privacy',
+  EMAIL_PREFERENCES_URL: 'mailto:privacy@seald.nromomentum.com?subject=Email%20preferences',
+  PDF_SIGNING_PROVIDER: 'local',
+  PDF_SIGNING_TSA_URL: 'https://freetsa.org/tsr',
+  ENVELOPE_RETENTION_YEARS: 7,
+  WORKER_ENABLED: false,
+};
+
+const USER_A = '00000000-0000-0000-0000-00000000000a';
+const USER_A_EMAIL = 'maya@example.com';
+
+describe('/me/export streaming (issue #45) — e2e', () => {
+  let app: INestApplication;
+  let envelopesRepo: InMemoryEnvelopesRepository;
+  let tk: Awaited<ReturnType<typeof buildTestJwks>>;
+  let tokenA: string;
+
+  beforeAll(async () => {
+    tk = await buildTestJwks();
+    envelopesRepo = new InMemoryEnvelopesRepository();
+
+    const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
+      .overrideProvider(APP_ENV)
+      .useValue(TEST_ENV)
+      .overrideProvider(JWKS_RESOLVER)
+      .useValue(tk.resolver)
+      .overrideProvider(ContactsRepository)
+      .useValue(new InMemoryContactsRepository())
+      .overrideProvider(EnvelopesRepository)
+      .useValue(envelopesRepo)
+      .overrideProvider(TemplatesRepository)
+      .useValue(new InMemoryTemplatesRepository())
+      .overrideProvider(OutboundEmailsRepository)
+      .useValue(new InMemoryOutboundEmailsRepository())
+      .overrideProvider(IdempotencyRepository)
+      .useValue(new InMemoryIdempotencyRepository())
+      .overrideProvider(SupabaseAdminClient)
+      .useValue(new StubSupabaseAdminClient())
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    app.useGlobalPipes(
+      new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true, transform: true }),
+    );
+    app.useGlobalFilters(new HttpExceptionFilter());
+    await app.init();
+
+    tokenA = await tk.sign(
+      { sub: USER_A, email: USER_A_EMAIL },
+      {
+        issuer: `${TEST_ENV.SUPABASE_URL}/auth/v1`,
+        audience: TEST_ENV.SUPABASE_JWT_AUDIENCE,
+      },
+    );
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('streams a 1000-envelope export without OOM and returns a valid JSON body', async () => {
+    // Seed 1000 envelopes directly via the in-memory repo. We bypass
+    // the controller path so we can hit the count we want without
+    // running the full draft/send flow per envelope.
+    for (let i = 0; i < 1000; i++) {
+      await envelopesRepo.createDraft({
+        owner_id: USER_A,
+        title: `Doc ${i}`,
+        // 13-char short codes — must be unique per envelope.
+        short_code: `c${i.toString().padStart(12, '0')}`,
+        tc_version: TEST_ENV.TC_VERSION,
+        privacy_version: TEST_ENV.PRIVACY_VERSION,
+        expires_at: new Date(Date.now() + 1000 * 60 * 60 * 24 * 30).toISOString(),
+      });
+    }
+    expect(envelopesRepo.envelopes.size).toBe(1000);
+
+    // Sample heap at a few points during the response so we can prove
+    // the stream isn't materializing the whole payload before sending.
+    const samples: number[] = [];
+    if (typeof global.gc === 'function') global.gc();
+    samples.push(process.memoryUsage().heapUsed);
+
+    const res = await request(app.getHttpServer())
+      .get('/me/export')
+      .set('Authorization', `Bearer ${tokenA}`)
+      .buffer(true)
+      .parse((response, callback) => {
+        const chunks: Buffer[] = [];
+        response.on('data', (c: Buffer) => {
+          chunks.push(c);
+          // Sample every ~100 chunks so we get a few mid-stream
+          // measurements instead of just one at the end.
+          if (chunks.length % 100 === 0) {
+            samples.push(process.memoryUsage().heapUsed);
+          }
+        });
+        response.on('end', () => callback(null, Buffer.concat(chunks)));
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers['content-type']).toMatch(/application\/json/);
+    expect(res.headers['content-disposition']).toMatch(/^attachment; filename="seald-export-/);
+
+    const body = (res.body as Buffer).toString('utf8');
+    const payload = JSON.parse(body) as {
+      meta: { counts: { envelopes: number } };
+      envelopes: unknown[];
+      meta_tail: { outbound_emails: number };
+      warnings: unknown[];
+    };
+
+    expect(payload.meta.counts.envelopes).toBe(1000);
+    expect(payload.envelopes).toHaveLength(1000);
+    expect(payload.meta_tail.outbound_emails).toBe(0);
+    expect(payload.warnings).toEqual([]);
+
+    // Loose delta bound — Nest e2e baseline heap varies wildly between
+    // CI runners, so a strict absolute threshold is brittle. Instead,
+    // assert that the *growth* during the stream stayed below ~150 MB.
+    // A regression to "buffer everything before sending" would push
+    // the delta proportionally to envelope count (1000 envelopes
+    // hydrated * ~10 KB each = ~10 MB of payload + serialization
+    // overhead, but the buffered-all-at-once build also needs the
+    // entire indented JSON.stringify result resident which inflates
+    // 3-5x). 150 MB is comfortably above streaming's actual ceiling
+    // and below the buffered ceiling on a 1000-envelope payload.
+    const baseline = samples[0] ?? 0;
+    const peakDelta = Math.max(...samples) - baseline;
+    expect(peakDelta).toBeLessThan(150 * 1024 * 1024);
+  }, 30_000);
+});

--- a/apps/api/test/me.e2e-spec.ts
+++ b/apps/api/test/me.e2e-spec.ts
@@ -177,12 +177,17 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       expect(payload.meta.format_version).toBe('1.0');
       expect(payload.meta.user).toEqual({ id: USER_A, email: USER_A_EMAIL });
       expect(payload.meta.includes_files).toBe(false);
+      // Streaming variant (issue #45): top-level `meta.counts` reports
+      // contact/template/envelope counts up-front; `outbound_emails` is
+      // unknown until envelopes are hydrated, so it lives in `meta_tail`.
       expect(payload.meta.counts).toEqual({
         contacts: 1,
         envelopes: 0,
         templates: 0,
-        outbound_emails: 0,
+        outbound_emails: null,
       });
+      expect(payload.meta_tail).toEqual({ outbound_emails: 0 });
+      expect(payload.warnings).toEqual([]);
       expect(typeof payload.meta.generated_at).toBe('string');
       expect(payload.contacts).toHaveLength(1);
       expect(payload.contacts[0].owner_id).toBe(USER_A);

--- a/apps/api/test/me.e2e-spec.ts
+++ b/apps/api/test/me.e2e-spec.ts
@@ -165,9 +165,13 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       expect(res.headers['content-type']).toMatch(/application\/json/);
       expect(res.headers['cache-control']).toBe('no-store');
       const cd = res.headers['content-disposition'] as string;
+      // RFC 6266 (issue #44): both an ASCII `filename=` fallback AND a
+      // `filename*=UTF-8''<encoded>` extension. The browser prefers the
+      // latter; we assert both pieces are present.
       expect(cd).toMatch(/^attachment; filename="seald-export-/);
       expect(cd).toContain(USER_A);
-      expect(cd).toMatch(/\.json"$/);
+      expect(cd).toMatch(/\.json"; filename\*=UTF-8''seald-export-/);
+      expect(cd).toMatch(/\.json$/);
 
       const payload = JSON.parse((res.body as Buffer).toString('utf8'));
       expect(payload.meta.format_version).toBe('1.0');

--- a/apps/api/test/me.e2e-spec.ts
+++ b/apps/api/test/me.e2e-spec.ts
@@ -176,7 +176,9 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       const payload = JSON.parse((res.body as Buffer).toString('utf8'));
       expect(payload.meta.format_version).toBe('1.0');
       expect(payload.meta.user).toEqual({ id: USER_A, email: USER_A_EMAIL });
-      expect(payload.meta.includes_files).toBe(false);
+      // Issue #46 — flipped to true now that streaming exports always
+      // attempt to attach signed Storage URLs for every envelope artifact.
+      expect(payload.meta.includes_files).toBe(true);
       // Streaming variant (issue #45): top-level `meta.counts` reports
       // contact/template/envelope counts up-front; `outbound_emails` is
       // unknown until envelopes are hydrated, so it lives in `meta_tail`.

--- a/apps/api/test/me.e2e-spec.ts
+++ b/apps/api/test/me.e2e-spec.ts
@@ -12,6 +12,7 @@ import { TemplatesRepository } from '../src/templates/templates.repository';
 import { OutboundEmailsRepository } from '../src/email/outbound-emails.repository';
 import { IdempotencyRepository } from '../src/me/idempotency.repository';
 import { SupabaseAdminClient } from '../src/me/supabase-admin.client';
+import { TombstonesRepository } from '../src/me/tombstones.repository';
 import { buildTestJwks } from './test-jwks';
 import { InMemoryContactsRepository } from './in-memory-contacts-repository';
 import { InMemoryEnvelopesRepository } from './in-memory-envelopes-repository';
@@ -19,6 +20,27 @@ import { InMemoryTemplatesRepository } from './in-memory-templates-repository';
 import { InMemoryOutboundEmailsRepository } from './in-memory-outbound-emails-repository';
 import { InMemoryIdempotencyRepository } from './in-memory-idempotency-repository';
 import { StubSupabaseAdminClient } from './stub-supabase-admin';
+
+/**
+ * Issues #38/#43 — in-memory tombstones recorder. Captures every
+ * `recordDeletion` call so the e2e suite can assert the
+ * `(user_id, sha256(lowercase(email)))` shape and the strict
+ * "tombstone-before-supabase" ordering invariant.
+ */
+class InMemoryTombstonesRepository extends TombstonesRepository {
+  readonly recorded: Array<{ readonly user_id: string; readonly email_hash: string }> = [];
+  callLog: string[] = [];
+  async recordDeletion(input: {
+    readonly user_id: string;
+    readonly email_hash: string;
+  }): Promise<void> {
+    this.callLog.push('tombstones.recordDeletion');
+    this.recorded.push({ user_id: input.user_id, email_hash: input.email_hash });
+  }
+  reset(): void {
+    this.recorded.length = 0;
+  }
+}
 
 const TEST_ENV: AppEnv = {
   NODE_ENV: 'test',
@@ -56,6 +78,7 @@ describe('/me (DSAR + account deletion) — e2e', () => {
   let outboundEmailsRepo: InMemoryOutboundEmailsRepository;
   let idempotencyRepo: InMemoryIdempotencyRepository;
   let supabaseAdmin: StubSupabaseAdminClient;
+  let tombstonesRepo: InMemoryTombstonesRepository;
   let callLog: string[];
   let tk: Awaited<ReturnType<typeof buildTestJwks>>;
   let tokenA: string;
@@ -69,16 +92,34 @@ describe('/me (DSAR + account deletion) — e2e', () => {
     outboundEmailsRepo = new InMemoryOutboundEmailsRepository();
     idempotencyRepo = new InMemoryIdempotencyRepository();
     supabaseAdmin = new StubSupabaseAdminClient();
+    tombstonesRepo = new InMemoryTombstonesRepository();
 
     callLog = [];
-    // Wire ordering tracking for both repos so we can assert
-    // idempotency-wipe-precedes-admin-call invariant.
+    // Wire ordering tracking across repos so we can assert the strict
+    // delete-pipeline order: idempotency → contacts → templates →
+    // envelopes purge → tombstone → supabase admin.
     const origDelete = idempotencyRepo.deleteByUser.bind(idempotencyRepo);
     idempotencyRepo.deleteByUser = async (id: string): Promise<number> => {
       callLog.push('idempotency.deleteByUser');
       return origDelete(id);
     };
+    const origContactsDelAll = contactsRepo.deleteAllByOwner.bind(contactsRepo);
+    contactsRepo.deleteAllByOwner = async (id: string): Promise<number> => {
+      callLog.push('contacts.deleteAllByOwner');
+      return origContactsDelAll(id);
+    };
+    const origTemplatesDelAll = templatesRepo.deleteAllByOwner.bind(templatesRepo);
+    templatesRepo.deleteAllByOwner = async (id: string): Promise<number> => {
+      callLog.push('templates.deleteAllByOwner');
+      return origTemplatesDelAll(id);
+    };
+    const origPurge = envelopesRepo.purgeOwnedDataForAccountDeletion.bind(envelopesRepo);
+    envelopesRepo.purgeOwnedDataForAccountDeletion = async (input) => {
+      callLog.push('envelopes.purgeOwnedDataForAccountDeletion');
+      return origPurge(input);
+    };
     supabaseAdmin.callLog = callLog;
+    tombstonesRepo.callLog = callLog;
 
     const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
       .overrideProvider(APP_ENV)
@@ -97,6 +138,8 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       .useValue(idempotencyRepo)
       .overrideProvider(SupabaseAdminClient)
       .useValue(supabaseAdmin)
+      .overrideProvider(TombstonesRepository)
+      .useValue(tombstonesRepo)
       .compile();
 
     app = moduleRef.createNestApplication();
@@ -121,6 +164,7 @@ describe('/me (DSAR + account deletion) — e2e', () => {
     outboundEmailsRepo.rows.length = 0;
     idempotencyRepo.reset();
     supabaseAdmin.reset();
+    tombstonesRepo.reset();
     callLog.length = 0;
   });
 
@@ -257,7 +301,7 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       expect(supabaseAdmin.deletedUserIds).toEqual([]);
     });
 
-    it('happy path → 204 + idempotency wipe runs BEFORE admin call', async () => {
+    it('happy path → 204 runs the full soft-delete pipeline in legal order', async () => {
       idempotencyRepo.seed(USER_A, 4);
 
       const res = await request(app.getHttpServer())
@@ -268,13 +312,28 @@ describe('/me (DSAR + account deletion) — e2e', () => {
       expect(res.status).toBe(204);
       expect(idempotencyRepo.countFor(USER_A)).toBe(0);
       expect(supabaseAdmin.deletedUserIds).toEqual([USER_A]);
-      // Order matters — see MeService comment. Idempotency wipe first
-      // because admin failure is retryable; idempotency wipe is
-      // idempotent.
-      expect(callLog).toEqual(['idempotency.deleteByUser', 'supabaseAdmin.deleteUser']);
+      // Issues #38/#43 — strict pipeline order. Idempotency first
+      // (FK doesn't cascade), then working-state hard-deletes
+      // (contacts/templates), then the envelopes purge that preserves
+      // sealed records, then the tombstone (forensic breadcrumb), then
+      // the supabase admin call last so a partial failure leaves a
+      // recoverable state.
+      expect(callLog).toEqual([
+        'idempotency.deleteByUser',
+        'contacts.deleteAllByOwner',
+        'templates.deleteAllByOwner',
+        'envelopes.purgeOwnedDataForAccountDeletion',
+        'tombstones.recordDeletion',
+        'supabaseAdmin.deleteUser',
+      ]);
+      // Tombstone captured the SHA-256 hash of the lowercase email so a
+      // future signer who shares the address cannot be linked back.
+      expect(tombstonesRepo.recorded).toHaveLength(1);
+      expect(tombstonesRepo.recorded[0]?.user_id).toBe(USER_A);
+      expect(tombstonesRepo.recorded[0]?.email_hash).toMatch(/^[0-9a-f]{64}$/);
     });
 
-    it('admin failure → 503 admin_api_unavailable, but idempotency wipe still ran', async () => {
+    it('admin failure → 503 admin_api_unavailable, prior steps + tombstone all ran', async () => {
       idempotencyRepo.seed(USER_A, 2);
       supabaseAdmin.failNextWithAdminError('SUPABASE_SERVICE_ROLE_KEY missing');
 
@@ -284,10 +343,13 @@ describe('/me (DSAR + account deletion) — e2e', () => {
         .send({ confirm: 'DELETE_MY_ACCOUNT' });
 
       expect(res.status).toBe(503);
-      // Idempotency rows were still cleared (the wipe ran first, then
-      // the admin call threw).
+      // Idempotency rows still cleared, and crucially — the tombstone
+      // was recorded BEFORE the supabase admin call so we have a
+      // forensic breadcrumb even when supabase is down.
       expect(idempotencyRepo.countFor(USER_A)).toBe(0);
       expect(supabaseAdmin.deletedUserIds).toEqual([]);
+      expect(tombstonesRepo.recorded).toHaveLength(1);
+      expect(tombstonesRepo.recorded[0]?.user_id).toBe(USER_A);
     });
 
     it('non-admin error from the admin client surfaces as a 500', async () => {

--- a/apps/api/test/pg-mem-db.ts
+++ b/apps/api/test/pg-mem-db.ts
@@ -183,6 +183,35 @@ export function createPgMemDb(): PgMemHandle {
   const patched0010 = raw0010.replace(/comment on column[\s\S]*?;/g, '');
   mem.public.none(patched0010);
 
+  // 0012 — drop ON DELETE CASCADE on envelopes.owner_id (preserve
+  // sealed envelopes when accounts are deleted, GDPR Art. 17(3)(b/e)
+  // carve-out for legal records) and add the deleted_user_tombstones
+  // table. pg-mem doesn't implement `alter constraint` for FKs cleanly
+  // so we apply just the column-relaxation + tombstone-create
+  // statements; the FK semantics aren't asserted by unit tests
+  // (production migrations do them with real Postgres). Strip BEGIN /
+  // COMMIT wrappers (pg-mem treats `mem.public.none()` as auto-commit)
+  // and the `comment on table` block.
+  const migration0012Path = resolve(
+    __dirname,
+    '../db/migrations/0012_preserve_envelopes_on_user_delete.sql',
+  );
+  const raw0012 = readFileSync(migration0012Path, 'utf8');
+  // pg-mem can't drop+re-add FKs reliably (different parser path), so
+  // we extract only the column-nullable relaxation + tombstone create.
+  // The drop_constraint / add_constraint pairs are no-ops for pg-mem
+  // tests because pg-mem already permits NULL on the column once
+  // relaxed, and the cascade behaviour is exercised in real PG only.
+  void raw0012; // referenced for traceability — see header comment
+  mem.public.none(`
+    alter table public.envelopes alter column owner_id drop not null;
+    create table if not exists public.deleted_user_tombstones (
+      user_id    uuid        primary key,
+      email_hash text        not null check (char_length(email_hash) = 64),
+      deleted_at timestamptz not null default now()
+    );
+  `);
+
   const { Pool } = mem.adapters.createPg();
   const pool = new Pool();
   // pg-mem inlines query parameters by serializing Buffers as utf-8

--- a/cspell.json
+++ b/cspell.json
@@ -460,7 +460,19 @@
     "ccpa",
     "serialisable",
     "hrefs",
-    "initialised"
+    "initialised",
+    "anonymize",
+    "Anonymize",
+    "anonymization",
+    "Anonymization",
+    "anonymized",
+    "Anonymized",
+    "tombstone",
+    "Tombstone",
+    "tombstones",
+    "Tombstones",
+    "tombstoned",
+    "Tombstoned"
   ],
   "ignoreRegExpList": [
     "Base64",

--- a/packages/shared/src/envelope-contract.ts
+++ b/packages/shared/src/envelope-contract.ts
@@ -100,7 +100,11 @@ export type Field = z.infer<typeof FieldSchema>;
 
 export const EnvelopeSchema = z.object({
   id: uuid,
-  owner_id: uuid,
+  // Nullable since Issue #38/#43 — when an account is deleted under
+  // GDPR/DSAR, sealed envelopes survive (statutory ESIGN §7001(d)
+  // retention) but their `owner_id` is detached so the upstream
+  // `auth.users` row can be hard-removed.
+  owner_id: uuid.nullable(),
   title: z.string().min(1).max(200),
   short_code: z.string().length(13),
   status: z.enum(ENVELOPE_STATUSES),


### PR DESCRIPTION
## Summary

Bundles five P1 privacy / security / compliance fixes that all touched
the `/me` surface and were small enough to ship together. The headline
fix (#38/#43) is the soft-delete pipeline that preserves
cryptographically-sealed envelopes when a user invokes their right to
erasure — the previous behavior cascaded sealed records out of
existence, which violates ESIGN Act §7001(d) and eIDAS Art. 25(2).

### Closes

- **#38** — DELETE /me cascades sealed envelopes (legal-gap)
- **#43** — DELETE /me cascades into completed envelopes — violates 7-year retention + ESIGN/UETA + breaks audit chain
- **#44** — Content-Disposition HTTP-header-injectable via authenticated user.id
- **#45** — /me/export accumulates entire account in memory
- **#46** — /me/export omits signed file pointers

### What changed (per issue)

**#38 / #43 (this commit)** — Soft-delete pipeline that preserves
sealed envelopes:
- Migration 0012 flips `envelopes.owner_id` FK from `ON DELETE
  CASCADE` to `ON DELETE SET NULL` and creates a
  `deleted_user_tombstones` table (forensic breadcrumb of `(user_id,
  sha256(lowercase(email)), deleted_at)` — no PII retained).
- New `EnvelopesRepository.purgeOwnedDataForAccountDeletion`
  transactionally hard-deletes drafts, anonymizes signer rows whose
  email matches the deleted user, appends a `retention_deleted` audit
  event to each preserved envelope's chain, and NULLs `owner_id`.
- New `TombstonesRepository` records the breadcrumb BEFORE the
  Supabase admin call so a partial Supabase failure still leaves a
  recoverable record.
- `MeService.deleteAccount` now runs:
  `idempotency wipe → contacts hard-delete → templates hard-delete →
  envelopes purge → tombstone → supabase admin` — order asserted by
  unit + e2e tests; load-bearing legal invariant.
- `Envelope.owner_id` in the shared wire contract is now nullable; no
  SPA changes required.

**#44 (commit 108fff5)** — UUID-validate JWT `sub` + RFC 6266
Content-Disposition with both ASCII fallback and `filename*=UTF-8''…`
extension so a hostile JWT can no longer inject CRLF/DQUOTE into the
download header.

**#45 (commit 2a01219)** — `/me/export` switched from "load entire
account into memory" to a backpressured `Readable` async generator
that hydrates envelopes in batches of 500 (~5 MB peak heap regardless
of account size). Hard cap of 100k inline envelopes with a
`warnings[]` truncation notice for the eventual async-export pivot.

**#46 (commit 90d66c4)** — Each envelope bundle in the export now
carries a `files` block of short-TTL (1h) signed Storage URLs for
original/sealed/audit PDFs and per-signer signature/initials images.
Per-object failures degrade to `null` URL + a `warnings[]` entry; one
bad object never aborts the whole export.

## Verification

- `pnpm --filter api test` — 408 unit tests pass
- `pnpm exec jest --config test/jest-e2e.json` — 140 e2e tests pass
- `pnpm --filter web test` — 783 vitest tests pass
- `pnpm -r typecheck && pnpm -r lint` — clean across api/web/shared/landing
- New test cases assert: tombstone email_hash uses
  sha256(lowercase(email)); tombstone runs strictly before supabase;
  full pipeline call order; sealed envelopes survive via the purge
  port (not cascade); 503 mapping on Supabase failure preserves all
  prior steps.

## Test plan

- [x] Unit: `me.service.spec.ts` — 12/12 pass (5 new deleteAccount cases)
- [x] e2e: `me.e2e-spec.ts` — 9/9 pass (call-order invariant + tombstone shape)
- [x] e2e: full suite (140 tests) — pass
- [x] Web: 783 vitest tests — pass
- [x] Typecheck + lint — clean
- [ ] Manual smoke: send envelope, complete it, then DELETE /me — verify sealed PDF still downloadable via `/verify/:envelopeId` after the auth.users row is gone
- [ ] Manual smoke: confirm `deleted_user_tombstones` row appears with correct `email_hash`