### PR TITLE
test(api/templates): cover service + controller + DTO validation (phase-4 wave-2)

### DIFF
--- a/apps/api/src/templates/dto/template-dto.spec.ts
+++ b/apps/api/src/templates/dto/template-dto.spec.ts
@@ -1,0 +1,346 @@
+// reflect-metadata must be loaded before any class-validator / class-transformer
+// import touches the DTO decorators — the standalone spec doesn't go through
+// AppModule so we polyfill it here. (Nest's @nestjs/core entrypoint normally
+// imports this for us when the spec spins up a TestingModule.)
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+import { CreateTemplateDto, TemplateFieldDto, TemplateLastSignerDto } from './create-template.dto';
+import { UpdateTemplateDto } from './update-template.dto';
+
+const VALID_FIELD = {
+  type: 'signature',
+  pageRule: 'last',
+  x: 60,
+  y: 540,
+};
+
+function propsWithErrors(errors: { property: string; children?: unknown[] }[]): string[] {
+  return errors.map((e) => e.property);
+}
+
+describe('CreateTemplateDto', () => {
+  it('accepts a minimal valid payload', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 'NDA',
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(errs).toEqual([]);
+  });
+
+  it('accepts every literal pageRule value (all / allButLast / first / last)', async () => {
+    for (const pr of ['all', 'allButLast', 'first', 'last']) {
+      const dto = plainToInstance(CreateTemplateDto, {
+        title: 't',
+        field_layout: [{ ...VALID_FIELD, pageRule: pr }],
+      });
+      const errs = await validate(dto);
+      expect(errs).toEqual([]);
+    }
+  });
+
+  it('accepts an integer pageRule (1-indexed page number)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: 5 }],
+    });
+    const errs = await validate(dto);
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects pageRule = 0 (not a positive integer)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: 0 }],
+    });
+    const errs = await validate(dto);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a negative integer pageRule', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: -1 }],
+    });
+    const errs = await validate(dto);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects a non-integer pageRule (1.5)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: 1.5 }],
+    });
+    const errs = await validate(dto);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects an unknown pageRule literal ("middle")', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: 'middle' }],
+    });
+    const errs = await validate(dto);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects an unknown field type', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, type: 'frob' }],
+    });
+    const errs = await validate(dto);
+    expect(errs.length).toBeGreaterThan(0);
+  });
+
+  it('rejects empty title (MinLength 1)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: '',
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('title');
+  });
+
+  it('rejects an over-long title (>200 chars)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 'x'.repeat(201),
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('title');
+  });
+
+  it('rejects a non-string title', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 12345,
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('title');
+  });
+
+  it('rejects an over-long description (>2000 chars)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      description: 'x'.repeat(2001),
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('description');
+  });
+
+  it('rejects an invalid cover_color (not a #RRGGBB hex)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      cover_color: 'red',
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('cover_color');
+  });
+
+  it('accepts a valid #RRGGBB cover_color', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      cover_color: '#A1B2C3',
+      field_layout: [VALID_FIELD],
+    });
+    const errs = await validate(dto);
+    expect(errs).toEqual([]);
+  });
+
+  it('caps field_layout at 200 entries', async () => {
+    const big = Array.from({ length: 201 }, () => ({ ...VALID_FIELD }));
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: big,
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('caps tags at 32 entries', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [VALID_FIELD],
+      tags: Array.from({ length: 33 }, (_, i) => `tag${i}`),
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('tags');
+  });
+
+  it('caps individual tag length at 48 chars', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [VALID_FIELD],
+      tags: ['x'.repeat(49)],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('tags');
+  });
+
+  it('caps last_signers at 50 entries', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [VALID_FIELD],
+      last_signers: Array.from({ length: 51 }, (_, i) => ({
+        id: `c-${i}`,
+        name: 'A',
+        email: `a${i}@x.com`,
+        color: '#000000',
+      })),
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('last_signers');
+  });
+
+  it('rejects last_signer with bad email', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [VALID_FIELD],
+      last_signers: [{ id: 'c-1', name: 'Ada', email: 'not-an-email', color: '#000000' }],
+    });
+    const errs = await validate(dto);
+    // The error nests under last_signers[0].email; presence of any error
+    // on `last_signers` is enough.
+    expect(propsWithErrors(errs)).toContain('last_signers');
+  });
+
+  it('rejects last_signer with bad color hex', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [VALID_FIELD],
+      last_signers: [{ id: 'c-1', name: 'Ada', email: 'ada@x.com', color: 'red' }],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('last_signers');
+  });
+
+  it('rejects field with non-numeric x/y', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, x: 'left' }],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('rejects an over-long field label (>100 chars)', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, label: 'x'.repeat(101) }],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('rejects negative signerIndex', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, signerIndex: -1 }],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('rejects non-integer signerIndex', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, signerIndex: 1.5 }],
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('preserves a unicode title verbatim through plainToInstance', () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 'NDA — שלום 🌍',
+      field_layout: [VALID_FIELD],
+    });
+    expect(dto.title).toBe('NDA — שלום 🌍');
+  });
+
+  it('custom IsPageRule decorator surfaces a useful default message', async () => {
+    const dto = plainToInstance(CreateTemplateDto, {
+      title: 't',
+      field_layout: [{ ...VALID_FIELD, pageRule: 'middle' }],
+    });
+    const errs = await validate(dto);
+    // Drill into the nested validation error to assert the custom
+    // decorator's default message contains the literal list. This
+    // exercises the `defaultMessage` branch of IsPageRule.
+    const flat = JSON.stringify(errs);
+    expect(flat).toMatch(/all, allButLast, first, last/);
+  });
+});
+
+describe('UpdateTemplateDto', () => {
+  it('accepts an empty object (every field optional)', async () => {
+    const dto = plainToInstance(UpdateTemplateDto, {});
+    const errs = await validate(dto);
+    expect(errs).toEqual([]);
+  });
+
+  it('validates individual fields when present (bad title)', async () => {
+    const dto = plainToInstance(UpdateTemplateDto, { title: '' });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('title');
+  });
+
+  it('caps field_layout at 200 entries', async () => {
+    const dto = plainToInstance(UpdateTemplateDto, {
+      field_layout: Array.from({ length: 201 }, () => ({ ...VALID_FIELD })),
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('field_layout');
+  });
+
+  it('rejects bad cover_color when present, accepts when absent', async () => {
+    const bad = await validate(plainToInstance(UpdateTemplateDto, { cover_color: 'red' }));
+    expect(propsWithErrors(bad)).toContain('cover_color');
+    const good = await validate(plainToInstance(UpdateTemplateDto, { cover_color: '#FFFFFF' }));
+    expect(good).toEqual([]);
+  });
+
+  it('rejects oversized tags array', async () => {
+    const dto = plainToInstance(UpdateTemplateDto, {
+      tags: Array.from({ length: 33 }, (_, i) => `tag${i}`),
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('tags');
+  });
+});
+
+describe('TemplateFieldDto / TemplateLastSignerDto direct use', () => {
+  // These DTOs are also exported standalone (e.g. by the SPA shared
+  // types via class metadata). Validate them directly for completeness.
+  it('TemplateFieldDto rejects a missing type', async () => {
+    const dto = plainToInstance(TemplateFieldDto, { pageRule: 'all', x: 0, y: 0 });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('type');
+  });
+
+  it('TemplateLastSignerDto rejects an over-long name (>120)', async () => {
+    const dto = plainToInstance(TemplateLastSignerDto, {
+      id: 'c-1',
+      name: 'x'.repeat(121),
+      email: 'a@b.c',
+      color: '#000000',
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('name');
+  });
+
+  it('TemplateLastSignerDto rejects an empty id', async () => {
+    const dto = plainToInstance(TemplateLastSignerDto, {
+      id: '',
+      name: 'A',
+      email: 'a@b.c',
+      color: '#000000',
+    });
+    const errs = await validate(dto);
+    expect(propsWithErrors(errs)).toContain('id');
+  });
+});

--- a/apps/api/src/templates/templates.controller.spec.ts
+++ b/apps/api/src/templates/templates.controller.spec.ts
@@ -1,0 +1,159 @@
+import type { Response } from 'express';
+import type { Template } from 'shared';
+import type { AuthUser } from '../auth/auth-user';
+import type { CreateTemplateDto } from './dto/create-template.dto';
+import type { UpdateTemplateDto } from './dto/update-template.dto';
+import { TemplatesController } from './templates.controller';
+import type { TemplatesService } from './templates.service';
+
+const USER: AuthUser = {
+  id: '11111111-1111-4111-8111-111111111111',
+  email: 'a@example.com',
+} as AuthUser;
+const ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function makeTemplate(overrides: Partial<Template> = {}): Template {
+  return {
+    id: ID,
+    owner_id: USER.id,
+    title: 't',
+    description: null,
+    cover_color: null,
+    field_layout: [],
+    tags: [],
+    last_signers: [],
+    has_example_pdf: false,
+    uses_count: 0,
+    last_used_at: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeMockSvc(): jest.Mocked<TemplatesService> {
+  // Cast through unknown — we only stub the methods the controller uses.
+  return {
+    list: jest.fn(),
+    get: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    use: jest.fn(),
+    attachExamplePdf: jest.fn(),
+    readExamplePdf: jest.fn(),
+  } as unknown as jest.Mocked<TemplatesService>;
+}
+
+function makeMockRes(): jest.Mocked<Response> {
+  // Only the headers + end the controller actually touches.
+  const res = {
+    setHeader: jest.fn(),
+    end: jest.fn(),
+  };
+  return res as unknown as jest.Mocked<Response>;
+}
+
+describe('TemplatesController', () => {
+  let svc: jest.Mocked<TemplatesService>;
+  let ctrl: TemplatesController;
+
+  beforeEach(() => {
+    svc = makeMockSvc();
+    ctrl = new TemplatesController(svc);
+  });
+
+  it('list passes the caller user.id through', async () => {
+    const rows = [makeTemplate()];
+    svc.list.mockResolvedValue(rows);
+    await expect(ctrl.list(USER)).resolves.toBe(rows);
+    expect(svc.list).toHaveBeenCalledWith(USER.id);
+  });
+
+  it('create forwards dto and user.id to service', async () => {
+    const dto = { title: 'X' } as unknown as CreateTemplateDto;
+    const t = makeTemplate({ title: 'X' });
+    svc.create.mockResolvedValue(t);
+    const out = await ctrl.create(USER, dto);
+    expect(out).toBe(t);
+    expect(svc.create).toHaveBeenCalledWith(USER.id, dto);
+  });
+
+  it('get forwards user.id + id to service', async () => {
+    const t = makeTemplate();
+    svc.get.mockResolvedValue(t);
+    const out = await ctrl.get(USER, ID);
+    expect(out).toBe(t);
+    expect(svc.get).toHaveBeenCalledWith(USER.id, ID);
+  });
+
+  it('update forwards user.id, id, dto to service', async () => {
+    const dto = { title: 'New' } as unknown as UpdateTemplateDto;
+    const t = makeTemplate({ title: 'New' });
+    svc.update.mockResolvedValue(t);
+    const out = await ctrl.update(USER, ID, dto);
+    expect(out).toBe(t);
+    expect(svc.update).toHaveBeenCalledWith(USER.id, ID, dto);
+  });
+
+  it('remove returns void; service receives user.id + id', async () => {
+    svc.remove.mockResolvedValue(undefined);
+    await expect(ctrl.remove(USER, ID)).resolves.toBeUndefined();
+    expect(svc.remove).toHaveBeenCalledWith(USER.id, ID);
+  });
+
+  it('use forwards user.id + id and returns the bumped row', async () => {
+    const bumped = makeTemplate({ uses_count: 1, last_used_at: '2026-04-30T00:00:00.000Z' });
+    svc.use.mockResolvedValue(bumped);
+    const out = await ctrl.use(USER, ID);
+    expect(out).toBe(bumped);
+    expect(svc.use).toHaveBeenCalledWith(USER.id, ID);
+  });
+
+  describe('uploadExample', () => {
+    it('forwards file buffer + mimetype to service', async () => {
+      const buffer = Buffer.from('%PDF-1.4 hi %%EOF', 'utf8');
+      const t = makeTemplate({ has_example_pdf: true });
+      svc.attachExamplePdf.mockResolvedValue(t);
+      const file = { buffer, mimetype: 'application/pdf' } as Express.Multer.File;
+      const out = await ctrl.uploadExample(USER, ID, file);
+      expect(out).toBe(t);
+      expect(svc.attachExamplePdf).toHaveBeenCalledWith(USER.id, ID, buffer, 'application/pdf');
+    });
+
+    it('passes undefined buffer + mime when no file uploaded (service decides)', async () => {
+      // The controller doesn't gate this — the service throws BadRequest
+      // for empty bodies. The point of the test is that the controller
+      // forwards rather than swallowing the missing file.
+      svc.attachExamplePdf.mockRejectedValue(new Error('example_pdf_empty'));
+      await expect(ctrl.uploadExample(USER, ID, undefined)).rejects.toThrow('example_pdf_empty');
+      expect(svc.attachExamplePdf).toHaveBeenCalledWith(USER.id, ID, undefined, undefined);
+    });
+  });
+
+  describe('downloadExample', () => {
+    it('streams the bytes via res.end with Content-Length + Cache-Control headers', async () => {
+      const buf = Buffer.from('%PDF-1.4 sample %%EOF', 'utf8');
+      svc.readExamplePdf.mockResolvedValue(buf);
+      const res = makeMockRes();
+      await ctrl.downloadExample(USER, ID, res);
+      expect(svc.readExamplePdf).toHaveBeenCalledWith(USER.id, ID);
+      // Must declare exact length so chunked transfer doesn't kick in.
+      expect(res.setHeader).toHaveBeenCalledWith('Content-Length', String(buf.length));
+      expect(res.setHeader).toHaveBeenCalledWith(
+        'Cache-Control',
+        'private, max-age=0, must-revalidate',
+      );
+      expect(res.end).toHaveBeenCalledWith(buf);
+    });
+
+    it('propagates service errors (e.g. 404 on missing PDF)', async () => {
+      svc.readExamplePdf.mockRejectedValue(new Error('template_example_not_found'));
+      const res = makeMockRes();
+      await expect(ctrl.downloadExample(USER, ID, res)).rejects.toThrow(
+        'template_example_not_found',
+      );
+      expect(res.end).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/templates/templates.service.spec.ts
+++ b/apps/api/src/templates/templates.service.spec.ts
@@ -1,0 +1,549 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import type { Template, TemplateField } from 'shared';
+import { StorageService } from '../storage/storage.service';
+import {
+  TemplatesRepository,
+  type CreateTemplateInput,
+  type UpdateTemplatePatch,
+} from './templates.repository';
+import { TemplatesService } from './templates.service';
+
+const SAMPLE_FIELDS: ReadonlyArray<TemplateField> = [
+  { type: 'signature', pageRule: 'last', x: 60, y: 540 },
+  { type: 'date', pageRule: 'last', x: 320, y: 540 },
+];
+
+class FakeTemplatesRepo extends TemplatesRepository {
+  rows = new Map<string, Template>();
+  examplePaths = new Map<string, string | null>();
+  // For asserting the exact patch the service forwarded after stripping
+  // undefined keys (the most common service-layer bug — forwarding
+  // `field: undefined` would clobber the column).
+  lastUpdatePatch: UpdateTemplatePatch | null = null;
+  // Force the repo's setExamplePdfPath to return null so we can hit the
+  // "race lost between findOneByOwner and setExamplePdfPath" branch
+  // (deleted concurrently → NotFoundException after upload).
+  failSetExamplePath = false;
+
+  async create(input: CreateTemplateInput): Promise<Template> {
+    const now = new Date().toISOString();
+    const t: Template = {
+      id: randomUUID(),
+      owner_id: input.owner_id,
+      title: input.title,
+      description: input.description,
+      cover_color: input.cover_color,
+      field_layout: input.field_layout,
+      tags: input.tags ?? [],
+      last_signers: input.last_signers ?? [],
+      has_example_pdf: false,
+      uses_count: 0,
+      last_used_at: null,
+      created_at: now,
+      updated_at: now,
+    };
+    this.rows.set(t.id, t);
+    return t;
+  }
+
+  async findAllByOwner(owner_id: string): Promise<ReadonlyArray<Template>> {
+    return [...this.rows.values()].filter((r) => r.owner_id === owner_id);
+  }
+
+  async findOneByOwner(owner_id: string, id: string): Promise<Template | null> {
+    const r = this.rows.get(id);
+    return r && r.owner_id === owner_id ? r : null;
+  }
+
+  async update(owner_id: string, id: string, patch: UpdateTemplatePatch): Promise<Template | null> {
+    this.lastUpdatePatch = patch;
+    const r = this.rows.get(id);
+    if (!r || r.owner_id !== owner_id) return null;
+    const next: Template = { ...r, ...patch, updated_at: new Date().toISOString() };
+    this.rows.set(id, next);
+    return next;
+  }
+
+  async delete(owner_id: string, id: string): Promise<boolean> {
+    const r = this.rows.get(id);
+    if (!r || r.owner_id !== owner_id) return false;
+    this.rows.delete(id);
+    return true;
+  }
+
+  async deleteAllByOwner(owner_id: string): Promise<number> {
+    let n = 0;
+    for (const [id, r] of [...this.rows]) {
+      if (r.owner_id === owner_id) {
+        this.rows.delete(id);
+        n++;
+      }
+    }
+    return n;
+  }
+
+  async incrementUseCount(owner_id: string, id: string): Promise<Template | null> {
+    const r = this.rows.get(id);
+    if (!r || r.owner_id !== owner_id) return null;
+    const now = new Date().toISOString();
+    const next: Template = {
+      ...r,
+      uses_count: r.uses_count + 1,
+      last_used_at: now,
+      updated_at: now,
+    };
+    this.rows.set(id, next);
+    return next;
+  }
+
+  async setExamplePdfPath(
+    owner_id: string,
+    id: string,
+    path: string | null,
+  ): Promise<Template | null> {
+    if (this.failSetExamplePath) return null;
+    const r = this.rows.get(id);
+    if (!r || r.owner_id !== owner_id) return null;
+    this.examplePaths.set(id, path);
+    const next: Template = {
+      ...r,
+      has_example_pdf: path !== null,
+      updated_at: new Date().toISOString(),
+    };
+    this.rows.set(id, next);
+    return next;
+  }
+
+  async getExamplePdfPath(owner_id: string, id: string): Promise<string | null> {
+    const r = this.rows.get(id);
+    if (!r || r.owner_id !== owner_id) return null;
+    return this.examplePaths.get(id) ?? null;
+  }
+}
+
+class FakeStorage extends StorageService {
+  uploads: Array<{ path: string; bytes: Buffer; contentType: string }> = [];
+  downloads = new Map<string, Buffer>();
+  // Throw on download to surface service-layer error propagation when
+  // configured; default false so the happy path also exercises this fake.
+  throwOnDownload: Error | null = null;
+
+  async upload(path: string, body: Buffer, contentType: string): Promise<void> {
+    this.uploads.push({ path, bytes: Buffer.from(body), contentType });
+  }
+  async download(path: string): Promise<Buffer> {
+    if (this.throwOnDownload) throw this.throwOnDownload;
+    return this.downloads.get(path) ?? Buffer.from('default-bytes');
+  }
+  async remove(_paths: string[]): Promise<void> {}
+  async createSignedUrl(path: string, _exp: number): Promise<string> {
+    return `https://test.invalid/${path}`;
+  }
+  async exists(path: string): Promise<boolean> {
+    return this.downloads.has(path);
+  }
+}
+
+describe('TemplatesService', () => {
+  const OWNER = '11111111-1111-4111-8111-111111111111';
+  const OTHER = '22222222-2222-4222-8222-222222222222';
+  let repo: FakeTemplatesRepo;
+  let storage: FakeStorage;
+  let svc: TemplatesService;
+
+  beforeEach(() => {
+    repo = new FakeTemplatesRepo();
+    storage = new FakeStorage();
+    svc = new TemplatesService(repo, storage);
+  });
+
+  describe('list', () => {
+    it('returns only the caller owner_id rows', async () => {
+      await repo.create({
+        owner_id: OWNER,
+        title: 'Mine',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await repo.create({
+        owner_id: OTHER,
+        title: 'Theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      const list = await svc.list(OWNER);
+      expect(list.map((t) => t.title)).toEqual(['Mine']);
+    });
+
+    it('returns an empty array (not null) when the owner has no templates', async () => {
+      // Empty list must be a real array — controllers must not 404 / 500
+      // when a brand-new account has no templates.
+      const list = await svc.list(OWNER);
+      expect(list).toEqual([]);
+    });
+  });
+
+  describe('get', () => {
+    it('returns the row for the owner', async () => {
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      const got = await svc.get(OWNER, created.id);
+      expect(got.id).toBe(created.id);
+    });
+
+    it('throws NotFoundException("template_not_found") when row is missing', async () => {
+      await expect(svc.get(OWNER, randomUUID())).rejects.toMatchObject({
+        constructor: NotFoundException,
+        message: 'template_not_found',
+      });
+    });
+
+    it('throws NotFoundException for a row owned by another user (no leak of existence)', async () => {
+      // Service surfaces "not found" rather than "forbidden" so that an
+      // attacker cannot enumerate existing template ids by probing 404
+      // vs 403 (timing/code oracle).
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'Theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(svc.get(OWNER, row.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('create', () => {
+    it('forwards the dto into the repo with default tags + last_signers', async () => {
+      const out = await svc.create(OWNER, {
+        title: 'Made via service',
+        field_layout: SAMPLE_FIELDS,
+      } as never);
+      expect(out.title).toBe('Made via service');
+      expect(out.tags).toEqual([]);
+      expect(out.last_signers).toEqual([]);
+      expect(out.description).toBeNull();
+      expect(out.cover_color).toBeNull();
+    });
+
+    it('preserves a unicode title verbatim', async () => {
+      const out = await svc.create(OWNER, {
+        title: 'NDA — שלום 🌍',
+        field_layout: SAMPLE_FIELDS,
+      } as never);
+      expect(out.title).toBe('NDA — שלום 🌍');
+    });
+
+    it('allows two templates with the same title (templates are not unique by name)', async () => {
+      const a = await svc.create(OWNER, {
+        title: 'Same name',
+        field_layout: SAMPLE_FIELDS,
+      } as never);
+      const b = await svc.create(OWNER, {
+        title: 'Same name',
+        field_layout: SAMPLE_FIELDS,
+      } as never);
+      expect(a.id).not.toBe(b.id);
+      expect(a.title).toBe(b.title);
+    });
+
+    it('forwards explicit tags + last_signers when provided', async () => {
+      const out = await svc.create(OWNER, {
+        title: 'With roster',
+        field_layout: SAMPLE_FIELDS,
+        tags: ['Legal'],
+        last_signers: [{ id: 'c-1', name: 'Ada', email: 'ada@x.com', color: '#000000' }],
+      } as never);
+      expect(out.tags).toEqual(['Legal']);
+      expect(out.last_signers).toHaveLength(1);
+    });
+  });
+
+  describe('update', () => {
+    it('strips undefined dto keys so they do not clobber existing values', async () => {
+      // class-transformer hangs `field: undefined` on the DTO instance for
+      // every absent optional. Forwarding undefined would set the column
+      // to "do nothing" in some adapters and to NULL in others — the
+      // service must filter them out so partial-update semantics hold.
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 'Original',
+        description: 'keep me',
+        cover_color: '#FFFBEB',
+        field_layout: SAMPLE_FIELDS,
+      });
+      const dirty = {
+        title: 'Renamed',
+        description: undefined,
+        cover_color: undefined,
+        field_layout: undefined,
+      } as unknown as Parameters<typeof svc.update>[2];
+      const out = await svc.update(OWNER, created.id, dirty);
+      expect(out.title).toBe('Renamed');
+      expect(out.description).toBe('keep me');
+      expect(out.cover_color).toBe('#FFFBEB');
+      // The patch the repo actually saw contained ONLY `title`.
+      expect(repo.lastUpdatePatch).toEqual({ title: 'Renamed' });
+    });
+
+    it('throws NotFoundException when the row is missing', async () => {
+      await expect(svc.update(OWNER, randomUUID(), { title: 'X' } as never)).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+
+    it('throws NotFoundException when the row is owned by another user', async () => {
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(
+        svc.update(OWNER, row.id, { title: 'attacker' } as never),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('forwards explicit null on description / cover_color (clearing them)', async () => {
+      // Distinguish "absent" (undefined → drop) from "explicit null"
+      // (clear). The service only drops undefined; null must be
+      // preserved so the user can erase the cover color or description.
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: 'desc',
+        cover_color: '#FFFBEB',
+        field_layout: SAMPLE_FIELDS,
+      });
+      const out = await svc.update(OWNER, created.id, {
+        description: null,
+        cover_color: null,
+      } as never);
+      expect(out.description).toBeNull();
+      expect(out.cover_color).toBeNull();
+      expect(repo.lastUpdatePatch).toEqual({ description: null, cover_color: null });
+    });
+  });
+
+  describe('remove', () => {
+    it('returns void on success', async () => {
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(svc.remove(OWNER, created.id)).resolves.toBeUndefined();
+      // Idempotency check — deleting again should now 404, not 500.
+      await expect(svc.remove(OWNER, created.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws NotFoundException when row is missing', async () => {
+      await expect(svc.remove(OWNER, randomUUID())).rejects.toMatchObject({
+        constructor: NotFoundException,
+        message: 'template_not_found',
+      });
+    });
+
+    it('throws NotFoundException when row belongs to another user', async () => {
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(svc.remove(OWNER, row.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('use', () => {
+    it('returns the bumped row (uses_count + last_used_at)', async () => {
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      const out = await svc.use(OWNER, created.id);
+      expect(out.uses_count).toBe(1);
+      expect(out.last_used_at).not.toBeNull();
+    });
+
+    it('throws NotFoundException for missing row', async () => {
+      await expect(svc.use(OWNER, randomUUID())).rejects.toMatchObject({
+        constructor: NotFoundException,
+        message: 'template_not_found',
+      });
+    });
+
+    it('throws NotFoundException when row belongs to another user', async () => {
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(svc.use(OWNER, row.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('attachExamplePdf', () => {
+    const PDF_BYTES = Buffer.from('%PDF-1.4\n% test\n%%EOF', 'utf8');
+
+    async function createOwned(): Promise<string> {
+      const r = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      return r.id;
+    }
+
+    it('rejects an empty buffer with example_pdf_empty', async () => {
+      const id = await createOwned();
+      await expect(
+        svc.attachExamplePdf(OWNER, id, undefined, 'application/pdf'),
+      ).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'example_pdf_empty',
+      });
+      await expect(
+        svc.attachExamplePdf(OWNER, id, Buffer.alloc(0), 'application/pdf'),
+      ).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'example_pdf_empty',
+      });
+    });
+
+    it('rejects a wrong mime type with example_pdf_wrong_type', async () => {
+      const id = await createOwned();
+      await expect(svc.attachExamplePdf(OWNER, id, PDF_BYTES, 'text/plain')).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'example_pdf_wrong_type',
+      });
+      // Missing mime is also rejected.
+      await expect(svc.attachExamplePdf(OWNER, id, PDF_BYTES, undefined)).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'example_pdf_wrong_type',
+      });
+    });
+
+    it('rejects oversized buffers with example_pdf_too_large', async () => {
+      const id = await createOwned();
+      // 25MB + 1 byte. Buffer.alloc is sparse-ish — fine for the size check.
+      const tooBig = Buffer.alloc(25 * 1024 * 1024 + 1);
+      await expect(
+        svc.attachExamplePdf(OWNER, id, tooBig, 'application/pdf'),
+      ).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'example_pdf_too_large',
+      });
+    });
+
+    it('throws NotFoundException BEFORE writing to storage when caller does not own the row', async () => {
+      // Must not touch the bucket for a wrong-tenant caller — the
+      // ownership check has to happen before storage.upload.
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(
+        svc.attachExamplePdf(OWNER, row.id, PDF_BYTES, 'application/pdf'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(storage.uploads).toHaveLength(0);
+    });
+
+    it('throws NotFoundException for a missing template before writing to storage', async () => {
+      await expect(
+        svc.attachExamplePdf(OWNER, randomUUID(), PDF_BYTES, 'application/pdf'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(storage.uploads).toHaveLength(0);
+    });
+
+    it('uploads to a stable per-template path and flips has_example_pdf', async () => {
+      const id = await createOwned();
+      const out = await svc.attachExamplePdf(OWNER, id, PDF_BYTES, 'application/pdf');
+      expect(out.has_example_pdf).toBe(true);
+      expect(storage.uploads).toHaveLength(1);
+      expect(storage.uploads[0]?.path).toBe(`templates/${OWNER}/${id}/example.pdf`);
+      expect(storage.uploads[0]?.contentType).toBe('application/pdf');
+      expect(storage.uploads[0]?.bytes.equals(PDF_BYTES)).toBe(true);
+    });
+
+    it('throws NotFoundException when the row vanishes between ownership check and persistence', async () => {
+      // Race: setExamplePdfPath returns null even though the earlier
+      // findOneByOwner resolved. The service must surface 404 rather
+      // than returning a half-baked Template.
+      const id = await createOwned();
+      repo.failSetExamplePath = true;
+      await expect(
+        svc.attachExamplePdf(OWNER, id, PDF_BYTES, 'application/pdf'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+  });
+
+  describe('readExamplePdf', () => {
+    it('throws NotFoundException("template_example_not_found") when no PDF is attached', async () => {
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      await expect(svc.readExamplePdf(OWNER, created.id)).rejects.toMatchObject({
+        constructor: NotFoundException,
+        message: 'template_example_not_found',
+      });
+    });
+
+    it('throws NotFoundException when caller does not own the row', async () => {
+      // getExamplePdfPath already scopes by owner — same 404 contract as
+      // findOneByOwner so attackers cannot distinguish "doesn't exist"
+      // from "exists but not yours".
+      const row = await repo.create({
+        owner_id: OTHER,
+        title: 'theirs',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      repo.examplePaths.set(row.id, `templates/${OTHER}/${row.id}/example.pdf`);
+      await expect(svc.readExamplePdf(OWNER, row.id)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('returns the bytes from storage for the owner', async () => {
+      const created = await repo.create({
+        owner_id: OWNER,
+        title: 't',
+        description: null,
+        cover_color: null,
+        field_layout: SAMPLE_FIELDS,
+      });
+      const path = `templates/${OWNER}/${created.id}/example.pdf`;
+      repo.examplePaths.set(created.id, path);
+      const bytes = Buffer.from('%PDF-1.4 hello %%EOF', 'utf8');
+      storage.downloads.set(path, bytes);
+      const got = await svc.readExamplePdf(OWNER, created.id);
+      expect(got.equals(bytes)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase-4 audit wave-2: closes the API templates coverage gap (Flow 14).

- `src/templates/` — **26.51% → 85.60%** statements / 35.71% → 78.57% branches (clears ≥75% Main-flow target)
- `templates.controller.ts` — 0% → **100%**
- `templates.service.ts` — 0% → **100%**
- All 4 DTOs: 0% → 100% (CreateTemplate / UpdateTemplate / TemplateField / TemplateLastSigner)
- +72 unit `it()` blocks across 3 spec files; **no production code changed**
- Suite: 408 → 481 passing on this branch

## Failure modes covered

- list (incl. empty owner returns `[]`), get with owner-scope no-existence-leak
- create: defaults / unicode title preserved / duplicate names allowed / explicit tags+last_signers
- update: undefined-key stripping, explicit `null` clears description+cover_color, RBAC 404
- remove idempotency, use, `attachExamplePdf` (empty / wrong mime / oversize / ownership-check-before-storage / stable storage path)
- `readExamplePdf` cross-owner 404 + round-trip
- DTO: pageRule literal/integer union, field-type enum, title length, description cap, cover_color hex shape, field_layout cap 200, tags cap 32×48, last_signers cap 50, signerIndex non-negative, unicode title preservation

## Test plan

- [x] `pnpm typecheck` (api) — clean
- [x] `pnpm lint` (api) — 0 warnings, 0 errors
- [x] `pnpm exec jest --testPathPatterns='templates'` — 4 suites / 82 tests pass
- [x] full unit suite — 42 suites / 481 tests pass
- [ ] CI gates: install / lint / unit / web / e2e / pades-verify
- [ ] No production code touched (S.1–S.6 PAdES sealing untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)