### PR TITLE
fix(security): close 2 codeql warnings (biased-rand, stack-trace-exposure)

### DIFF
--- a/apps/api/scripts/seed-signer.ts
+++ b/apps/api/scripts/seed-signer.ts
@@ -4,6 +4,8 @@ import { join } from 'node:path';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { Client } from 'pg';
 
+import { generateShortCode } from '../src/common/short-code';
+
 // Load `apps/api/.env` so the script can be run standalone without piping
 // `source .env`. Keeps the expected dev ergonomics: `pnpm seed:signer`.
 function loadDotenv(): void {
@@ -45,18 +47,6 @@ loadDotenv();
  * seed rows accumulate; clean them periodically with:
  *   delete from public.envelopes where title = 'SEED test envelope';
  */
-
-const SHORT_CODE_ALPHABET = '23456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
-const SHORT_CODE_LENGTH = 13;
-
-function generateShortCode(): string {
-  let id = '';
-  const buf = randomBytes(SHORT_CODE_LENGTH);
-  for (let i = 0; i < SHORT_CODE_LENGTH; i += 1) {
-    id += SHORT_CODE_ALPHABET[buf[i]! % SHORT_CODE_ALPHABET.length];
-  }
-  return id;
-}
 
 function generateToken(): string {
   return randomBytes(32).toString('base64url');

--- a/apps/api/src/common/short-code.spec.ts
+++ b/apps/api/src/common/short-code.spec.ts
@@ -1,0 +1,77 @@
+import { SHORT_CODE_ALPHABET, SHORT_CODE_DEFAULT_LENGTH, generateShortCode } from './short-code';
+
+describe('generateShortCode', () => {
+  it('produces a string of the requested length', () => {
+    expect(generateShortCode()).toHaveLength(SHORT_CODE_DEFAULT_LENGTH);
+    expect(generateShortCode(7)).toHaveLength(7);
+    expect(generateShortCode(32)).toHaveLength(32);
+  });
+
+  it('only emits characters from the supplied alphabet (no off-by-one)', () => {
+    const id = generateShortCode(5_000);
+    const allowed = new Set(SHORT_CODE_ALPHABET);
+    for (const ch of id) {
+      expect(allowed.has(ch)).toBe(true);
+    }
+  });
+
+  it('reaches every character in the alphabet given enough samples', () => {
+    // With 200_000 picks across a 57-char alphabet, the probability of
+    // missing any single character is ≈ (56/57)^200000 ≈ 10^-1525, so a
+    // failure here means the picker is biased away from at least one
+    // index — exactly the regression we want to catch.
+    const seen = new Set<string>();
+    const id = generateShortCode(200_000);
+    for (const ch of id) seen.add(ch);
+    expect(seen.size).toBe(SHORT_CODE_ALPHABET.length);
+  });
+
+  it('asks the picker for an index in [0, alphabet.length) on every position', () => {
+    const calls: number[] = [];
+    const stub = (max: number) => {
+      calls.push(max);
+      return 0; // pin to first char so the assertion below is deterministic
+    };
+    const id = generateShortCode(8, SHORT_CODE_ALPHABET, stub);
+    // 8 picks → 8 calls, each constrained to [0, alphabet.length).
+    expect(calls).toHaveLength(8);
+    for (const max of calls) expect(max).toBe(SHORT_CODE_ALPHABET.length);
+    // Pinning to 0 returns the first alphabet char each time — proves
+    // the loop indexes the alphabet by the picker's output (not by some
+    // internal modulo on a wider value).
+    expect(id).toBe(SHORT_CODE_ALPHABET[0]!.repeat(8));
+  });
+
+  it('hits the full index range when the picker walks 0..length-1', () => {
+    let counter = 0;
+    const walking = (max: number) => counter++ % max;
+    const id = generateShortCode(SHORT_CODE_ALPHABET.length, SHORT_CODE_ALPHABET, walking);
+    // The walking picker emits 0,1,2,…,N-1 in order, so the output is
+    // exactly the alphabet — proves no off-by-one and that every index
+    // is reachable through the seam.
+    expect(id).toBe(SHORT_CODE_ALPHABET);
+  });
+
+  it('rejects out-of-range picker outputs', () => {
+    expect(() => generateShortCode(1, 'AB', () => 2)).toThrow(RangeError);
+    expect(() => generateShortCode(1, 'AB', () => -1)).toThrow(RangeError);
+    expect(() => generateShortCode(1, 'AB', () => 0.5)).toThrow(RangeError);
+  });
+
+  it('rejects non-positive or non-integer lengths', () => {
+    expect(() => generateShortCode(0)).toThrow(RangeError);
+    expect(() => generateShortCode(-1)).toThrow(RangeError);
+    expect(() => generateShortCode(1.5)).toThrow(RangeError);
+  });
+
+  it('rejects degenerate alphabets', () => {
+    expect(() => generateShortCode(4, '')).toThrow(RangeError);
+    expect(() => generateShortCode(4, 'x')).toThrow(RangeError);
+  });
+
+  it('honors a custom alphabet end-to-end', () => {
+    const alpha = 'AB';
+    const id = generateShortCode(64, alpha);
+    expect(id).toMatch(/^[AB]{64}$/);
+  });
+});

--- a/apps/api/src/common/short-code.ts
+++ b/apps/api/src/common/short-code.ts
@@ -1,0 +1,45 @@
+import { randomInt } from 'node:crypto';
+
+/**
+ * Crockford-ish base-58 alphabet (no `0/O/1/l/I`) used for human-friendly
+ * short codes that index test/seed envelopes.
+ */
+export const SHORT_CODE_ALPHABET = '23456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ';
+
+/** Default length keeps the entropy ≳ 75 bits, plenty for opaque seed ids. */
+export const SHORT_CODE_DEFAULT_LENGTH = 13;
+
+/**
+ * Pick a uniformly-distributed integer in `[0, max)`. Defaults to
+ * `crypto.randomInt`, which uses rejection sampling under the hood — the
+ * de-biased replacement for the legacy `randomBytes(n)[i] % max` form
+ * CodeQL flagged as `js/biased-cryptographic-random`. The optional
+ * `pickIndex` seam exists strictly so unit tests can inject a
+ * deterministic picker and prove the loop wiring without introducing
+ * statistical flake; production callers always use the default.
+ */
+export type IndexPicker = (maxExclusive: number) => number;
+
+const defaultPickIndex: IndexPicker = (max) => randomInt(0, max);
+
+export function generateShortCode(
+  length: number = SHORT_CODE_DEFAULT_LENGTH,
+  alphabet: string = SHORT_CODE_ALPHABET,
+  pickIndex: IndexPicker = defaultPickIndex,
+): string {
+  if (!Number.isInteger(length) || length <= 0) {
+    throw new RangeError('generateShortCode: length must be a positive integer');
+  }
+  if (alphabet.length < 2) {
+    throw new RangeError('generateShortCode: alphabet must have ≥ 2 characters');
+  }
+  let id = '';
+  for (let i = 0; i < length; i += 1) {
+    const idx = pickIndex(alphabet.length);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= alphabet.length) {
+      throw new RangeError(`generateShortCode: pickIndex returned out-of-range value ${idx}`);
+    }
+    id += alphabet[idx];
+  }
+  return id;
+}

--- a/apps/api/test/pades-tsa.e2e-spec.ts
+++ b/apps/api/test/pades-tsa.e2e-spec.ts
@@ -218,9 +218,15 @@ function startFakeTsa(): Promise<{ url: string; server: Server; hits: number[] }
         const resp = buildFakeTsaResponse(imprintBytes);
         res.writeHead(200, { 'Content-Type': 'application/timestamp-reply' });
         res.end(resp);
-      } catch (err) {
-        res.writeHead(400);
-        res.end(String(err));
+      } catch {
+        // Closes CodeQL js/stack-trace-exposure: the previous handler
+        // serialized `err` (and thus its stack frames) back to the
+        // caller. Even though this fake TSA only ever talks to
+        // localhost in jest, returning a static reason keeps the alert
+        // from re-tripping and matches what a real TSA would expose
+        // via RFC 3161 status codes.
+        res.writeHead(400, { 'Content-Type': 'text/plain' });
+        res.end('bad_tsa_request');
       }
     });
   });


### PR DESCRIPTION
## Summary
Closes **2 CodeQL warnings**:

- **#22 \`js/biased-cryptographic-random\`** \u2014 \`apps/api/scripts/seed-signer.ts\` used \`crypto.randomBytes()[i] % alphabet.length\`, which is biased because 256 is not divisible by 57.
- **#21 \`js/stack-trace-exposure\`** \u2014 \`apps/api/test/pades-tsa.e2e-spec.ts\` returned \`String(err)\` from a fake-TSA HTTP fixture, leaking the stack trace.

## Changes
- **NEW \`apps/api/src/common/short-code.ts\`** (46 lines) \u2014 extracted helper exporting \`SHORT_CODE_ALPHABET\` (57-char Crockford-ish), \`SHORT_CODE_DEFAULT_LENGTH\` (13), and \`generateShortCode(length, alphabet, pickIndex?)\`. Uses \`crypto.randomInt(0, alphabet.length)\` (rejection sampling) instead of biased modulo. Includes a \`pickIndex\` injection seam for deterministic tests.
- **NEW \`apps/api/src/common/short-code.spec.ts\`** (9 cases) \u2014 length, alphabet membership over 5k samples, full-range reachability over 200k samples, picker-seam wiring asserts each call constrained to \`[0, 57)\`, walking-picker regression proving no off-by-one, validation tests.
- **\`apps/api/scripts/seed-signer.ts\`** \u2014 removed inline biased helper, now imports from \`../src/common/short-code\`. Net \u221212 lines.
- **\`apps/api/test/pades-tsa.e2e-spec.ts\`** lines 221\u2013230 \u2014 fake-TSA \`catch\` handler now responds with \`HTTP 400 + 'bad_tsa_request'\` instead of \`String(err)\`. Test intent unchanged (assertions are status-code based).

## Decision notes
- **Helper location**: \`apps/api/src/common/\` (alongside existing \`extract-client-ip.ts\`).
- **Test seam over module mock**: \`jest.spyOn(crypto, 'randomInt')\` fails on Node 20 (non-configurable export). Settled on a \`pickIndex\` parameter with a default \u2014 deterministic regression coverage without statistical flake.
- **Stack-trace fix**: rewrite, not suppression \u2014 the test's assertions don't depend on response body content.

## Verification
- [x] \`pnpm typecheck\` (api) \u2014 clean
- [x] \`pnpm lint --max-warnings=0\` (api) \u2014 clean
- [x] \`pnpm test --testPathPatterns=short-code\` \u2014 2 suites / 18 tests pass
- [x] \`pnpm test:e2e\` (pades-tsa) \u2014 1 suite / 2 tests pass
- [x] \`pnpm test\` (api) \u2014 47 suites / **628/628** pass
- [x] No \`apps/api/src/sealing/**\` modified (CLAUDE.md S.1\u2013S.6)

## Test plan
- [ ] CI gates green on this PR
- [ ] Confirm CodeQL alerts #21 + #22 close after merge

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)