### PR TITLE
fix(guest-mode): persist envelope_id + gate authed routes + rehydrate anon JWT

### DIFF
--- a/apps/web/e2e/guest-flow.spec.ts
+++ b/apps/web/e2e/guest-flow.spec.ts
@@ -40,6 +40,61 @@ interface GuestApiCallLog {
 async function installGuestMocks(page: Page): Promise<GuestApiCallLog> {
   const log: GuestApiCallLog = { contactsPostAttempts: 0 };
 
+  // Supabase auth mock — the AuthProvider now re-issues an anonymous
+  // session on hydration when `sealed.guest=1` but `getSession()` came
+  // back empty (closes the production failure mode where access tokens
+  // expired but the localStorage flag persisted, leaving the SPA acting
+  // as a guest with no JWT). Without this stub the spec would hit the
+  // real Supabase project (which has anonymous sign-ins disabled in
+  // shared envs) and the hydration fallback would drop the guest flag,
+  // bouncing the test off /document/new.
+  await page.route('**/auth/v1/signup**', async (route: Route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-anon-access-token',
+          refresh_token: 'e2e-anon-refresh-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          user: {
+            id: 'e2e-anon-user',
+            email: null,
+            is_anonymous: true,
+            aud: 'authenticated',
+            role: 'authenticated',
+          },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  // The supabase-js client polls `/auth/v1/user` and `/auth/v1/token` once
+  // a session is loaded. Both are 200/empty here so the polling loop
+  // doesn't error out the SPA.
+  await page.route('**/auth/v1/user**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'e2e-anon-user', is_anonymous: true }),
+    });
+  });
+  await page.route('**/auth/v1/token**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'e2e-anon-access-token',
+        refresh_token: 'e2e-anon-refresh-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user: { id: 'e2e-anon-user', is_anonymous: true },
+      }),
+    });
+  });
+
   // Real backend behavior for an unauthenticated request: 401.
   // The fix under test must NOT depend on this response succeeding.
   await page.route('**/api/contacts', async (route: Route) => {
@@ -236,5 +291,25 @@ test.describe('guest mode — full sender flow', () => {
     await senderDialog.getByRole('button', { name: /^continue$/i }).click();
     await page.waitForURL(/\/document\/[^/]+\/sent$/, { timeout: 15_000 });
     await expect(page).toHaveURL(/\/document\/[^/]+\/sent$/);
+
+    // ---- Confirmation page must render the handoff summary on the
+    // server-uuid URL. Pre-fix this asserted "Document not found" because
+    // `getDocument(<server-uuid>)` returned undefined — the in-memory
+    // draft was only addressable by its local `d_xxx` id. The fix
+    // persists `envelope_id` on the local draft so post-send lookup
+    // resolves.
+    await expect(
+      page.getByRole('heading', { level: 1, name: /sent\. your envelope is on its way/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/guest-signer@example\.com/i)).toBeVisible();
+
+    // ---- "Back to documents" must NOT bounce a guest off the dashboard
+    // (which is gated by RequireAuth, not RequireAuthOrGuest). Pre-fix
+    // the click navigated to /documents which then redirected the guest
+    // back to /document/new — flashing the editor again, which the user
+    // reported as "the screen jumps back to the signature fields screen".
+    await page.getByRole('button', { name: /back to documents/i }).click();
+    await page.waitForURL(/\/document\/new$/, { timeout: 5_000 });
+    await expect(page).toHaveURL(/\/document\/new$/);
   });
 });

--- a/apps/web/e2e/template-sign-flow.spec.ts
+++ b/apps/web/e2e/template-sign-flow.spec.ts
@@ -152,6 +152,60 @@ interface ApiCallLog {
 async function installMocks(page: Page): Promise<ApiCallLog> {
   const log = { contacts: 0, signFinish: 0, signPdf: 0 };
 
+  // --- Supabase auth: mint an anonymous session on hydration.
+  // The AuthProvider re-issues an anonymous Supabase session when
+  // `sealed.guest=1` is set but `getSession()` returned null (closes
+  // the prod failure mode where access tokens expired but the localStorage
+  // flag persisted). In CI the dev server points VITE_SUPABASE_URL at a
+  // dead loopback (`http://127.0.0.1:54321`), so without this stub
+  // `signInAnonymously()` would error out, the AuthProvider would drop
+  // the guest flag, and `RequireAuthOrGuest` would redirect to /signin
+  // before the dropzone ever renders. Same shape as
+  // `e2e/guest-flow.spec.ts#installGuestMocks`.
+  await page.route('**/auth/v1/signup**', async (route: Route) => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          access_token: 'e2e-anon-access-token',
+          refresh_token: 'e2e-anon-refresh-token',
+          token_type: 'bearer',
+          expires_in: 3600,
+          user: {
+            id: 'e2e-anon-user',
+            email: null,
+            is_anonymous: true,
+            aud: 'authenticated',
+            role: 'authenticated',
+          },
+        }),
+      });
+      return;
+    }
+    await route.fallback();
+  });
+  await page.route('**/auth/v1/user**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ id: 'e2e-anon-user', is_anonymous: true }),
+    });
+  });
+  await page.route('**/auth/v1/token**', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        access_token: 'e2e-anon-access-token',
+        refresh_token: 'e2e-anon-refresh-token',
+        token_type: 'bearer',
+        expires_in: 3600,
+        user: { id: 'e2e-anon-user', is_anonymous: true },
+      }),
+    });
+  });
+
   // --- Sender: envelope create + upload + signers + fields + send.
   // Guest mode now goes through the same `/envelopes/*` API path as
   // authed users (anonymous Supabase JWT). Mock the full chain so

--- a/apps/web/src/lib/mockApi/types.ts
+++ b/apps/web/src/lib/mockApi/types.ts
@@ -52,6 +52,18 @@ export interface AppDocument {
    * drafts.
    */
   readonly fromTemplateFreshUpload?: boolean | undefined;
+  /**
+   * Server envelope id assigned by `POST /envelopes` once the draft has been
+   * published via `useSendEnvelope`. Stored back on the local draft so
+   * post-send navigation (which uses the server uuid in the URL) can still
+   * resolve the in-memory record by `getDocument(envelopeId)` — without this
+   * the `/document/:id/sent` and `/document/:id` routes would lose the
+   * draft state, blanking the SentConfirmationPage and the editor surface
+   * for guest senders who have no `/envelopes/:id` query fallback (their
+   * anonymous session can't retrieve a sealed envelope owned by the same
+   * anon user reliably across reloads).
+   */
+  readonly envelopeId?: string | undefined;
 }
 
 export interface AppUser {

--- a/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.test.tsx
+++ b/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { renderWithProviders } from '../../test/renderWithProviders';
 
 // The page resolves the envelope via either local AppState (drafts) or
@@ -64,5 +65,70 @@ describe('SentConfirmationPage', () => {
       await screen.findByRole('heading', { level: 1, name: /sent\. your envelope is on its way/i }),
     ).toBeInTheDocument();
     expect(await screen.findByText(/maya raskin/i)).toBeInTheDocument();
+  });
+
+  it('"Back to documents" sends a guest to /document/new (not /documents)', async () => {
+    // `/documents` is gated by `RequireAuth` (not `RequireAuthOrGuest`)
+    // so a guest landing there bounces back to `/document/new`. The
+    // SentConfirmationPage now points the CTA straight at `/document/new`
+    // for guests to skip the round-trip flash that surfaced the
+    // user-reported "screen jumps back to fields" symptom.
+    function LocationProbe(): React.ReactElement {
+      const loc = useLocation();
+      return <div data-pathname>{loc.pathname}</div>;
+    }
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/sent/env-test']}>
+        <Routes>
+          <Route
+            path="/sent/:id"
+            element={
+              <>
+                <SentConfirmationPage />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route path="/document/new" element={<LocationProbe />} />
+          <Route path="/documents" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+      { auth: { guest: true, user: null } },
+    );
+
+    // Wait for the page to hydrate from the API stub.
+    await screen.findByRole('heading', { level: 1, name: /sent\. your envelope is on its way/i });
+
+    const backBtn = screen.getByRole('button', { name: /back to documents/i });
+    await userEvent.click(backBtn);
+
+    const probe = await screen.findByText('/document/new');
+    expect(probe).toBeInTheDocument();
+  });
+
+  it('"Back to documents" sends an authed user to /documents', async () => {
+    function LocationProbe(): React.ReactElement {
+      const loc = useLocation();
+      return <div data-pathname>{loc.pathname}</div>;
+    }
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/sent/env-test']}>
+        <Routes>
+          <Route
+            path="/sent/:id"
+            element={
+              <>
+                <SentConfirmationPage />
+                <LocationProbe />
+              </>
+            }
+          />
+          <Route path="/documents" element={<LocationProbe />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await screen.findByRole('heading', { level: 1, name: /sent\. your envelope is on its way/i });
+    await userEvent.click(screen.getByRole('button', { name: /back to documents/i }));
+    expect(await screen.findByText('/documents')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.tsx
+++ b/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.tsx
@@ -6,6 +6,7 @@ import { DocThumb } from '@/components/DocThumb';
 import { Skeleton } from '@/components/Skeleton';
 import { useEnvelopeQuery } from '@/features/envelopes';
 import { useAppState } from '@/providers/AppStateProvider';
+import { useAuth } from '@/providers/AuthProvider';
 import {
   Actions,
   AuditBadge,
@@ -59,6 +60,12 @@ export function SentConfirmationPage() {
   const params = useParams<{ readonly id: string }>();
   const navigate = useNavigate();
   const { getDocument } = useAppState();
+  const { guest } = useAuth();
+  // `/documents` is gated by `RequireAuth` (not `RequireAuthOrGuest`), so a
+  // guest sender clicking "Back to documents" would get bounced back to
+  // `/document/new`. Steer them straight there to avoid the round-trip
+  // flash. Authed users continue to land on the dashboard list.
+  const documentsHref = guest ? '/document/new' : '/documents';
   const draft = params.id ? getDocument(params.id) : undefined;
 
   // Only fetch from the server when the local draft is missing — saves a
@@ -106,7 +113,7 @@ export function SentConfirmationPage() {
           <Title>Document not found</Title>
           <Body>We couldn&apos;t find this document. It may have been removed.</Body>
           <Actions>
-            <Button variant="primary" onClick={() => navigate('/documents')}>
+            <Button variant="primary" onClick={() => navigate(documentsHref)}>
               Back to documents
             </Button>
           </Actions>
@@ -117,7 +124,7 @@ export function SentConfirmationPage() {
 
   const openEnvelope = (): void => {
     if (params.id) navigate(`/document/${params.id}`);
-    else navigate('/documents');
+    else navigate(documentsHref);
   };
 
   return (
@@ -188,7 +195,7 @@ export function SentConfirmationPage() {
           <Button variant="primary" iconLeft={ShieldCheck} onClick={openEnvelope}>
             View envelope
           </Button>
-          <Button variant="secondary" iconLeft={LayoutList} onClick={() => navigate('/documents')}>
+          <Button variant="secondary" iconLeft={LayoutList} onClick={() => navigate(documentsHref)}>
             Back to documents
           </Button>
         </Actions>

--- a/apps/web/src/providers/AppStateProvider.test.tsx
+++ b/apps/web/src/providers/AppStateProvider.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { ReactElement, ReactNode } from 'react';
+import { act, renderHook } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthContext, type AuthContextValue } from './AuthProvider';
+import { AppStateProvider, useAppState } from './AppStateProvider';
+import { seald } from '../styles/theme';
+
+// The contacts hooks fan out to the apiClient — stub them so the provider
+// boots without trying to fetch in the test environment.
+vi.mock('../features/contacts', () => ({
+  useContactsQuery: () => ({ data: [], isPending: false }),
+  useCreateContactMutation: () => ({ mutateAsync: vi.fn() }),
+  useUpdateContactMutation: () => ({ mutateAsync: vi.fn() }),
+  useDeleteContactMutation: () => ({ mutateAsync: vi.fn() }),
+}));
+
+const guestAuth: AuthContextValue = {
+  session: null,
+  user: null,
+  guest: true,
+  loading: false,
+  signInWithPassword: async () => {},
+  signUpWithPassword: async () => ({ needsEmailConfirmation: false }),
+  signInWithGoogle: async () => {},
+  resetPassword: async () => {},
+  signOut: async () => {},
+  enterGuestMode: async () => {},
+  exitGuestMode: () => {},
+};
+
+function wrapper({ children }: { readonly children: ReactNode }): ReactElement {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <ThemeProvider theme={seald}>
+      <QueryClientProvider client={qc}>
+        <AuthContext.Provider value={guestAuth}>
+          <AppStateProvider>{children}</AppStateProvider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    </ThemeProvider>
+  );
+}
+
+function newPdf(name: string): File {
+  return new File([new Uint8Array([0x25, 0x50, 0x44, 0x46])], name, { type: 'application/pdf' });
+}
+
+describe('AppStateProvider', () => {
+  it('createDocument returns a local id resolvable by getDocument', () => {
+    const { result } = renderHook(() => useAppState(), { wrapper });
+    let id = '';
+    act(() => {
+      id = result.current.createDocument(newPdf('a.pdf'), 1);
+    });
+    expect(id).toMatch(/^d_/);
+    const doc = result.current.getDocument(id);
+    expect(doc?.title).toBe('a');
+    expect(doc?.envelopeId).toBeUndefined();
+  });
+
+  it('sendDocument(id, envelopeId) persists envelopeId and getDocument(envelopeId) resolves the same draft', () => {
+    // This is the assertion that fails on pre-fix code: post-send the
+    // SPA navigates to `/document/<envelope-uuid>/sent` and tries to
+    // resolve the local draft via `getDocument(envelope-uuid)` — which
+    // returned `undefined` before the fix because lookup was strictly
+    // by local id (`d_xxx`). The result was the SentConfirmationPage's
+    // "Document not found" fallback for guest senders, exactly the
+    // user-reported "screen jumps back to fields" symptom.
+    const { result } = renderHook(() => useAppState(), { wrapper });
+    let localId = '';
+    act(() => {
+      localId = result.current.createDocument(newPdf('contract.pdf'), 1);
+    });
+
+    const envelopeId = 'env-uuid-7c1b';
+    act(() => {
+      result.current.sendDocument(localId, envelopeId);
+    });
+
+    // Both ids must resolve to the same in-memory draft.
+    const byLocal = result.current.getDocument(localId);
+    const byEnvelope = result.current.getDocument(envelopeId);
+    expect(byLocal).toBeDefined();
+    expect(byEnvelope).toBeDefined();
+    expect(byEnvelope?.id).toBe(localId);
+    expect(byEnvelope?.envelopeId).toBe(envelopeId);
+    expect(byEnvelope?.status).toBe('awaiting-others');
+  });
+
+  it('sendDocument without envelopeId leaves the field undefined (back-compat)', () => {
+    const { result } = renderHook(() => useAppState(), { wrapper });
+    let localId = '';
+    act(() => {
+      localId = result.current.createDocument(newPdf('b.pdf'), 1);
+    });
+    act(() => {
+      result.current.sendDocument(localId);
+    });
+    const doc = result.current.getDocument(localId);
+    expect(doc?.envelopeId).toBeUndefined();
+    expect(doc?.status).toBe('awaiting-others');
+  });
+});

--- a/apps/web/src/providers/AppStateProvider.tsx
+++ b/apps/web/src/providers/AppStateProvider.tsx
@@ -43,7 +43,13 @@ export interface AppStateValue {
   readonly getDocument: (id: string) => AppDocument | undefined;
   readonly createDocument: (file: File, totalPages: number) => string;
   readonly updateDocument: (id: string, patch: Partial<AppDocument>) => void;
-  readonly sendDocument: (id: string) => void;
+  /**
+   * Mark a local draft as sent. Pass `envelopeId` when the server-side
+   * `/envelopes` POST returned an id so subsequent `getDocument(envelopeId)`
+   * lookups (used by `/document/:id/sent` and `/document/:id` after the
+   * post-send redirect) can still resolve the draft.
+   */
+  readonly sendDocument: (id: string, envelopeId?: string) => void;
   readonly deleteDocument: (id: string) => void;
   readonly addContact: (name: string, email: string) => Promise<AddSignerContact>;
   readonly updateContact: (id: string, patch: { name?: string; email?: string }) => Promise<void>;
@@ -115,7 +121,14 @@ export function AppStateProvider(props: AppStateProviderProps) {
   const loading = contactsLoading;
 
   const getDocument = useCallback(
-    (id: string): AppDocument | undefined => documents.find((d) => d.id === id),
+    // Accept either the local draft id (`d_<rand>`) or the server-assigned
+    // envelope uuid stored on the draft after `sendDocument(id, envelopeId)`.
+    // Without the envelopeId branch the post-send redirect to
+    // `/document/<envelope-uuid>/sent` would lose the local draft and
+    // `SentConfirmationPage` would render the "Document not found" fallback
+    // for guest senders.
+    (id: string): AppDocument | undefined =>
+      documents.find((d) => d.id === id || d.envelopeId === id),
     [documents],
   );
 
@@ -144,14 +157,30 @@ export function AppStateProvider(props: AppStateProviderProps) {
     setDocuments((prev) => prev.map((d) => (d.id === id ? { ...d, ...patch } : d)));
   }, []);
 
-  const sendDocument = useCallback((id: string): void => {
+  const sendDocument = useCallback((id: string, envelopeId?: string): void => {
     // Mark the local draft as awaiting-others so SentConfirmationPage can
     // keep rendering the handoff summary. The server-authoritative record
     // lives under `/envelopes/:id` once `useSendEnvelope` publishes the
     // draft; the dashboard will show it on next refetch.
+    //
+    // When `envelopeId` is provided we also persist it on the local draft
+    // so post-send navigation (which uses the server uuid in the URL) can
+    // still resolve the draft via `getDocument`. This is what lets the
+    // SentConfirmationPage render the handoff summary on `/document/<uuid>/sent`
+    // and lets a click on "View envelope" land back on the editor with
+    // the original draft state instead of an empty fallback.
     const nowIso = new Date().toISOString();
     setDocuments((prev) =>
-      prev.map((d) => (d.id === id ? { ...d, status: 'awaiting-others', updatedAt: nowIso } : d)),
+      prev.map((d) =>
+        d.id === id
+          ? {
+              ...d,
+              status: 'awaiting-others',
+              updatedAt: nowIso,
+              ...(envelopeId !== undefined ? { envelopeId } : {}),
+            }
+          : d,
+      ),
     );
   }, []);
 

--- a/apps/web/src/providers/AuthProvider.test.tsx
+++ b/apps/web/src/providers/AuthProvider.test.tsx
@@ -143,6 +143,62 @@ describe('AuthProvider', () => {
     expect(window.localStorage.getItem('sealed.guest')).toBe(null);
   });
 
+  it('hydration re-issues an anonymous session when sealed.guest=1 but getSession returns null', async () => {
+    // Reproduces the production failure mode behind the user-reported
+    // "send not sent" bug: the SPA boots with the guest flag still in
+    // localStorage (e.g. left over from a prior session whose access
+    // token has since expired) but `getSession()` resolves to null. The
+    // apiClient would attach no Bearer token and every API call would
+    // 401. The fix mints a fresh anonymous session on hydration so the
+    // guest flow works without forcing the user back through the
+    // signup → Skip flow.
+    window.localStorage.setItem('sealed.guest', '1');
+    supabaseAuth.getSession.mockResolvedValueOnce({ data: { session: null } });
+    supabaseAuth.signInAnonymously.mockResolvedValueOnce({ data: null, error: null });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(supabaseAuth.signInAnonymously).toHaveBeenCalledTimes(1);
+    // Flag stays set — the listener will pick up the new anon session.
+    expect(window.localStorage.getItem('sealed.guest')).toBe('1');
+    expect(result.current.guest).toBe(true);
+  });
+
+  it('hydration drops the guest flag if signInAnonymously fails on rehydrate', async () => {
+    // Defence in depth: when the Supabase project disables anonymous
+    // sign-ins, the rehydrate attempt returns an error. We must not
+    // leave the SPA in "acts like guest, has no JWT" purgatory — drop
+    // the flag so RequireAuthOrGuest will redirect to /signin instead.
+    window.localStorage.setItem('sealed.guest', '1');
+    supabaseAuth.getSession.mockResolvedValueOnce({ data: { session: null } });
+    supabaseAuth.signInAnonymously.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Anonymous sign-ins are disabled' },
+    });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(supabaseAuth.signInAnonymously).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem('sealed.guest')).toBe(null);
+    expect(result.current.guest).toBe(false);
+  });
+
+  it('hydration does NOT call signInAnonymously when an existing session is present', async () => {
+    // Healthy case: the persisted refresh token already produced an
+    // access token. We must not waste a round-trip minting a new anon
+    // session on top.
+    window.localStorage.setItem('sealed.guest', '1');
+    supabaseAuth.getSession.mockResolvedValueOnce({ data: { session: makeAnonSession() } });
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(supabaseAuth.signInAnonymously).not.toHaveBeenCalled();
+    expect(result.current.guest).toBe(true);
+  });
+
   it('renders children without throwing', () => {
     const view = render(
       <AuthProvider>

--- a/apps/web/src/providers/AuthProvider.tsx
+++ b/apps/web/src/providers/AuthProvider.tsx
@@ -100,7 +100,7 @@ export function AuthProvider(props: AuthProviderProps) {
     let cancelled = false;
     supabase.auth
       .getSession()
-      .then(({ data }) => {
+      .then(async ({ data }) => {
         if (cancelled) return;
         setSession(data.session ?? null);
         // Anonymous sessions intentionally keep `guest === true`. Only a
@@ -109,7 +109,35 @@ export function AuthProvider(props: AuthProviderProps) {
           setGuest(false);
           writeGuestFlag(false);
         }
-        setLoading(false);
+        // Re-issue the anonymous session if the user previously entered
+        // guest mode but `getSession()` came back empty (Supabase access
+        // tokens expire after ~1h by default — the persisted refresh
+        // token is what normally rehydrates them, but if that's missing
+        // too we need to mint a new anon session so the apiClient has a
+        // Bearer token to attach. Without this the SPA renders as
+        // "guest mode" but every API call 401s, exactly the symptom
+        // behind the user-reported "send not sent" bug).
+        if (!data.session && readGuestFlag()) {
+          try {
+            const { error } = await supabase.auth.signInAnonymously();
+            if (cancelled) return;
+            if (error) {
+              // Anonymous provider disabled or quota hit — drop the flag
+              // so the route guard can redirect to /signin instead of
+              // leaving the user in a half-authenticated state.
+              setGuest(false);
+              writeGuestFlag(false);
+            }
+            // The `onAuthStateChange` listener below will pick up the
+            // newly-issued session; no need to setSession here.
+          } catch {
+            if (!cancelled) {
+              setGuest(false);
+              writeGuestFlag(false);
+            }
+          }
+        }
+        if (!cancelled) setLoading(false);
       })
       .catch(() => {
         if (!cancelled) setLoading(false);
@@ -221,7 +249,17 @@ export function AuthProvider(props: AuthProviderProps) {
     writeGuestFlag(false);
   }, []);
 
-  const user = useMemo<AuthUser | null>(() => toAuthUser(session?.user), [session]);
+  const user = useMemo<AuthUser | null>(() => {
+    // Anonymous Supabase sessions intentionally surface as `user === null`
+    // — the rest of the SPA treats `user !== null` as "named-account
+    // signed in" (used by NavBar to flip the primary nav, by AppState to
+    // enable the contacts query, etc). The hydration re-issue path (see
+    // useEffect above) creates anon sessions with `is_anonymous: true`,
+    // and we must not let those flip the SPA out of guest mode.
+    if (!session?.user) return null;
+    if (session.user.is_anonymous) return null;
+    return toAuthUser(session.user);
+  }, [session]);
 
   const value = useMemo<AuthContextValue>(
     () => ({

--- a/apps/web/src/routes/DocumentRoute.tsx
+++ b/apps/web/src/routes/DocumentRoute.tsx
@@ -266,7 +266,13 @@ export function DocumentRoute() {
           ...(senderName !== undefined ? { senderName } : {}),
         });
 
-        sendDocument(doc.id);
+        // Persist the server envelope id back onto the local draft so the
+        // post-send redirect (which puts the server uuid in the URL) can
+        // still resolve the draft via `getDocument`. Without this the
+        // SentConfirmationPage would render its "Document not found"
+        // fallback for guest senders, and "View envelope" from /sent would
+        // land on an empty editor instead of the original draft.
+        sendDocument(doc.id, result.envelope_id);
         navigate(`/document/${result.envelope_id}/sent`);
       } catch (err) {
         setSendError(err instanceof Error ? err.message : 'Unable to send the document.');


### PR DESCRIPTION
## Summary
- Closes 5 user-facing guest-mode bugs surfaced by a live walk through the SPA.
- Reproducer + regression coverage: 8 new vitest tests + e2e covering the full guest send chain.
- All scoped gates green locally (typecheck / lint / vitest / playwright guest-flow.spec.ts).

## Bugs fixed
1. **POST /envelopes 401 after refresh** — `AuthProvider` now re-issues an anonymous Supabase session on hydration when `sealed.guest=1` but `getSession()` returned null. Drops the flag (+ falls back to `/signin`) if the provider is disabled.
2. **NavBar flipped to authed primary nav while in guest mode** — anon sessions are now filtered out of `user`, preserving the `user !== null` semantics ("named-account signed in").
3. **`SentConfirmationPage` rendered "Document not found" after send** — `AppStateProvider.sendDocument` now persists the server `envelope_id` on the local draft so `getDocument(envelope_id)` resolves the same in-memory record. `DocumentRoute` passes the id through.
4. **"Back to documents" bounced guests off `/documents`** (which is `RequireAuth`-gated) back to `/document/new` — `SentConfirmationPage` now points the CTA straight at `/document/new` for guests; authed users still land on `/documents`.
5. **(Bonus)** Reproducer + regression coverage:
   - `apps/web/e2e/guest-flow.spec.ts` now drives the full POST /envelopes chain with mocked Supabase auth and asserts `/sent` renders + the "back to documents" CTA respects the route guard.
   - 8 new vitest tests (AuthProvider hydration scenarios, AppState envelope_id round-trip, SentConfirmationPage CTA routing).

Bug 6 (production Supabase project disables anonymous sign-ins → 422) is a config change in the Supabase dashboard, not code. The hydration path now rolls back the guest flag instead of leaving the SPA in "acts like guest, no JWT" purgatory.

## Test plan
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web vitest run` (23/23)
- [x] `pnpm --filter web exec playwright test e2e/guest-flow.spec.ts --project=chromium` (1/1)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)