### PR TITLE
chore(ci): add explicit GITHUB_TOKEN permissions to all workflows

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,6 +24,15 @@ concurrency:
   group: chromatic-${{ github.ref }}
   cancel-in-progress: true
 
+# Chromatic uses its own CHROMATIC_PROJECT_TOKEN secret for the upload
+# auth — no GITHUB_TOKEN write is required for the upload itself. The
+# CLI does post a check-run / PR comment when running on PRs via the
+# Chromatic GitHub App (installed separately), not via GITHUB_TOKEN, so
+# read scope is sufficient here. Tightens per CodeQL
+# `actions/missing-workflow-permissions`.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Default GITHUB_TOKEN scope for every job in this workflow. CI only
+# checks out source, runs tests/lint, and uploads artifacts via the
+# artifact action (which uses its own scoped path, not GITHUB_TOKEN
+# write). `contents: read` covers checkout + artifact download.
+# Tightens to least-privilege per CodeQL `actions/missing-workflow-permissions`.
+permissions:
+  contents: read
+
 # Silence the Sep 2026 Node 20 deprecation notice from GitHub by
 # opting every step into Node 24 up-front. Harmless now, and skips the
 # runtime bump when June 2 2026 flips the default.

--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -29,6 +29,12 @@ concurrency:
   group: deploy-cloudflare
   cancel-in-progress: false
 
+# Cloudflare Pages deploy uses CLOUDFLARE_API_TOKEN for upload + domain
+# attachment. GITHUB_TOKEN is only used by `actions/checkout`, so
+# `contents: read` is the minimum scope required.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,11 @@ concurrency:
   group: deploy
   cancel-in-progress: false
 
+# Deploy is SSH-only — uses DEPLOY_SSH_KEY, never the GITHUB_TOKEN.
+# Only `contents: read` is needed for the initial checkout step.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,12 @@ concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: false
 
+# Default workflow scope: read-only. The `build` job overrides this
+# below to grant the additional `packages: write` (GHCR push) and
+# `id-token: write` (reserved for cosign keyless) it actually needs.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/lint-meta.yml
+++ b/.github/workflows/lint-meta.yml
@@ -35,6 +35,11 @@ concurrency:
   group: lint-meta-${{ github.ref }}
   cancel-in-progress: true
 
+# Lint-only workflow: read source, run actionlint / gherkin-lint /
+# cspell. No GITHUB_TOKEN write surface required.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,6 +31,11 @@ concurrency:
   group: playwright-${{ github.ref }}
   cancel-in-progress: true
 
+# Browser e2e — read-only: checkout source, install browsers, run
+# tests, upload report artifacts. No GITHUB_TOKEN write needed.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/prod-diagnose.yml
+++ b/.github/workflows/prod-diagnose.yml
@@ -8,6 +8,11 @@ name: Prod diagnose (read-only SSH)
 on:
   workflow_dispatch: {}
 
+# SSH-only diagnostic — never touches the GitHub API. The workflow
+# doesn't even check out source. Empty permissions block makes that
+# explicit (CodeQL `actions/missing-workflow-permissions`).
+permissions: {}
+
 jobs:
   diagnose:
     runs-on: ubuntu-latest

--- a/.github/workflows/prod-restore.yml
+++ b/.github/workflows/prod-restore.yml
@@ -21,6 +21,11 @@ name: Prod restore (.env + KMS binding cert + redeploy)
 on:
   workflow_dispatch: {}
 
+# SSH-only restore — uses DEPLOY_SSH_KEY + PROD_API_ENV secrets, never
+# the GITHUB_TOKEN. The workflow doesn't even check out source. Empty
+# permissions block makes that explicit.
+permissions: {}
+
 jobs:
   restore:
     runs-on: ubuntu-latest

--- a/.github/workflows/seed-secrets-manager.yml
+++ b/.github/workflows/seed-secrets-manager.yml
@@ -27,6 +27,11 @@ concurrency:
   group: seed-secrets-manager
   cancel-in-progress: false
 
+# AWS-only — uses AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY for the
+# put-secret-value call, never the GITHUB_TOKEN. No checkout step
+# either. Empty permissions block makes that explicit.
+permissions: {}
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -26,6 +26,12 @@ concurrency:
   group: terraform-${{ github.ref }}
   cancel-in-progress: false
 
+# Default workflow scope is read-only. The `terraform` job overrides
+# this below to additionally grant `pull-requests: write` so the
+# `Comment plan on PR` step can post the terraform plan.
+permissions:
+  contents: read
+
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 


### PR DESCRIPTION
## Summary
Closes **20 CodeQL alerts** of type \`actions/missing-workflow-permissions\` (CWE-275, principle of least privilege). Adds an explicit \`permissions:\` block to every workflow in \`.github/workflows/\`.

## Per-file scopes

| File | Root permissions | Job-level overrides |
|---|---|---|
| \`ci.yml\` | \`contents: read\` | none |
| \`chromatic.yml\` | \`contents: read\` | none (Chromatic uses its own GitHub App) |
| \`deploy.yml\` | \`contents: read\` | none |
| \`deploy-cloudflare.yml\` | \`contents: read\` | none (uses \`CLOUDFLARE_API_TOKEN\`) |
| \`docker.yml\` | \`contents: read\` | \`build\`: \`packages: write, id-token: write\` (kept) |
| \`lint-meta.yml\` | \`contents: read\` | none |
| \`playwright.yml\` | \`contents: read\` | none |
| \`prod-diagnose.yml\` | \`{}\` (empty) | SSH-only \u2014 no GH API needed |
| \`prod-restore.yml\` | \`{}\` (empty) | SSH-only |
| \`seed-secrets-manager.yml\` | \`{}\` (empty) | AWS-only |
| \`terraform.yml\` | \`contents: read\` | \`terraform\`: \`pull-requests: write\` (kept for plan-comment) |

## Verification
- [x] \`actionlint .github/workflows/*.yml\` \u2014 clean
- [x] \`pnpm -r typecheck\` \u2014 clean
- [x] No non-workflow files touched
- [ ] CI gates green on this PR

## Test plan
- [ ] Watch all CI checks complete green (deploy/docker jobs may need their job-level overrides exercised)
- [ ] Confirm Chromatic still posts PR comments via its GitHub App (not GITHUB_TOKEN)

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)