### PR TITLE
fix(security): patch cucumber-messages to drop uuid 3.x (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
       "lodash": "^4.18.0",
       "protobufjs": "^7.5.5",
       "uuid": "^14.0.0",
-      "cucumber-messages>uuid": "3.4.0",
       "tmp": "^0.2.4"
     },
     "auditConfig": {
@@ -76,6 +75,9 @@
         "GHSA-v52c-386h-88mc",
         "GHSA-5528-5vmv-3xc2"
       ]
+    },
+    "patchedDependencies": {
+      "cucumber-messages@8.0.0": "patches/cucumber-messages@8.0.0.patch"
     }
   }
 }

--- a/patches/cucumber-messages@8.0.0.patch
+++ b/patches/cucumber-messages@8.0.0.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/src/IdGenerator.js b/dist/src/IdGenerator.js
+index d02a88e0ea7870c5b00cde95a2f4d0667899761b..6d7e5acc75b8f71a017acbfb8ee0f5f79bf92c76 100644
+--- a/dist/src/IdGenerator.js
++++ b/dist/src/IdGenerator.js
+@@ -1,11 +1,8 @@
+ "use strict";
+-var __importDefault = (this && this.__importDefault) || function (mod) {
+-    return (mod && mod.__esModule) ? mod : { "default": mod };
+-};
+ Object.defineProperty(exports, "__esModule", { value: true });
+-var v4_1 = __importDefault(require("uuid/v4"));
++var uuid_1 = require("uuid");
+ function uuid() {
+-    return function () { return v4_1.default(); };
++    return function () { return (0, uuid_1.v4)(); };
+ }
+ exports.uuid = uuid;
+ function incrementing() {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,8 +19,12 @@ overrides:
   lodash: ^4.18.0
   protobufjs: ^7.5.5
   uuid: ^14.0.0
-  cucumber-messages>uuid: 3.4.0
   tmp: ^0.2.4
+
+patchedDependencies:
+  cucumber-messages@8.0.0:
+    hash: mauzlonvt7u3exevejx2kgspc4
+    path: patches/cucumber-messages@8.0.0.patch
 
 importers:
 
@@ -8468,11 +8472,6 @@ packages:
     resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
-  uuid@3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
 
@@ -13868,11 +13867,11 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cucumber-messages@8.0.0:
+  cucumber-messages@8.0.0(patch_hash=mauzlonvt7u3exevejx2kgspc4):
     dependencies:
       '@types/uuid': 3.4.13
       protobufjs: 7.5.6
-      uuid: 3.4.0
+      uuid: 14.0.0
 
   damerau-levenshtein@1.0.8: {}
 
@@ -15067,7 +15066,7 @@ snapshots:
   gherkin@9.0.0:
     dependencies:
       commander: 4.1.1
-      cucumber-messages: 8.0.0
+      cucumber-messages: 8.0.0(patch_hash=mauzlonvt7u3exevejx2kgspc4)
       source-map-support: 0.5.21
 
   github-from-package@0.0.0: {}
@@ -18737,8 +18736,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@14.0.0: {}
-
-  uuid@3.4.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Closes the last open Dependabot alert (`GHSA-w5hq-g745-h8pq` — uuid medium severity) by removing uuid 3.x from the dependency tree entirely.

## Why this is still open after PR #87

PR #87 closed seven alerts via `pnpm.overrides: { uuid: "^14.0.0" }`. That broke `cucumber-messages@8.0.0` (transitive: `gherkin-lint > gherkin > cucumber-messages`) because it calls `require("uuid/v4")` — the deep CJS subpath uuid removed in v7. To unblock CI, PR #87 added a nested override `cucumber-messages>uuid: 3.4.0`, which is exactly the version Dependabot flags.

## Fix

Use `pnpm patch` to rewrite the one offending line in `cucumber-messages/dist/src/IdGenerator.js`:

```diff
-var v4_1 = __importDefault(require("uuid/v4"));
+var uuid_1 = require("uuid");
 function uuid() {
-    return function () { return v4_1.default(); };
+    return function () { return (0, uuid_1.v4)(); };
 }
```

Then drop the `cucumber-messages>uuid: 3.4.0` nested override so uuid `^14` wins everywhere.

## Verification

- `pnpm why uuid` → only `uuid 14.0.0` in the tree (was 3.4.0 + 14.0.0)
- `pnpm audit --prod --audit-level=moderate` → "No known vulnerabilities"
- `pnpm lint:gherkin` runs clean
- Smoke-tested patched IdGenerator: still produces valid v4 UUIDs
- Pre-commit gate (typecheck across all 5 packages) passed locally

## Test plan

- [ ] CI install/lint/unit/web/e2e all green
- [ ] BDD e2e (gherkin-lint + playwright-bdd) passes — exercises the patched module
- [ ] CodeQL/pnpm audit job passes
- [ ] Dependabot auto-closes alert #47 (GHSA-w5hq-g745-h8pq) after merge

## Risk

Cucumber-messages is dev-only (BDD test infrastructure) and only generates v4 UUIDs without a `buf` argument, so the actual exploit path was never reached. This patch closes the alert at the source rather than relying on a "won't reach" rationale and clears the security tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)