### PR TITLE
fix(envelopes): guest send-to-sign now creates the envelope + emails the signer

### DIFF
--- a/apps/api/src/envelopes/dto/dtos.spec.ts
+++ b/apps/api/src/envelopes/dto/dtos.spec.ts
@@ -5,6 +5,7 @@ import { AddSignerDto } from './add-signer.dto';
 import { CreateEnvelopeDto } from './create-envelope.dto';
 import { PatchEnvelopeDto } from './patch-envelope.dto';
 import { FieldPlacementDto, PlaceFieldsDto } from './place-fields.dto';
+import { SendEnvelopeDto } from './send-envelope.dto';
 
 /**
  * Direct DTO validation tests. Each DTO is exercised through the same
@@ -193,6 +194,57 @@ describe('FieldPlacementDto', () => {
     const dto = plainToInstance(FieldPlacementDto, { ...valid, width: 1.01 });
     const errors = validateSync(dto);
     expect(pathsOf(errors)).toEqual(['width']);
+  });
+});
+
+describe('SendEnvelopeDto', () => {
+  it('accepts an empty body (both fields optional, JWT-email path)', () => {
+    const dto = plainToInstance(SendEnvelopeDto, {});
+    expect(validateSync(dto)).toEqual([]);
+  });
+
+  it('accepts a valid sender_email', () => {
+    const dto = plainToInstance(SendEnvelopeDto, { sender_email: 'guest@example.com' });
+    expect(validateSync(dto)).toEqual([]);
+  });
+
+  it('accepts a valid sender_email + sender_name', () => {
+    const dto = plainToInstance(SendEnvelopeDto, {
+      sender_email: 'guest@example.com',
+      sender_name: 'Guest User',
+    });
+    expect(validateSync(dto)).toEqual([]);
+  });
+
+  it('rejects malformed sender_email', () => {
+    const dto = plainToInstance(SendEnvelopeDto, { sender_email: 'not-an-email' });
+    const errors = validateSync(dto);
+    expect(pathsOf(errors)).toEqual(['sender_email']);
+  });
+
+  it('rejects sender_email longer than 254 chars', () => {
+    const localPart = 'a'.repeat(250);
+    const dto = plainToInstance(SendEnvelopeDto, { sender_email: `${localPart}@x.io` });
+    const errors = validateSync(dto);
+    expect(pathsOf(errors)).toContain('sender_email');
+  });
+
+  it('rejects sender_name longer than 120 chars', () => {
+    const dto = plainToInstance(SendEnvelopeDto, {
+      sender_email: 'guest@example.com',
+      sender_name: 'x'.repeat(121),
+    });
+    const errors = validateSync(dto);
+    expect(pathsOf(errors)).toEqual(['sender_name']);
+  });
+
+  it('rejects empty sender_name when provided', () => {
+    const dto = plainToInstance(SendEnvelopeDto, {
+      sender_email: 'guest@example.com',
+      sender_name: '',
+    });
+    const errors = validateSync(dto);
+    expect(pathsOf(errors)).toEqual(['sender_name']);
   });
 });
 

--- a/apps/api/src/envelopes/dto/send-envelope.dto.ts
+++ b/apps/api/src/envelopes/dto/send-envelope.dto.ts
@@ -1,0 +1,21 @@
+import { IsEmail, IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+/**
+ * POST /envelopes/:id/send body. Both fields are optional and only consulted
+ * when the caller's JWT carries no `email` claim (anonymous Supabase
+ * sessions used by the no-sign-up "guest" flow). When the JWT *does* have
+ * an email, the controller ignores the body completely — the JWT email is
+ * authoritative, defeating any spoofing attempt by a signed-in user.
+ */
+export class SendEnvelopeDto {
+  @IsOptional()
+  @IsEmail()
+  @MaxLength(254)
+  readonly sender_email?: string;
+
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  readonly sender_name?: string;
+}

--- a/apps/api/src/envelopes/envelopes.controller.spec.ts
+++ b/apps/api/src/envelopes/envelopes.controller.spec.ts
@@ -246,15 +246,44 @@ describe('EnvelopesController', () => {
   });
 
   describe('POST /envelopes/:id/send', () => {
-    it('400 sender_email_missing when JWT has no email', () => {
-      const noEmailUser: AuthUser = { id: USER.id, email: null, provider: 'email' };
-      expect(() => controller.send(noEmailUser, 'env-1', makeRequest())).toThrow(
-        BadRequestException,
+    it('uses JWT email when present and ignores body sender_email (anti-spoof)', async () => {
+      const env = makeEnvelope({ status: 'awaiting_others' });
+      svc.send.mockResolvedValue(env);
+      await controller.send(USER, 'env-1', makeRequest({ userAgent: 'Mozilla/5.0' }), {
+        sender_email: 'evil@spoof.example',
+        sender_name: 'Bad Actor',
+      });
+      expect(svc.send).toHaveBeenCalledWith(
+        USER.id,
+        'env-1',
+        { email: USER.email, name: null },
+        { ip: expect.any(String), user_agent: 'Mozilla/5.0' },
       );
+    });
+
+    it('falls back to body sender_email + name when JWT carries no email (anon/guest)', async () => {
+      const anon: AuthUser = { id: USER.id, email: null, provider: 'anonymous' };
+      const env = makeEnvelope({ status: 'awaiting_others' });
+      svc.send.mockResolvedValue(env);
+      await controller.send(anon, 'env-1', makeRequest({ userAgent: 'curl/8' }), {
+        sender_email: 'guest@example.com',
+        sender_name: 'Guest User',
+      });
+      expect(svc.send).toHaveBeenCalledWith(
+        USER.id,
+        'env-1',
+        { email: 'guest@example.com', name: 'Guest User' },
+        { ip: expect.any(String), user_agent: 'curl/8' },
+      );
+    });
+
+    it('400 sender_email_missing when JWT has no email and body is empty', () => {
+      const anon: AuthUser = { id: USER.id, email: null, provider: 'anonymous' };
+      expect(() => controller.send(anon, 'env-1', makeRequest(), {})).toThrow(BadRequestException);
       expect(svc.send).not.toHaveBeenCalled();
     });
 
-    it('threads sender email + audit metadata to service', async () => {
+    it('threads sender email + audit metadata to service when JWT has email and body omitted', async () => {
       const env = makeEnvelope({ status: 'awaiting_others' });
       svc.send.mockResolvedValue(env);
       const req = makeRequest({ userAgent: 'Mozilla/5.0' });
@@ -262,7 +291,7 @@ describe('EnvelopesController', () => {
       expect(svc.send).toHaveBeenCalledWith(
         USER.id,
         'env-1',
-        { email: USER.email },
+        { email: USER.email, name: null },
         { ip: expect.any(String), user_agent: 'Mozilla/5.0' },
       );
     });
@@ -281,20 +310,37 @@ describe('EnvelopesController', () => {
   });
 
   describe('POST /envelopes/:id/signers/:signer_id/remind', () => {
-    it('400 sender_email_missing when JWT has no email', async () => {
-      const noEmailUser: AuthUser = { id: USER.id, email: null, provider: 'email' };
-      await expect(
-        controller.remindSigner(noEmailUser, 'env-1', 'signer-1'),
-      ).rejects.toBeInstanceOf(BadRequestException);
+    it('400 sender_email_missing when JWT has no email and body is empty', async () => {
+      const anon: AuthUser = { id: USER.id, email: null, provider: 'anonymous' };
+      await expect(controller.remindSigner(anon, 'env-1', 'signer-1', {})).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
       expect(svc.remindSigner).not.toHaveBeenCalled();
     });
 
-    it('returns queued and forwards sender email', async () => {
+    it('returns queued and forwards sender email from JWT (ignores body)', async () => {
       svc.remindSigner.mockResolvedValue(undefined);
-      const out = await controller.remindSigner(USER, 'env-1', 'signer-1');
+      const out = await controller.remindSigner(USER, 'env-1', 'signer-1', {
+        sender_email: 'evil@spoof.example',
+      });
       expect(out).toEqual({ status: 'queued' });
       expect(svc.remindSigner).toHaveBeenCalledWith(USER.id, 'env-1', 'signer-1', {
         email: USER.email,
+        name: null,
+      });
+    });
+
+    it('falls back to body sender_email + name when JWT carries no email (anon/guest)', async () => {
+      svc.remindSigner.mockResolvedValue(undefined);
+      const anon: AuthUser = { id: USER.id, email: null, provider: 'anonymous' };
+      const out = await controller.remindSigner(anon, 'env-1', 'signer-1', {
+        sender_email: 'guest@example.com',
+        sender_name: 'Guest User',
+      });
+      expect(out).toEqual({ status: 'queued' });
+      expect(svc.remindSigner).toHaveBeenCalledWith(USER.id, 'env-1', 'signer-1', {
+        email: 'guest@example.com',
+        name: 'Guest User',
       });
     });
   });

--- a/apps/api/src/envelopes/envelopes.controller.ts
+++ b/apps/api/src/envelopes/envelopes.controller.ts
@@ -26,6 +26,7 @@ import { AddSignerDto } from './dto/add-signer.dto';
 import { CreateEnvelopeDto } from './dto/create-envelope.dto';
 import { PatchEnvelopeDto } from './dto/patch-envelope.dto';
 import { PlaceFieldsDto } from './dto/place-fields.dto';
+import { SendEnvelopeDto } from './dto/send-envelope.dto';
 import type {
   EnvelopeEvent,
   EnvelopeField,
@@ -119,17 +120,22 @@ export class EnvelopesController {
     @CurrentUser() user: AuthUser,
     @Param('id', ParseUUIDPipe) id: string,
     @Req() req: Request,
+    @Body() dto: SendEnvelopeDto = {},
   ): Promise<Envelope> {
-    if (!user.email) {
-      // The sender's display identity is threaded into the invite email's
-      // "From: <name>" line, so we need at least the email claim. Supabase
-      // JWTs for Google OAuth always carry email; this guard is defensive.
+    // The sender's display identity is threaded into the invite email's
+    // "From: <name>" line, so we need at least an email. JWT email always
+    // wins (anti-spoofing — a signed-in user can't impersonate via body);
+    // body sender_email is only consulted for anonymous Supabase sessions
+    // (guest mode) where the JWT carries `email: null`.
+    const sender_email = user.email ?? dto.sender_email ?? null;
+    if (!sender_email) {
       throw new BadRequestException('sender_email_missing');
     }
+    const sender_name = user.email ? null : (dto.sender_name ?? null);
     return this.svc.send(
       user.id,
       id,
-      { email: user.email },
+      { email: sender_email, name: sender_name },
       { ip: extractClientIp(req), user_agent: req.headers['user-agent'] ?? null },
     );
   }
@@ -158,9 +164,18 @@ export class EnvelopesController {
     @CurrentUser() user: AuthUser,
     @Param('id', ParseUUIDPipe) id: string,
     @Param('signer_id', ParseUUIDPipe) signer_id: string,
+    @Body() dto: SendEnvelopeDto = {},
   ): Promise<{ status: 'queued' }> {
-    if (!user.email) throw new BadRequestException('sender_email_missing');
-    await this.svc.remindSigner(user.id, id, signer_id, { email: user.email });
+    // Same JWT-email-wins resolution as POST /:id/send. Anonymous senders
+    // (guest mode) include `sender_email` in the body so the reminder can
+    // still go out under their identity.
+    const sender_email = user.email ?? dto.sender_email ?? null;
+    if (!sender_email) throw new BadRequestException('sender_email_missing');
+    const sender_name = user.email ? null : (dto.sender_name ?? null);
+    await this.svc.remindSigner(user.id, id, signer_id, {
+      email: sender_email,
+      name: sender_name,
+    });
     return { status: 'queued' };
   }
 

--- a/apps/api/test/envelopes-sender.e2e-spec.ts
+++ b/apps/api/test/envelopes-sender.e2e-spec.ts
@@ -866,4 +866,100 @@ describe('Envelopes — sender draft flow (e2e)', () => {
       expect(res.status).toBe(404);
     });
   });
+
+  /**
+   * Guest mode in the SPA exchanges the localStorage flag for an anonymous
+   * Supabase session, so the JWT carries `sub` but no `email`. The send /
+   * remind endpoints accept the sender's email in the request body for
+   * exactly this case (controller resolves JWT-email-wins; body email used
+   * only when JWT email is null). These tests cover the wire contract end
+   * to end so the no-sign-up flow actually persists envelopes + queues
+   * invite emails.
+   */
+  describe('anon (guest) send + remind via body sender_email', () => {
+    let anonToken: string;
+
+    beforeAll(async () => {
+      const signOpts = { issuer: ISSUER, audience: TEST_ENV.SUPABASE_JWT_AUDIENCE };
+      // No `email` claim — mirrors a Supabase anonymous sign-in.
+      anonToken = await tk.sign({ sub: USER_A }, signOpts);
+    });
+
+    async function buildAnonDraft(): Promise<{ envId: string; signerId: string }> {
+      const contact = await contactsRepo.create({
+        owner_id: USER_A,
+        name: 'Bea',
+        email: 'bea@example.com',
+        color: '#abcdef',
+      });
+      const env = await request(app.getHttpServer())
+        .post('/envelopes')
+        .set(auth(anonToken))
+        .send({ title: 'Guest send' });
+      await request(app.getHttpServer())
+        .post(`/envelopes/${env.body.id}/upload`)
+        .set(auth(anonToken))
+        .attach('file', tinyPdf, { filename: 't.pdf', contentType: 'application/pdf' });
+      const signer = await request(app.getHttpServer())
+        .post(`/envelopes/${env.body.id}/signers`)
+        .set(auth(anonToken))
+        .send({ contact_id: contact.id });
+      await request(app.getHttpServer())
+        .put(`/envelopes/${env.body.id}/fields`)
+        .set(auth(anonToken))
+        .send({
+          fields: [
+            {
+              signer_id: signer.body.id,
+              kind: 'signature',
+              page: 1,
+              x: 0.1,
+              y: 0.1,
+              required: true,
+            },
+          ],
+        });
+      return { envId: env.body.id, signerId: signer.body.id };
+    }
+
+    it('POST /:id/send with body sender_email creates envelope + enqueues invite', async () => {
+      const { envId, signerId } = await buildAnonDraft();
+
+      const res = await request(app.getHttpServer())
+        .post(`/envelopes/${envId}/send`)
+        .set(auth(anonToken))
+        .send({ sender_email: 'guest@example.com', sender_name: 'Guest User' });
+      expect(res.status).toBe(201);
+      expect(res.body.status).toBe('awaiting_others');
+      expect(res.body.sender_email).toBe('guest@example.com');
+      expect(res.body.sender_name).toBe('Guest User');
+
+      const queued = outbound.rows.filter((r) => r.envelope_id === envId);
+      expect(queued).toHaveLength(1);
+      expect(queued[0]!.signer_id).toBe(signerId);
+      expect(queued[0]!.to_email).toBe('bea@example.com');
+      expect(queued[0]!.payload).toMatchObject({
+        sender_email: 'guest@example.com',
+        sender_name: 'Guest User',
+      });
+    });
+
+    it('POST /:id/send with no body returns 400 sender_email_missing', async () => {
+      const { envId } = await buildAnonDraft();
+      const res = await request(app.getHttpServer())
+        .post(`/envelopes/${envId}/send`)
+        .set(auth(anonToken));
+      expect(res.status).toBe(400);
+      expect(res.body).toEqual({ error: 'sender_email_missing' });
+    });
+
+    it('POST /:id/send with malformed sender_email rejected by DTO with 400', async () => {
+      const { envId } = await buildAnonDraft();
+      const res = await request(app.getHttpServer())
+        .post(`/envelopes/${envId}/send`)
+        .set(auth(anonToken))
+        .send({ sender_email: 'not-an-email' });
+      expect(res.status).toBe(400);
+    });
+  });
 });

--- a/apps/web/e2e/guest-flow.spec.ts
+++ b/apps/web/e2e/guest-flow.spec.ts
@@ -61,17 +61,96 @@ async function installGuestMocks(page: Page): Promise<GuestApiCallLog> {
     });
   });
 
-  // Any envelope-side traffic the editor may emit while we're driving it.
-  // Guest mode short-circuits the real send chain, so these are tolerant
-  // catch-alls only — no assertions read them.
-  // IMPORTANT: must be scoped to `/api/envelopes/**` — a bare `**/envelopes/**`
-  // also matches Vite dev-server module URLs like `/src/features/envelopes/*.ts`,
-  // which makes the SPA bundle fail to load and the page renders blank.
-  await page.route('**/api/envelopes/**', async (route: Route) => {
+  // Envelope chain — guest mode now POSTs through the same `/envelopes/*`
+  // API path as authed users (anonymous Supabase JWT). Mock the five-step
+  // sender chain (`useSendEnvelope.run`) so the click → /sent navigation
+  // works without a backend.
+  // IMPORTANT: scope to `/api/envelopes` — a bare `**/envelopes/**` would
+  // also match Vite dev-server module URLs like `/src/features/envelopes/*.ts`
+  // and break the SPA bundle (renders blank).
+  const ENVELOPE_ID = 'env-guest-flow-001';
+  const SIGNER_ID = 'signer-guest-flow-001';
+  await page.route('**/api/envelopes', async (route: Route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          id: ENVELOPE_ID,
+          owner_id: 'guest',
+          title: 'Untitled',
+          short_code: 'GUEST-01',
+          status: 'draft',
+          original_pages: 1,
+          expires_at: '2099-12-31T00:00:00.000Z',
+          tc_version: 'v1',
+          privacy_version: 'v1',
+          sent_at: null,
+          completed_at: null,
+          signers: [],
+          fields: [],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/upload`, async (route: Route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({}),
+      body: JSON.stringify({ pages: 1, sha256: 'a'.repeat(64) }),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/signers`, async (route: Route) => {
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: SIGNER_ID,
+        email: 'guest-signer@example.com',
+        name: 'Guest Signer',
+        color: '#10b981',
+        role: 'signatory',
+        signing_order: 1,
+        status: 'awaiting',
+        viewed_at: null,
+        tc_accepted_at: null,
+        signed_at: null,
+        declined_at: null,
+      }),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/fields`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/send`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: ENVELOPE_ID,
+        owner_id: 'guest',
+        title: 'Untitled',
+        short_code: 'GUEST-01',
+        status: 'awaiting_others',
+        original_pages: 1,
+        expires_at: '2099-12-31T00:00:00.000Z',
+        tc_version: 'v1',
+        privacy_version: 'v1',
+        sent_at: new Date().toISOString(),
+        completed_at: null,
+        signers: [],
+        fields: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
     });
   });
 
@@ -147,8 +226,14 @@ test.describe('guest mode — full sender flow', () => {
     await sigTile.dragTo(canvas, { targetPosition: { x: 200, y: 240 } });
     await page.getByRole('button', { name: /^apply$/i }).click();
 
-    // ---- Send (guest mode short-circuits to /document/:id/sent locally).
+    // ---- Send. Guest mode now goes through the real `/envelopes/*` API
+    // chain (mocked above). The GuestSenderEmailDialog opens first to
+    // capture the sender's email (anonymous JWT has no email claim).
     await page.getByRole('button', { name: /send to sign/i }).click();
+    const senderDialog = page.getByRole('dialog', { name: /send as guest/i });
+    await expect(senderDialog).toBeVisible();
+    await senderDialog.getByRole('textbox').first().fill('guest-sender@example.com');
+    await senderDialog.getByRole('button', { name: /^continue$/i }).click();
     await page.waitForURL(/\/document\/[^/]+\/sent$/, { timeout: 15_000 });
     await expect(page).toHaveURL(/\/document\/[^/]+\/sent$/);
   });

--- a/apps/web/e2e/template-sign-flow.spec.ts
+++ b/apps/web/e2e/template-sign-flow.spec.ts
@@ -152,6 +152,69 @@ interface ApiCallLog {
 async function installMocks(page: Page): Promise<ApiCallLog> {
   const log = { contacts: 0, signFinish: 0, signPdf: 0 };
 
+  // --- Sender: envelope create + upload + signers + fields + send.
+  // Guest mode now goes through the same `/envelopes/*` API path as
+  // authed users (anonymous Supabase JWT). Mock the full chain so
+  // `useSendEnvelope` succeeds and `runSend` navigates to /sent.
+  await page.route('**/api/envelopes', async (route: Route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 201,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...makeBaseEnvelope(),
+          status: 'draft',
+          owner_id: 'guest',
+          sent_at: null,
+          completed_at: null,
+          signers: [],
+          fields: [],
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        }),
+      });
+      return;
+    }
+    await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/upload`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ pages: 1, sha256: 'a'.repeat(64) }),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/signers`, async (route: Route) => {
+    await route.fulfill({
+      status: 201,
+      contentType: 'application/json',
+      body: JSON.stringify({ ...makeBaseSigner(), signing_order: 1 }),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/fields`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+  await page.route(`**/api/envelopes/${ENVELOPE_ID}/send`, async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ...makeBaseEnvelope(),
+        owner_id: 'guest',
+        sent_at: new Date().toISOString(),
+        completed_at: null,
+        signers: [{ ...makeBaseSigner(), signing_order: 1 }],
+        fields: [],
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      }),
+    });
+  });
+
   // --- Sender: contacts list (empty in guest mode, but the SPA may probe).
   await page.route('**/api/contacts', async (route: Route) => {
     if (route.request().method() === 'POST') {
@@ -339,6 +402,13 @@ test.describe('template + sign happy path', () => {
     // ---------------------- 3. Sender: send (guest mode → /document/:id/sent)
 
     await page.getByRole('button', { name: /send to sign/i }).click();
+    // GuestSenderEmailDialog opens first to capture the sender's email
+    // (anonymous Supabase JWT has no email claim, so the API needs it
+    // in the body). Fill it and click Continue to proceed with the send.
+    const senderDialog = page.getByRole('dialog', { name: /send as guest/i });
+    await expect(senderDialog).toBeVisible();
+    await senderDialog.getByRole('textbox').first().fill('sender@example.com');
+    await senderDialog.getByRole('button', { name: /^continue$/i }).click();
     await page.waitForURL(/\/document\/[^/]+\/sent$/, { timeout: 15_000 });
     await expect(page).toHaveURL(/\/document\/[^/]+\/sent$/);
 

--- a/apps/web/src/components/AuthForm/AuthForm.stories.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.stories.tsx
@@ -25,7 +25,7 @@ const fakeAuth: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/components/AuthForm/AuthForm.test.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.test.tsx
@@ -18,7 +18,7 @@ const auth = {
   signInWithGoogle: vi.fn(async () => undefined),
   resetPassword: vi.fn(async () => undefined),
   signOut: vi.fn(async () => undefined),
-  enterGuestMode: vi.fn(),
+  enterGuestMode: vi.fn(async () => undefined),
   exitGuestMode: vi.fn(),
 } satisfies AuthContextValue;
 

--- a/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.styles.ts
+++ b/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.styles.ts
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(11, 18, 32, 0.48);
+  z-index: ${({ theme }) => theme.z.modal};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${({ theme }) => theme.space[5]};
+`;
+
+export const Card = styled.div`
+  background: ${({ theme }) => theme.color.bg.surface};
+  border-radius: ${({ theme }) => theme.radius.xl};
+  box-shadow: ${({ theme }) => theme.shadow.xl};
+  padding: ${({ theme }) => theme.space[6]};
+  width: 100%;
+  max-width: 460px;
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space[4]};
+`;
+
+export const Title = styled.h2`
+  margin: 0;
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: ${({ theme }) => theme.font.size.h4};
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.color.fg[1]};
+`;
+
+export const Description = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.body};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
+  color: ${({ theme }) => theme.color.fg[3]};
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space[3]};
+`;
+
+export const FieldRow = styled.label`
+  display: flex;
+  flex-direction: column;
+  gap: ${({ theme }) => theme.space[1]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  color: ${({ theme }) => theme.color.fg[2]};
+`;
+
+export const TextInput = styled.input`
+  font-size: ${({ theme }) => theme.font.size.body};
+  padding: 10px 12px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  background: ${({ theme }) => theme.color.bg.surface};
+  color: ${({ theme }) => theme.color.fg[1]};
+
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.color.indigo[500]};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.color.indigo[100]};
+  }
+`;
+
+export const ErrorText = styled.span`
+  color: ${({ theme }) => theme.color.danger[700]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: ${({ theme }) => theme.space[2]};
+`;

--- a/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.test.tsx
+++ b/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { GuestSenderEmailDialog } from './GuestSenderEmailDialog';
+
+describe('GuestSenderEmailDialog', () => {
+  it('does not render when closed', () => {
+    renderWithProviders(
+      <GuestSenderEmailDialog open={false} onConfirm={vi.fn()} onCancel={vi.fn()} />,
+      {},
+    );
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders an email input and Continue button when open', () => {
+    renderWithProviders(<GuestSenderEmailDialog open onConfirm={vi.fn()} onCancel={vi.fn()} />, {});
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByLabelText(/your email/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue/i })).toBeInTheDocument();
+  });
+
+  it('refuses to confirm with an empty email and surfaces an error', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <GuestSenderEmailDialog open onConfirm={onConfirm} onCancel={vi.fn()} />,
+      {},
+    );
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/email/i);
+  });
+
+  it('refuses to confirm with a malformed email', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <GuestSenderEmailDialog open onConfirm={onConfirm} onCancel={vi.fn()} />,
+      {},
+    );
+    await user.type(screen.getByLabelText(/your email/i), 'not-an-email');
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/valid email/i);
+  });
+
+  it('fires onConfirm with trimmed email and undefined name when name is omitted', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <GuestSenderEmailDialog open onConfirm={onConfirm} onCancel={vi.fn()} />,
+      {},
+    );
+    await user.type(screen.getByLabelText(/your email/i), '  ada@example.com  ');
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onConfirm).toHaveBeenCalledWith('ada@example.com', undefined);
+  });
+
+  it('fires onConfirm with trimmed name when provided', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    renderWithProviders(
+      <GuestSenderEmailDialog open onConfirm={onConfirm} onCancel={vi.fn()} />,
+      {},
+    );
+    await user.type(screen.getByLabelText(/your email/i), 'ada@example.com');
+    await user.type(screen.getByLabelText(/your name/i), '  Ada Lovelace  ');
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onConfirm).toHaveBeenCalledWith('ada@example.com', 'Ada Lovelace');
+  });
+
+  it('fires onCancel when the Cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    renderWithProviders(
+      <GuestSenderEmailDialog open onConfirm={vi.fn()} onCancel={onCancel} />,
+      {},
+    );
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.tsx
+++ b/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useId, useRef, useState, type FormEvent, type ReactElement } from 'react';
+import { Button } from '../Button';
+import {
+  Backdrop,
+  Card,
+  Description,
+  ErrorText,
+  FieldRow,
+  Footer,
+  Form,
+  TextInput,
+  Title,
+} from './GuestSenderEmailDialog.styles';
+import type { GuestSenderEmailDialogProps } from './GuestSenderEmailDialog.types';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const EMAIL_MAX = 254;
+const NAME_MAX = 120;
+
+/**
+ * Captures the sender's identity in guest mode just before we POST
+ * `/envelopes/:id/send`. The signed-in flow sources sender from the JWT
+ * email claim, but anonymous Supabase sessions have no email — the API
+ * accepts `{ sender_email, sender_name }` only when the JWT lacks
+ * `email`, so we ask the user once here.
+ *
+ * Validation mirrors the backend `SendEnvelopeDto`:
+ *   - email: required, RFC-loose regex, ≤ 254 chars
+ *   - name: optional, ≤ 120 chars (whitespace-only treated as omitted)
+ */
+export function GuestSenderEmailDialog({
+  open,
+  onConfirm,
+  onCancel,
+  ...rest
+}: GuestSenderEmailDialogProps): ReactElement | null {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const titleId = useId();
+  const descId = useId();
+  const emailInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Focus email input when the dialog opens; reset state when it closes.
+  useEffect(() => {
+    if (open) {
+      emailInputRef.current?.focus();
+      return;
+    }
+    setEmail('');
+    setName('');
+    setError(null);
+  }, [open]);
+
+  if (!open) return null;
+
+  function handleSubmit(e: FormEvent<HTMLFormElement>): void {
+    e.preventDefault();
+    const trimmedEmail = email.trim();
+    const trimmedName = name.trim();
+    if (!trimmedEmail) {
+      setError('Please enter your email so signers know who is asking.');
+      return;
+    }
+    if (trimmedEmail.length > EMAIL_MAX) {
+      setError(`Email is too long (max ${EMAIL_MAX} characters).`);
+      return;
+    }
+    if (!EMAIL_RE.test(trimmedEmail)) {
+      setError('Please enter a valid email address.');
+      return;
+    }
+    if (trimmedName.length > NAME_MAX) {
+      setError(`Name is too long (max ${NAME_MAX} characters).`);
+      return;
+    }
+    setError(null);
+    onConfirm(trimmedEmail, trimmedName.length > 0 ? trimmedName : undefined);
+  }
+
+  return (
+    <Backdrop role="presentation" onMouseDown={onCancel}>
+      <Card
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descId}
+        onMouseDown={(e) => e.stopPropagation()}
+        {...rest}
+      >
+        <Title id={titleId}>Send as guest</Title>
+        <Description id={descId}>
+          You are sending without an account. We will include your email on the invite so signers
+          know who is asking.
+        </Description>
+        <Form onSubmit={handleSubmit} noValidate>
+          <FieldRow>
+            Your email
+            <TextInput
+              ref={emailInputRef}
+              type="email"
+              autoComplete="email"
+              inputMode="email"
+              required
+              maxLength={EMAIL_MAX}
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              aria-invalid={error !== null}
+            />
+          </FieldRow>
+          <FieldRow>
+            Your name (optional)
+            <TextInput
+              type="text"
+              autoComplete="name"
+              maxLength={NAME_MAX}
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+          </FieldRow>
+          {error !== null && <ErrorText role="alert">{error}</ErrorText>}
+          <Footer>
+            <Button type="button" variant="secondary" onClick={onCancel}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Continue
+            </Button>
+          </Footer>
+        </Form>
+      </Card>
+    </Backdrop>
+  );
+}

--- a/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.types.ts
+++ b/apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.types.ts
@@ -1,0 +1,12 @@
+import type { HTMLAttributes } from 'react';
+
+export interface GuestSenderEmailDialogProps extends HTMLAttributes<HTMLDivElement> {
+  readonly open: boolean;
+  /**
+   * Fires when the user submits a valid email. The parent passes the
+   * captured `(email, name?)` pair into the API send request as the
+   * sender identity for guest mode.
+   */
+  readonly onConfirm: (email: string, name?: string) => void;
+  readonly onCancel: () => void;
+}

--- a/apps/web/src/components/GuestSenderEmailDialog/index.ts
+++ b/apps/web/src/components/GuestSenderEmailDialog/index.ts
@@ -1,0 +1,2 @@
+export { GuestSenderEmailDialog } from './GuestSenderEmailDialog';
+export type { GuestSenderEmailDialogProps } from './GuestSenderEmailDialog.types';

--- a/apps/web/src/features/envelopeDetail/model/useEnvelopeDetailController.test.tsx
+++ b/apps/web/src/features/envelopeDetail/model/useEnvelopeDetailController.test.tsx
@@ -220,16 +220,8 @@ describe('useEnvelopeDetailController — handleSendReminder', () => {
     });
 
     expect(post).toHaveBeenCalledTimes(2);
-    expect(post).toHaveBeenCalledWith(
-      '/envelopes/env-1/signers/s1/remind',
-      undefined,
-      expect.anything(),
-    );
-    expect(post).toHaveBeenCalledWith(
-      '/envelopes/env-1/signers/s2/remind',
-      undefined,
-      expect.anything(),
-    );
+    expect(post).toHaveBeenCalledWith('/envelopes/env-1/signers/s1/remind', {}, expect.anything());
+    expect(post).toHaveBeenCalledWith('/envelopes/env-1/signers/s2/remind', {}, expect.anything());
     expect(result.current.toast).toEqual({
       kind: 'success',
       text: 'Reminder sent to 2 signers.',

--- a/apps/web/src/features/envelopes/envelopesApi.ts
+++ b/apps/web/src/features/envelopes/envelopesApi.ts
@@ -195,11 +195,15 @@ export async function getEnvelopeDownloadUrl(
 export async function remindEnvelopeSigner(
   envelopeId: string,
   signerId: string,
+  payload?: SendEnvelopePayload,
   signal?: AbortSignal,
 ): Promise<void> {
+  const body: { sender_email?: string; sender_name?: string } = {};
+  if (payload?.sender_email !== undefined) body.sender_email = payload.sender_email;
+  if (payload?.sender_name !== undefined) body.sender_name = payload.sender_name;
   await apiClient.post<void>(
     `/envelopes/${envelopeId}/signers/${signerId}/remind`,
-    undefined,
+    body,
     configWithSignal(signal),
   );
 }
@@ -265,10 +269,28 @@ export async function placeEnvelopeFields(
   return data;
 }
 
-export async function sendEnvelope(id: string, signal?: AbortSignal): Promise<Envelope> {
+export interface SendEnvelopePayload {
+  /**
+   * Caller-supplied sender email. Server uses this only when the JWT has
+   * no `email` claim (anonymous Supabase sessions used by guest mode);
+   * when the JWT carries an email, the server ignores this and uses the
+   * JWT email instead (anti-spoofing).
+   */
+  readonly sender_email?: string;
+  readonly sender_name?: string;
+}
+
+export async function sendEnvelope(
+  id: string,
+  payload?: SendEnvelopePayload,
+  signal?: AbortSignal,
+): Promise<Envelope> {
+  const body: { sender_email?: string; sender_name?: string } = {};
+  if (payload?.sender_email !== undefined) body.sender_email = payload.sender_email;
+  if (payload?.sender_name !== undefined) body.sender_name = payload.sender_name;
   const { data } = await apiClient.post<Envelope>(
     `/envelopes/${id}/send`,
-    undefined,
+    body,
     configWithSignal(signal),
   );
   return data;

--- a/apps/web/src/features/envelopes/useSendEnvelope.test.ts
+++ b/apps/web/src/features/envelopes/useSendEnvelope.test.ts
@@ -73,7 +73,7 @@ describe('useSendEnvelope', () => {
     expect(placeEnvelopeFields).toHaveBeenCalledWith('env-1', [
       expect.objectContaining({ signer_id: 'server-s1', kind: 'signature' }),
     ]);
-    expect(sendEnvelope).toHaveBeenCalledWith('env-1');
+    expect(sendEnvelope).toHaveBeenCalledWith('env-1', {});
     await waitFor(() => expect(result.current.phase).toBe('done'));
   });
 
@@ -94,7 +94,31 @@ describe('useSendEnvelope', () => {
     });
 
     expect(placeEnvelopeFields).not.toHaveBeenCalled();
-    expect(sendEnvelope).toHaveBeenCalledWith('env-empty');
+    expect(sendEnvelope).toHaveBeenCalledWith('env-empty', {});
+  });
+
+  it('passes senderEmail/senderName through to sendEnvelope (guest mode)', async () => {
+    createEnvelope.mockResolvedValueOnce({ id: 'env-guest', short_code: 'SC' });
+    uploadEnvelopeFile.mockResolvedValueOnce({ pages: 1, sha256: '' });
+    sendEnvelope.mockResolvedValueOnce({ id: 'env-guest', short_code: 'SC' });
+
+    const { result } = renderHook(() => useSendEnvelope());
+
+    await act(async () => {
+      await result.current.run({
+        title: 'Guest send',
+        file: FILE,
+        signers: [],
+        buildFields: () => [],
+        senderEmail: 'guest@example.com',
+        senderName: 'Ada Lovelace',
+      });
+    });
+
+    expect(sendEnvelope).toHaveBeenCalledWith('env-guest', {
+      sender_email: 'guest@example.com',
+      sender_name: 'Ada Lovelace',
+    });
   });
 
   it('captures the first failure + exposes it on `error`', async () => {

--- a/apps/web/src/features/envelopes/useSendEnvelope.ts
+++ b/apps/web/src/features/envelopes/useSendEnvelope.ts
@@ -29,6 +29,13 @@ export interface SendEnvelopeInput {
     /** Map: local contact id → server signer id returned by addSigner. */
     contactIdToSignerId: ReadonlyMap<string, string>,
   ) => ReadonlyArray<FieldPlacement>;
+  /**
+   * Optional sender identity for the final POST /envelopes/:id/send.
+   * Used by guest mode (anonymous Supabase session, JWT has no email);
+   * authed callers leave both undefined and the server uses the JWT email.
+   */
+  readonly senderEmail?: string;
+  readonly senderName?: string;
 }
 
 export interface SendEnvelopeResult {
@@ -101,7 +108,10 @@ export function useSendEnvelope(): UseSendEnvelope {
       }
 
       setPhase('sending');
-      const sent = await sendEnvelope(envelope.id);
+      const payload: { sender_email?: string; sender_name?: string } = {};
+      if (input.senderEmail !== undefined) payload.sender_email = input.senderEmail;
+      if (input.senderName !== undefined) payload.sender_name = input.senderName;
+      const sent = await sendEnvelope(envelope.id, payload);
 
       setPhase('done');
       return { envelope_id: sent.id, short_code: sent.short_code };

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
@@ -25,7 +25,7 @@ const LOADING_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
@@ -25,7 +25,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
@@ -27,7 +27,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
@@ -27,7 +27,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.test.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.test.tsx
@@ -340,16 +340,8 @@ describe('EnvelopeDetailPage', () => {
     const toast = await screen.findByRole('status');
     expect(toast).toHaveTextContent(/Reminder sent to 2 signers\./i);
     expect(post).toHaveBeenCalledTimes(2);
-    expect(post).toHaveBeenCalledWith(
-      '/envelopes/env-1/signers/s1/remind',
-      undefined,
-      expect.anything(),
-    );
-    expect(post).toHaveBeenCalledWith(
-      '/envelopes/env-1/signers/s2/remind',
-      undefined,
-      expect.anything(),
-    );
+    expect(post).toHaveBeenCalledWith('/envelopes/env-1/signers/s1/remind', {}, expect.anything());
+    expect(post).toHaveBeenCalledWith('/envelopes/env-1/signers/s2/remind', {}, expect.anything());
   });
 
   it('shows a danger toast when the cancel mutation fails', async () => {

--- a/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
@@ -25,7 +25,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
+++ b/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
@@ -27,7 +27,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
@@ -25,7 +25,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
 import { AuthShell } from '@/components/AuthShell';
@@ -19,6 +19,7 @@ const ErrorBanner = styled.div`
 
 const ERROR_COPY: Record<string, string> = {
   oauth: "We couldn't complete the Google sign-in. Please try again.",
+  guest: "We couldn't start a guest session. Please sign up to continue.",
 };
 
 /**
@@ -31,11 +32,21 @@ export function SignInPage() {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const { enterGuestMode } = useAuth();
-  const errorKey = params.get('error');
+  const queryError = params.get('error');
+  const [guestError, setGuestError] = useState<string | null>(null);
+  const errorKey = guestError ? 'guest' : queryError;
 
   const handleSkip = useCallback((): void => {
-    enterGuestMode();
-    navigate('/document/new');
+    setGuestError(null);
+    // enterGuestMode is async — it provisions an anonymous Supabase session
+    // so subsequent API calls have a Bearer JWT. If the project doesn't
+    // allow anonymous sign-ins, surface the failure in the existing
+    // error banner instead of silently leaving the user stuck.
+    enterGuestMode()
+      .then(() => navigate('/document/new'))
+      .catch((err: unknown) => {
+        setGuestError(err instanceof Error ? err.message : 'Could not start guest session.');
+      });
   }, [enterGuestMode, navigate]);
 
   const handleSwitch = useCallback(

--- a/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
@@ -25,7 +25,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/SignUpPage/SignUpPage.test.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.test.tsx
@@ -49,7 +49,7 @@ describe('SignUpPage', () => {
 
   it('skip link enters guest mode and lands on /document/new once consent is given', async () => {
     const user = userEvent.setup();
-    const enterGuestMode = vi.fn();
+    const enterGuestMode = vi.fn(async () => undefined);
     renderSignUp({ auth: { enterGuestMode } });
 
     // Consent gates Skip in signup mode (commit 5a3f252) — tick both first so

--- a/apps/web/src/pages/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,10 +1,21 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import { AuthShell } from '@/components/AuthShell';
 import { AuthForm } from '@/components/AuthForm';
 import type { AuthFormMode } from '@/components/AuthForm/AuthForm.types';
 import { pathForAuthMode } from '@/layout/authPaths';
 import { useAuth } from '@/providers/AuthProvider';
+
+const ErrorBanner = styled.div`
+  background: ${({ theme }) => theme.color.danger[50]};
+  border: 1px solid ${({ theme }) => theme.color.danger[500]};
+  color: ${({ theme }) => theme.color.danger[700]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  padding: 10px 12px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  margin: 0 0 ${({ theme }) => theme.space[4]};
+`;
 
 /**
  * L4 page — `/signup`. Handles three post-submit outcomes:
@@ -15,10 +26,18 @@ import { useAuth } from '@/providers/AuthProvider';
 export function SignUpPage() {
   const navigate = useNavigate();
   const { enterGuestMode } = useAuth();
+  const [guestError, setGuestError] = useState<string | null>(null);
 
   const handleSkip = useCallback((): void => {
-    enterGuestMode();
-    navigate('/document/new');
+    setGuestError(null);
+    // Async — provisions an anon Supabase session so the API has a Bearer
+    // token to attach. Surface the error if the project disabled the
+    // anonymous provider so the user knows to sign up instead.
+    enterGuestMode()
+      .then(() => navigate('/document/new'))
+      .catch((err: unknown) => {
+        setGuestError(err instanceof Error ? err.message : 'Could not start guest session.');
+      });
   }, [enterGuestMode, navigate]);
 
   const handleSwitch = useCallback(
@@ -41,6 +60,7 @@ export function SignUpPage() {
 
   return (
     <AuthShell>
+      {guestError ? <ErrorBanner role="alert">{guestError}</ErrorBanner> : null}
       <AuthForm
         mode="signup"
         onSkip={handleSkip}

--- a/apps/web/src/pages/TemplatesListPage/TemplatesListPage.stories.tsx
+++ b/apps/web/src/pages/TemplatesListPage/TemplatesListPage.stories.tsx
@@ -42,7 +42,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.stories.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.stories.tsx
@@ -34,7 +34,7 @@ const STORY_AUTH: AuthContextValue = {
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
   signOut: asyncNoop,
-  enterGuestMode: noop,
+  enterGuestMode: asyncNoop,
   exitGuestMode: noop,
 };
 

--- a/apps/web/src/providers/AuthProvider.test.tsx
+++ b/apps/web/src/providers/AuthProvider.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, renderHook, waitFor } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+
+/**
+ * Hoisted mock surface for the Supabase auth client. The AuthProvider
+ * reads `getSession`, `onAuthStateChange`, `signInAnonymously`, and
+ * `signOut`; tests below rebind these per case.
+ */
+type GetSession = () => Promise<{ data: { session: Session | null } }>;
+type AuthStateCb = (event: string, session: Session | null) => void;
+type OnAuthStateChange = (cb: AuthStateCb) => {
+  data: { subscription: { unsubscribe: () => void } };
+};
+type SignInAnonymously = () => Promise<{ data: unknown; error: { message: string } | null }>;
+type SignOut = () => Promise<{ error: unknown }>;
+
+const { supabaseAuth, listeners } = vi.hoisted(() => {
+  const cbs: Array<(event: string, session: Session | null) => void> = [];
+  return {
+    listeners: cbs,
+    supabaseAuth: {
+      getSession: vi.fn<GetSession>(async () => ({ data: { session: null } })),
+      onAuthStateChange: vi.fn<OnAuthStateChange>((cb) => {
+        cbs.push(cb);
+        return { data: { subscription: { unsubscribe: vi.fn() } } };
+      }),
+      signInAnonymously: vi.fn<SignInAnonymously>(async () => ({ data: null, error: null })),
+      signOut: vi.fn<SignOut>(async () => ({ error: null })),
+    },
+  };
+});
+
+vi.mock('../lib/supabase/supabaseClient', () => ({
+  supabase: { auth: supabaseAuth },
+  setKeepSignedIn: vi.fn(),
+}));
+
+// eslint-disable-next-line import/first
+import { AuthProvider, useAuth } from './AuthProvider';
+
+function makeAnonSession(): Session {
+  return {
+    access_token: 'anon-tok',
+    refresh_token: 'r',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: { id: 'anon-1', email: '', is_anonymous: true } as unknown as User,
+  } as unknown as Session;
+}
+
+function makeNamedSession(email: string): Session {
+  return {
+    access_token: 'tok',
+    refresh_token: 'r',
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: { id: 'u-1', email, is_anonymous: false } as unknown as User,
+  } as unknown as Session;
+}
+
+function wrapper({ children }: { readonly children: ReactNode }): ReactElement {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    listeners.length = 0;
+    supabaseAuth.getSession.mockReset();
+    supabaseAuth.getSession.mockResolvedValue({ data: { session: null } });
+    supabaseAuth.signInAnonymously.mockReset();
+    supabaseAuth.signInAnonymously.mockResolvedValue({ data: null, error: null });
+    supabaseAuth.signOut.mockReset();
+    supabaseAuth.signOut.mockResolvedValue({ error: null });
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('enterGuestMode provisions an anonymous Supabase session and sets guest=true', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.enterGuestMode();
+    });
+
+    expect(supabaseAuth.signInAnonymously).toHaveBeenCalledTimes(1);
+    expect(result.current.guest).toBe(true);
+    expect(window.localStorage.getItem('sealed.guest')).toBe('1');
+  });
+
+  it('enterGuestMode rolls back guest flag when signInAnonymously fails', async () => {
+    supabaseAuth.signInAnonymously.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'anonymous sign-ins disabled' },
+    });
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await expect(
+      act(async () => {
+        await result.current.enterGuestMode();
+      }),
+    ).rejects.toThrow(/anonymous sign-ins disabled/i);
+
+    expect(result.current.guest).toBe(false);
+    expect(window.localStorage.getItem('sealed.guest')).toBe(null);
+  });
+
+  it('onAuthStateChange with an anonymous session does NOT clobber guest=true', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.enterGuestMode();
+    });
+    expect(result.current.guest).toBe(true);
+
+    // Race the listener — anonymous session should not flip guest off.
+    act(() => {
+      for (const cb of listeners) cb('SIGNED_IN', makeAnonSession());
+    });
+    expect(result.current.guest).toBe(true);
+  });
+
+  it('onAuthStateChange with a NAMED session clears the guest flag', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      await result.current.enterGuestMode();
+    });
+    expect(result.current.guest).toBe(true);
+
+    act(() => {
+      for (const cb of listeners) cb('SIGNED_IN', makeNamedSession('ada@example.com'));
+    });
+    expect(result.current.guest).toBe(false);
+    expect(window.localStorage.getItem('sealed.guest')).toBe(null);
+  });
+
+  it('renders children without throwing', () => {
+    const view = render(
+      <AuthProvider>
+        <div>hello</div>
+      </AuthProvider>,
+    );
+    expect(view.getByText('hello')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/providers/AuthProvider.tsx
+++ b/apps/web/src/providers/AuthProvider.tsx
@@ -29,7 +29,7 @@ export interface AuthContextValue {
   readonly signInWithGoogle: () => Promise<void>;
   readonly resetPassword: (email: string) => Promise<void>;
   readonly signOut: () => Promise<void>;
-  readonly enterGuestMode: () => void;
+  readonly enterGuestMode: () => Promise<void>;
   readonly exitGuestMode: () => void;
 }
 
@@ -103,7 +103,9 @@ export function AuthProvider(props: AuthProviderProps) {
       .then(({ data }) => {
         if (cancelled) return;
         setSession(data.session ?? null);
-        if (data.session) {
+        // Anonymous sessions intentionally keep `guest === true`. Only a
+        // real (named-account) sign-in flips guest off.
+        if (data.session && !data.session.user.is_anonymous) {
           setGuest(false);
           writeGuestFlag(false);
         }
@@ -115,7 +117,9 @@ export function AuthProvider(props: AuthProviderProps) {
 
     const { data: sub } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       setSession(nextSession ?? null);
-      if (nextSession) {
+      // Same rule as above: anonymous sign-in must not clobber the guest
+      // flag we set inside `enterGuestMode`.
+      if (nextSession && !nextSession.user.is_anonymous) {
         setGuest(false);
         writeGuestFlag(false);
       }
@@ -186,9 +190,30 @@ export function AuthProvider(props: AuthProviderProps) {
     writeGuestFlag(false);
   }, []);
 
-  const enterGuestMode = useCallback((): void => {
+  const enterGuestMode = useCallback(async (): Promise<void> => {
+    // Provision an anonymous Supabase session so the apiClient has a real
+    // Bearer JWT to attach. Without this the localStorage flag would be
+    // set but every API call would 401 — silently breaking the no-sign-up
+    // "guest" send-to-sign flow. Requires "Anonymous Sign-ins" enabled in
+    // the Supabase project (Authentication → Providers → Anonymous); the
+    // underlying error is re-surfaced so the caller can toast it.
+    //
+    // We flip the guest flag *before* the network call so the
+    // `onAuthStateChange` listener (which already filters anonymous
+    // sessions out of its guest=false branch) has a coherent view if it
+    // races us.
     setGuest(true);
     writeGuestFlag(true);
+    const { error } = await supabase.auth.signInAnonymously();
+    if (error) {
+      // Roll back so the SPA doesn't lie about a half-broken guest state.
+      setGuest(false);
+      writeGuestFlag(false);
+      throw new Error(
+        error.message ||
+          'Could not start a guest session. Anonymous sign-ins may be disabled — please sign up instead.',
+      );
+    }
   }, []);
 
   const exitGuestMode = useCallback((): void => {

--- a/apps/web/src/routes/DocumentRoute.tsx
+++ b/apps/web/src/routes/DocumentRoute.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { DocumentPage } from '../pages/DocumentPage';
 import { EnvelopeDetailPage } from '../pages/EnvelopeDetailPage';
 import { ExitConfirmDialog } from '../components/ExitConfirmDialog';
+import { GuestSenderEmailDialog } from '../components/GuestSenderEmailDialog';
 import { SaveAsTemplateDialog } from '../components/SaveAsTemplateDialog';
 import type { SaveAsTemplatePayload } from '../components/SaveAsTemplateDialog';
 import { SendConfirmDialog } from '../components/SendConfirmDialog';
@@ -83,6 +84,7 @@ export function DocumentRoute() {
   const [sendError, setSendError] = useState<string | null>(null);
   const [saveTplOpen, setSaveTplOpen] = useState(false);
   const [sendConfirmOpen, setSendConfirmOpen] = useState(false);
+  const [guestSenderOpen, setGuestSenderOpen] = useState(false);
   const [toast, setToast] = useState<ToastState | null>(null);
   const sendEnvelope = useSendEnvelope();
 
@@ -220,54 +222,58 @@ export function DocumentRoute() {
    * Internal — actually push the envelope to the API. Split out from
    * `handleSend` so the SendConfirmDialog branches can call it after
    * doing or skipping the template-update step.
+   *
+   * Guest mode now goes through the same `/envelopes/*` API path as
+   * authed users (anonymous Supabase JWT). The caller passes the
+   * sender identity captured by `GuestSenderEmailDialog`; for authed
+   * users both args are `undefined` and the server uses the JWT email.
    */
-  const runSend = useCallback(async () => {
-    if (!doc || !doc.file) return;
-    setSendError(null);
+  const runSend = useCallback(
+    async (senderEmail?: string, senderName?: string) => {
+      if (!doc || !doc.file) return;
+      setSendError(null);
 
-    if (guest) {
-      sendDocument(doc.id);
-      navigate(`/document/${doc.id}/sent`);
-      return;
-    }
-
-    try {
-      const result = await sendEnvelope.run({
-        title: doc.title,
-        file: doc.file,
-        signers: doc.signers.map((s) => ({ contactId: s.id })),
-        buildFields: (contactIdToSignerId) => {
-          const out: FieldPlacement[] = [];
-          for (const f of doc.fields) {
-            const normalized = toNormalized(f);
-            for (const localSignerId of f.signerIds) {
-              const serverSignerId = contactIdToSignerId.get(localSignerId);
-              if (serverSignerId) {
-                const placement: FieldPlacement = {
-                  signer_id: serverSignerId,
-                  kind: f.type as FieldKind,
-                  page: f.page,
-                  x: normalized.x,
-                  y: normalized.y,
-                  required: f.required ?? true,
-                  ...(normalized.width !== undefined ? { width: normalized.width } : {}),
-                  ...(normalized.height !== undefined ? { height: normalized.height } : {}),
-                  ...(f.linkId ? { link_id: f.linkId } : {}),
-                };
-                out.push(placement);
+      try {
+        const result = await sendEnvelope.run({
+          title: doc.title,
+          file: doc.file,
+          signers: doc.signers.map((s) => ({ contactId: s.id })),
+          buildFields: (contactIdToSignerId) => {
+            const out: FieldPlacement[] = [];
+            for (const f of doc.fields) {
+              const normalized = toNormalized(f);
+              for (const localSignerId of f.signerIds) {
+                const serverSignerId = contactIdToSignerId.get(localSignerId);
+                if (serverSignerId) {
+                  const placement: FieldPlacement = {
+                    signer_id: serverSignerId,
+                    kind: f.type as FieldKind,
+                    page: f.page,
+                    x: normalized.x,
+                    y: normalized.y,
+                    required: f.required ?? true,
+                    ...(normalized.width !== undefined ? { width: normalized.width } : {}),
+                    ...(normalized.height !== undefined ? { height: normalized.height } : {}),
+                    ...(f.linkId ? { link_id: f.linkId } : {}),
+                  };
+                  out.push(placement);
+                }
               }
             }
-          }
-          return out;
-        },
-      });
+            return out;
+          },
+          ...(senderEmail !== undefined ? { senderEmail } : {}),
+          ...(senderName !== undefined ? { senderName } : {}),
+        });
 
-      sendDocument(doc.id);
-      navigate(`/document/${result.envelope_id}/sent`);
-    } catch (err) {
-      setSendError(err instanceof Error ? err.message : 'Unable to send the document.');
-    }
-  }, [doc, guest, navigate, sendDocument, sendEnvelope]);
+        sendDocument(doc.id);
+        navigate(`/document/${result.envelope_id}/sent`);
+      } catch (err) {
+        setSendError(err instanceof Error ? err.message : 'Unable to send the document.');
+      }
+    },
+    [doc, navigate, sendDocument, sendEnvelope],
+  );
 
   /**
    * Patch the source template with the current placed-field layout —
@@ -284,6 +290,14 @@ export function DocumentRoute() {
   }, [doc?.fields, doc?.fromTemplateId, doc?.totalPages, doc?.signers]);
 
   const handleSend = useCallback(() => {
+    // Guest mode: capture sender identity first (the anonymous Supabase
+    // JWT has no email, so the API needs it in the body). The
+    // template-confirm and actual send fire from inside the dialog's
+    // onConfirm handler.
+    if (guest) {
+      setGuestSenderOpen(true);
+      return;
+    }
     // When the draft was started from a saved template, prompt the
     // user with the "update template too?" dialog before sending.
     // Plain drafts (no template provenance) skip straight to send.
@@ -294,7 +308,29 @@ export function DocumentRoute() {
     runSend().catch(() => {
       /* surfaced via setSendError inside runSend */
     });
-  }, [doc?.fromTemplateId, runSend]);
+  }, [doc?.fromTemplateId, guest, runSend]);
+
+  const handleGuestSenderConfirm = useCallback(
+    (email: string, name?: string) => {
+      setGuestSenderOpen(false);
+      // Same template-prompt branching as the authed path, just
+      // threaded with the captured guest sender identity.
+      if (doc?.fromTemplateId) {
+        // Stash sender for the SendConfirmDialog branches via runSend
+        // bound below — for guest+template, skip the prompt and just
+        // send. (The "update template" choice is meaningless to a
+        // guest who has no persisted templates.)
+        runSend(email, name).catch(() => {
+          /* surfaced via setSendError */
+        });
+        return;
+      }
+      runSend(email, name).catch(() => {
+        /* surfaced via setSendError */
+      });
+    },
+    [doc?.fromTemplateId, runSend],
+  );
 
   const handleSendJust = useCallback(() => {
     setSendConfirmOpen(false);
@@ -454,6 +490,11 @@ export function DocumentRoute() {
         onSendAndUpdate={handleSendAndUpdate}
         onJustSend={handleSendJust}
         onCancel={() => setSendConfirmOpen(false)}
+      />
+      <GuestSenderEmailDialog
+        open={guestSenderOpen}
+        onConfirm={handleGuestSenderConfirm}
+        onCancel={() => setGuestSenderOpen(false)}
       />
       {toast ? (
         <Toast

--- a/apps/web/src/routes/TemplateEditorRoute.tsx
+++ b/apps/web/src/routes/TemplateEditorRoute.tsx
@@ -7,6 +7,7 @@ import { TemplateModeBanner } from '../components/TemplateModeBanner';
 import { Toast } from '../components/Toast';
 import { SendConfirmDialog } from '../components/SendConfirmDialog';
 import { ExitConfirmDialog } from '../components/ExitConfirmDialog';
+import { GuestSenderEmailDialog } from '../components/GuestSenderEmailDialog';
 import { SendingOverlay } from '../components/SendingOverlay';
 import type { AddSignerContact } from '../components/AddSignerDropdown/AddSignerDropdown.types';
 import type { PlacedFieldValue } from '../components/PlacedField/PlacedField.types';
@@ -379,6 +380,7 @@ export function TemplateEditorRoute() {
   const [pendingNav, setPendingNav] = useState<string | null>(null);
   const [sendError, setSendError] = useState<string | null>(null);
   const [sendConfirmOpen, setSendConfirmOpen] = useState(false);
+  const [guestSenderOpen, setGuestSenderOpen] = useState(false);
   const [toast, setToast] = useState<{
     readonly title: string;
     readonly subtitle?: string | undefined;
@@ -540,58 +542,74 @@ export function TemplateEditorRoute() {
     [],
   );
 
-  const runSend = useCallback(async () => {
-    if (!draft || !draft.file) return;
-    setSendError(null);
-    if (guest) {
-      sendDocument(draft.id);
-      navigate(`/document/${draft.id}/sent`);
-      return;
-    }
-    try {
-      const result = await sendEnvelope.run({
-        title: draft.title,
-        file: draft.file,
-        signers: draft.signers.map((s) => ({ contactId: s.id })),
-        buildFields: (contactIdToSignerId) => {
-          const out: FieldPlacement[] = [];
-          for (const f of draft.fields) {
-            const normalized = toNormalized(f);
-            for (const localSignerId of f.signerIds) {
-              const serverSignerId = contactIdToSignerId.get(localSignerId);
-              if (serverSignerId) {
-                const placement: FieldPlacement = {
-                  signer_id: serverSignerId,
-                  kind: f.type as FieldKind,
-                  page: f.page,
-                  x: normalized.x,
-                  y: normalized.y,
-                  required: f.required ?? true,
-                  ...(normalized.width !== undefined ? { width: normalized.width } : {}),
-                  ...(normalized.height !== undefined ? { height: normalized.height } : {}),
-                  ...(f.linkId ? { link_id: f.linkId } : {}),
-                };
-                out.push(placement);
+  const runSend = useCallback(
+    async (senderEmail?: string, senderName?: string) => {
+      if (!draft || !draft.file) return;
+      setSendError(null);
+      try {
+        const result = await sendEnvelope.run({
+          title: draft.title,
+          file: draft.file,
+          signers: draft.signers.map((s) => ({ contactId: s.id })),
+          buildFields: (contactIdToSignerId) => {
+            const out: FieldPlacement[] = [];
+            for (const f of draft.fields) {
+              const normalized = toNormalized(f);
+              for (const localSignerId of f.signerIds) {
+                const serverSignerId = contactIdToSignerId.get(localSignerId);
+                if (serverSignerId) {
+                  const placement: FieldPlacement = {
+                    signer_id: serverSignerId,
+                    kind: f.type as FieldKind,
+                    page: f.page,
+                    x: normalized.x,
+                    y: normalized.y,
+                    required: f.required ?? true,
+                    ...(normalized.width !== undefined ? { width: normalized.width } : {}),
+                    ...(normalized.height !== undefined ? { height: normalized.height } : {}),
+                    ...(f.linkId ? { link_id: f.linkId } : {}),
+                  };
+                  out.push(placement);
+                }
               }
             }
-          }
-          return out;
-        },
-      });
-      sendDocument(draft.id);
-      navigate(`/document/${result.envelope_id}/sent`);
-    } catch (err) {
-      setSendError(err instanceof Error ? err.message : 'Unable to send the document.');
-    }
-  }, [draft, guest, navigate, sendDocument, sendEnvelope, toNormalized]);
+            return out;
+          },
+          ...(senderEmail !== undefined ? { senderEmail } : {}),
+          ...(senderName !== undefined ? { senderName } : {}),
+        });
+        sendDocument(draft.id);
+        navigate(`/document/${result.envelope_id}/sent`);
+      } catch (err) {
+        setSendError(err instanceof Error ? err.message : 'Unable to send the document.');
+      }
+    },
+    [draft, navigate, sendDocument, sendEnvelope, toNormalized],
+  );
 
   const handleSend = useCallback(() => {
+    // Guest mode: capture sender identity first so the API can fall back
+    // to the body when the JWT (anonymous Supabase session) lacks email.
+    if (guest) {
+      setGuestSenderOpen(true);
+      return;
+    }
     if (sourceTemplate) {
       setSendConfirmOpen(true);
       return;
     }
     runSend().catch(() => {});
-  }, [sourceTemplate, runSend]);
+  }, [guest, sourceTemplate, runSend]);
+
+  const handleGuestSenderConfirm = useCallback(
+    (email: string, name?: string) => {
+      setGuestSenderOpen(false);
+      // Guests have no persisted templates, so there's no "update
+      // template" choice to surface — go straight to send.
+      runSend(email, name).catch(() => {});
+    },
+    [runSend],
+  );
 
   const handleSendJust = useCallback(() => {
     setSendConfirmOpen(false);
@@ -809,6 +827,11 @@ export function TemplateEditorRoute() {
         onSendAndUpdate={handleSendAndUpdate}
         onJustSend={handleSendJust}
         onCancel={() => setSendConfirmOpen(false)}
+      />
+      <GuestSenderEmailDialog
+        open={guestSenderOpen}
+        onConfirm={handleGuestSenderConfirm}
+        onCancel={() => setGuestSenderOpen(false)}
       />
       {toast ? (
         <Toast

--- a/apps/web/src/test/renderWithProviders.tsx
+++ b/apps/web/src/test/renderWithProviders.tsx
@@ -34,7 +34,7 @@ function buildContext(override: Partial<AuthContextValue>): AuthContextValue {
     signInWithGoogle: asyncNoop,
     resetPassword: asyncNoop,
     signOut: asyncNoop,
-    enterGuestMode: noop,
+    enterGuestMode: asyncNoop,
     exitGuestMode: noop,
     ...override,
   };


### PR DESCRIPTION
## Summary

Guest users hitting **Send to sign** were never reaching the API: the envelope stayed local, no invite email was queued. This PR fixes that with a minimal anonymous-Supabase-session approach (Option A).

## Root cause

- `apiClient` injects the Authorization header from the Supabase session. Guests had no session → no token → all backend calls would have been rejected by the global `AuthGuard`.
- To compensate, the SPA short-circuited the send flow (`if (guest) { sendDocument(...); navigate(...) }` in `DocumentRoute.tsx` and `TemplateEditorRoute.tsx`) — only mutating local state to `awaiting-others` without ever calling `POST /envelopes/:id/send`. No real envelope, no invite email.

## Fix (Option A — anonymous Supabase session)

**Frontend (`apps/web`)**
- `AuthProvider.enterGuestMode()` is now async — calls `supabase.auth.signInAnonymously()` first, then flips the guest flag. Rolls back the guest flag if Supabase fails.
- Both `getSession()` callback and `onAuthStateChange` listener filter `is_anonymous` so anon sessions don't clobber the guest flag (regression-tested).
- New `GuestSenderEmailDialog` opens for guest users on send, capturing `sender_email` + optional `sender_name` so the invite email has a real sender.
- Removed the `if (guest) { ... return }` short-circuits in `DocumentRoute.tsx` + `TemplateEditorRoute.tsx`. Guests now flow through `useSendEnvelope` like every other user.
- `useSendEnvelope.SendEnvelopeInput` extended with optional `senderEmail` / `senderName`; forwarded as request body to the API.

**Backend (`apps/api`)**
- New `SendEnvelopeDto` with class-validator: optional `sender_email` (`@IsEmail`, max 254) + `sender_name` (max 120).
- `EnvelopesController.send()` and `remindSigner()` accept the DTO and resolve the sender using **JWT-wins anti-spoofing**: `sender_email = user.email ?? dto.sender_email ?? null`. Throws `BadRequestException('sender_email_missing')` when both are absent.
- Body field is consulted only when the JWT lacks `email` (i.e., anon Supabase sessions). Authenticated users **cannot** spoof a different sender.

## Verification

- **Web:** vitest 1061/1061 ✓ (typecheck + lint clean)
- **API:** typecheck + lint ✓; new tests cover all 4 send branches (JWT/anon/neither/both) and 3 e2e anon cases
- **Pre-commit gate** (multi-package typecheck + lint + scoped tests) passed before commit; one `JSX.Element` namespace error caught by the hook and fixed in place — no `--no-verify`

### New tests
- `apps/web/src/components/GuestSenderEmailDialog/GuestSenderEmailDialog.test.tsx` — 7 cases (open/closed, validation, trim, name optional, cancel)
- `apps/web/src/providers/AuthProvider.test.tsx` — 5 cases (anon provisioning, rollback, listener-no-clobber, guest-clear on named session)
- `apps/api/src/envelopes/envelopes.controller.spec.ts` — 4 send + 3 remind cases
- `apps/api/src/envelopes/dto/dtos.spec.ts` — 7 SendEnvelopeDto validation cases
- `apps/api/test/envelopes-sender.e2e-spec.ts` — 3 anon e2e cases

## Operational requirement

**The Supabase project must have *Anonymous Sign-ins* enabled** (Authentication → Providers → Anonymous). Without it, `signInAnonymously` throws and the user sees the inline error toast on Skip. Production project already has this enabled; staging/dev may need flipping.

## Test plan

- [ ] CI install/lint/unit/web/e2e/BDD all green
- [ ] Manual: incognito → Skip on signin → upload PDF → place fields → Send to sign → dialog opens → enter email → envelope appears in `/documents` → invite email arrives at the signer's address
- [ ] Manual: authed user send still works (JWT email used, no dialog shown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)