### PR TITLE
fix(docker): copy patches/ before pnpm install (post-PR-89 image build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,12 @@ FROM base AS deps
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/api/package.json ./apps/api/
 COPY packages/shared/package.json ./packages/shared/
+# pnpm.patchedDependencies in package.json points at files under patches/
+# (e.g. cucumber-messages@8.0.0.patch). pnpm hashes these files during
+# `install --frozen-lockfile` to validate the lockfile entry, so the
+# directory MUST be present in the build context before the install step
+# — otherwise pnpm exits with ENOENT on the patch path.
+COPY patches ./patches
 # apps/web is excluded from the API image since we only serve API traffic
 # from the container. The web app deploys separately (Vercel / static host).
 ENV HUSKY=0


### PR DESCRIPTION
## Summary
- PR #89 added `pnpm.patchedDependencies` for `cucumber-messages@8.0.0` pointing at `patches/cucumber-messages@8.0.0.patch`
- The Dockerfile `deps` stage never copied `patches/` into the image context, so `pnpm install --frozen-lockfile` exited with `ENOENT: no such file or directory, open '/app/patches/cucumber-messages@8.0.0.patch'`
- Both downstream image builds on the post-PR-89 main pushes failed:
  - `Build + push image` (run [25247346494](https://github.com/eliranRP/seald/actions/runs/25247346494))
  - `Deploy (SSH pull + compose up)` (run [25247346491](https://github.com/eliranRP/seald/actions/runs/25247346491))
- Fix: `COPY patches ./patches` between the manifest COPYs and the install RUN, with an inline comment so future patches don't trip the same wire

## Test plan
- [x] `pnpm install --frozen-lockfile` clean (patch hash matches lockfile)
- [x] `pnpm why uuid` confirms cucumber-messages still resolves uuid@14.0.0 (no uuid 3.x — security posture intact)
- [x] `pnpm -r typecheck`, `pnpm -r lint` pass
- [x] `pnpm --filter api test` — 768 / 768 pass
- [x] `pnpm --filter web test` — 1080 / 1080 pass
- [x] `pnpm --filter api test:e2e` — 144 / 146 pass (2 skipped as in main)
- [ ] CI image builds (`Build + push image`, `Deploy (SSH ...)`) succeed on this PR