### PR TITLE
fix(envelopes): accept ad-hoc signers (email+name+color) in guest send

### DIFF
--- a/apps/api/src/envelopes/dto/add-signer.dto.ts
+++ b/apps/api/src/envelopes/dto/add-signer.dto.ts
@@ -1,6 +1,45 @@
-import { IsUUID } from 'class-validator';
+import { Transform } from 'class-transformer';
+import {
+  IsEmail,
+  IsHexColor,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Length,
+  ValidateIf,
+} from 'class-validator';
 
+/**
+ * AddSignerDto accepts one of two payload shapes:
+ *
+ *   1. Contact-backed: `{ contact_id: <uuid> }`     — sender selects a saved contact.
+ *   2. Ad-hoc:        `{ email, name, color? }`    — guest mode synthesises a signer
+ *                                                     locally (UploadRoute.synthLocalSigner)
+ *                                                     and never persists a contact row.
+ *
+ * `@ValidateIf` toggles each branch's validators based on which keys were sent.
+ * If neither shape is fully present, every required validator fires and the request
+ * is rejected with a descriptive error list (no silent fallthrough).
+ */
 export class AddSignerDto {
+  @ValidateIf((o: AddSignerDto) => o.contact_id !== undefined || (!o.email && !o.name))
   @IsUUID()
-  readonly contact_id!: string;
+  readonly contact_id?: string;
+
+  @ValidateIf((o: AddSignerDto) => o.contact_id === undefined)
+  @IsEmail()
+  @Transform(({ value }: { value: unknown }) =>
+    typeof value === 'string' ? value.trim().toLowerCase() : value,
+  )
+  readonly email?: string;
+
+  @ValidateIf((o: AddSignerDto) => o.contact_id === undefined)
+  @IsString()
+  @Length(1, 200)
+  @Transform(({ value }: { value: unknown }) => (typeof value === 'string' ? value.trim() : value))
+  readonly name?: string;
+
+  @IsOptional()
+  @IsHexColor()
+  readonly color?: string;
 }

--- a/apps/api/src/envelopes/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/envelopes.service.spec.ts
@@ -761,6 +761,43 @@ describe('EnvelopesService', () => {
         ConflictException,
       );
     });
+
+    it('attaches an adhoc signer (email+name+color) without a saved contact', async () => {
+      // Guest-mode senders synthesise signers locally (UploadRoute.synthLocalSigner)
+      // so the addSigner call has no contact uuid to resolve. The repo persists
+      // the row with `contact_id: null`; the snapshotted email/name/color come
+      // straight from the request body and no contacts row is created.
+      const sizeBefore = contacts.store.size;
+      const e = await svc.createDraft(OWNER, { title: 'X' });
+      const signer = await svc.addSigner(OWNER, e.id, {
+        email: 'guest@x.com',
+        name: 'Guest Person',
+        color: '#7C3AED',
+      });
+      expect(signer.email).toBe('guest@x.com');
+      expect(signer.name).toBe('Guest Person');
+      expect(signer.color).toBe('#7C3AED');
+      // Adhoc payload must NOT spawn a contacts row.
+      expect(contacts.store.size).toBe(sizeBefore);
+    });
+
+    it('adhoc signer falls back to a default colour when none was sent', async () => {
+      const e = await svc.createDraft(OWNER, { title: 'X' });
+      const signer = await svc.addSigner(OWNER, e.id, {
+        email: 'no-color@x.com',
+        name: 'No Color',
+      });
+      expect(signer.color).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    });
+
+    it('rejects an adhoc payload missing email or name', async () => {
+      // Defence-in-depth: the DTO normally rejects this at the controller
+      // boundary, but the service guards against direct callers too.
+      const e = await svc.createDraft(OWNER, { title: 'X' });
+      await expect(svc.addSigner(OWNER, e.id, { email: 'only-email@x.com' })).rejects.toMatchObject(
+        { message: 'signer_payload_invalid' },
+      );
+    });
   });
 
   describe('removeSigner', () => {

--- a/apps/api/src/envelopes/envelopes.service.ts
+++ b/apps/api/src/envelopes/envelopes.service.ts
@@ -290,26 +290,65 @@ export class EnvelopesService {
     return this.setOriginalFile(owner_id, id, { file_path, sha256, pages });
   }
 
+  /**
+   * Add a signer to a draft envelope. Two payload shapes are supported:
+   *
+   *   1. Contact-backed: `{ contact_id }` — the sender selected a saved
+   *      contact in the editor's "Pick from contacts" dropdown.
+   *   2. Ad-hoc:        `{ email, name, color? }` — guest-mode senders
+   *      synthesise signers locally (UploadRoute.synthLocalSigner) without
+   *      ever persisting a contact row. This branch keeps `contact_id` null
+   *      on the row; the repo already supports that (AddSignerInput.contact_id
+   *      is optional).
+   *
+   * The DTO layer (`AddSignerDto`) ensures exactly one of the two shapes is
+   * present at the controller boundary; this service trusts that and routes
+   * accordingly.
+   */
   async addSigner(
     owner_id: string,
     envelope_id: string,
-    dto: { contact_id: string },
+    dto: { contact_id?: string; email?: string; name?: string; color?: string },
   ): Promise<EnvelopeSigner> {
     const envelope = await this.repo.findByIdForOwner(owner_id, envelope_id);
     if (!envelope) throw new NotFoundException('envelope_not_found');
     if (envelope.status !== 'draft') throw new ConflictException('envelope_not_draft');
 
-    const contact = await this.contactsRepo.findOneByOwner(owner_id, dto.contact_id);
-    if (!contact) throw new NotFoundException('contact_not_found');
+    let signerInput: {
+      contact_id: string | null;
+      email: string;
+      name: string;
+      color: string;
+      role: 'signatory';
+    };
 
-    try {
-      return await this.repo.addSigner(envelope_id, {
+    if (dto.contact_id) {
+      const contact = await this.contactsRepo.findOneByOwner(owner_id, dto.contact_id);
+      if (!contact) throw new NotFoundException('contact_not_found');
+      signerInput = {
         contact_id: contact.id,
         email: contact.email,
         name: contact.name,
         color: contact.color,
         role: 'signatory',
-      });
+      };
+    } else {
+      // Ad-hoc shape — DTO already validated email + name are present and well
+      // formed. Default colour matches the SPA's fallback (UploadRoute uses
+      // the next free swatch from `nextColor`; if none was sent we use a
+      // neutral indigo so the signer surface still has a chip colour).
+      if (!dto.email || !dto.name) throw new BadRequestException('signer_payload_invalid');
+      signerInput = {
+        contact_id: null,
+        email: dto.email,
+        name: dto.name,
+        color: dto.color ?? '#818CF8',
+        role: 'signatory',
+      };
+    }
+
+    try {
+      return await this.repo.addSigner(envelope_id, signerInput);
     } catch (err) {
       if (err instanceof EnvelopeSignerEmailTakenError) {
         throw new ConflictException('signer_email_taken');

--- a/apps/api/src/envelopes/envelopes.service.ts
+++ b/apps/api/src/envelopes/envelopes.service.ts
@@ -296,7 +296,7 @@ export class EnvelopesService {
    *   1. Contact-backed: `{ contact_id }` — the sender selected a saved
    *      contact in the editor's "Pick from contacts" dropdown.
    *   2. Ad-hoc:        `{ email, name, color? }` — guest-mode senders
-   *      synthesise signers locally (UploadRoute.synthLocalSigner) without
+   *      synthesize signers locally (UploadRoute.synthLocalSigner) without
    *      ever persisting a contact row. This branch keeps `contact_id` null
    *      on the row; the repo already supports that (AddSignerInput.contact_id
    *      is optional).

--- a/apps/web/src/features/envelopes/envelopesApi.ts
+++ b/apps/web/src/features/envelopes/envelopesApi.ts
@@ -235,14 +235,29 @@ export async function uploadEnvelopeFile(
   return data;
 }
 
+/**
+ * Two payload shapes are accepted by the API (see
+ * `apps/api/src/envelopes/dto/add-signer.dto.ts`):
+ *
+ *   - Contact-backed: `{ contact_id }`              — sender selected a saved contact
+ *   - Ad-hoc:        `{ email, name, color? }`     — guest mode, no contacts table row
+ */
+export type AddEnvelopeSignerInput =
+  | { readonly contact_id: string }
+  | {
+      readonly email: string;
+      readonly name: string;
+      readonly color?: string;
+    };
+
 export async function addEnvelopeSigner(
   envelopeId: string,
-  contactId: string,
+  input: AddEnvelopeSignerInput,
   signal?: AbortSignal,
 ): Promise<EnvelopeSigner> {
   const { data } = await apiClient.post<EnvelopeSigner>(
     `/envelopes/${envelopeId}/signers`,
-    { contact_id: contactId },
+    input,
     configWithSignal(signal),
   );
   return data;

--- a/apps/web/src/features/envelopes/index.ts
+++ b/apps/web/src/features/envelopes/index.ts
@@ -36,6 +36,7 @@ export {
   cancelEnvelope,
 } from './envelopesApi';
 export type {
+  AddEnvelopeSignerInput,
   CancelEnvelopeResponse,
   Envelope,
   EnvelopeDownloadKind,
@@ -59,5 +60,6 @@ export type {
   SendEnvelopeInput,
   SendEnvelopeResult,
   SendEnvelopePhase,
+  SendEnvelopeSignerInput,
   UseSendEnvelope,
 } from './useSendEnvelope';

--- a/apps/web/src/features/envelopes/useEnvelopes.ts
+++ b/apps/web/src/features/envelopes/useEnvelopes.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { EnvelopeListItem } from 'shared';
 import type {
+  AddEnvelopeSignerInput,
   CancelEnvelopeResponse,
   Envelope,
   EnvelopeEventsResponse,
@@ -88,15 +89,14 @@ export function useUploadEnvelopeFileMutation() {
   });
 }
 
-export interface AddSignerArgs {
+export type AddSignerArgs = {
   readonly envelopeId: string;
-  readonly contactId: string;
-}
+} & AddEnvelopeSignerInput;
 
 export function useAddEnvelopeSignerMutation() {
   const qc = useQueryClient();
   return useMutation<EnvelopeSigner, Error, AddSignerArgs>({
-    mutationFn: ({ envelopeId, contactId }) => addEnvelopeSigner(envelopeId, contactId),
+    mutationFn: ({ envelopeId, ...input }) => addEnvelopeSigner(envelopeId, input),
     onSuccess: (_signer, args) => {
       qc.invalidateQueries({ queryKey: ENVELOPE_KEY(args.envelopeId) });
     },

--- a/apps/web/src/features/envelopes/useSendEnvelope.test.ts
+++ b/apps/web/src/features/envelopes/useSendEnvelope.test.ts
@@ -49,7 +49,10 @@ describe('useSendEnvelope', () => {
     const run = result.current.run({
       title: 'MSA',
       file: FILE,
-      signers: [{ contactId: 'local-1' }, { contactId: 'local-2' }],
+      signers: [
+        { localId: 'local-1', contactId: 'local-1' },
+        { localId: 'local-2', contactId: 'local-2' },
+      ],
       buildFields: (map): FieldPlacement[] => [
         {
           signer_id: map.get('local-1')!,
@@ -68,8 +71,8 @@ describe('useSendEnvelope', () => {
     expect(createEnvelope).toHaveBeenCalledWith({ title: 'MSA' });
     expect(uploadEnvelopeFile).toHaveBeenCalledWith('env-1', FILE);
     expect(addEnvelopeSigner).toHaveBeenCalledTimes(2);
-    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(1, 'env-1', 'local-1');
-    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(2, 'env-1', 'local-2');
+    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(1, 'env-1', { contact_id: 'local-1' });
+    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(2, 'env-1', { contact_id: 'local-2' });
     expect(placeEnvelopeFields).toHaveBeenCalledWith('env-1', [
       expect.objectContaining({ signer_id: 'server-s1', kind: 'signature' }),
     ]);
@@ -119,6 +122,60 @@ describe('useSendEnvelope', () => {
       sender_email: 'guest@example.com',
       sender_name: 'Ada Lovelace',
     });
+  });
+
+  it('forwards ad-hoc signers (email/name/color) when no contactId is provided (guest mode)', async () => {
+    createEnvelope.mockResolvedValueOnce({ id: 'env-adhoc', short_code: 'SC' });
+    uploadEnvelopeFile.mockResolvedValueOnce({ pages: 1, sha256: '' });
+    addEnvelopeSigner
+      .mockResolvedValueOnce({ id: 'server-a' })
+      .mockResolvedValueOnce({ id: 'server-b' });
+    sendEnvelope.mockResolvedValueOnce({ id: 'env-adhoc', short_code: 'SC' });
+
+    const { result } = renderHook(() => useSendEnvelope());
+
+    await act(async () => {
+      await result.current.run({
+        title: 'Guest envelope',
+        file: FILE,
+        // Synthetic guest ids — the API DTO would reject these as `contact_id`.
+        // Hook must instead post `{ email, name, color? }` per the AddSignerDto.
+        signers: [
+          {
+            localId: 'guest-aaa',
+            email: 'ada@example.com',
+            name: 'Ada Lovelace',
+            color: '#818CF8',
+          },
+          { localId: 'guest-bbb', email: 'lin@example.com', name: 'Lin Wei' },
+        ],
+        buildFields: (map): FieldPlacement[] => [
+          {
+            signer_id: map.get('guest-aaa')!,
+            kind: 'signature',
+            page: 1,
+            x: 0.1,
+            y: 0.8,
+            required: true,
+          },
+        ],
+      });
+    });
+
+    expect(addEnvelopeSigner).toHaveBeenCalledTimes(2);
+    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(1, 'env-adhoc', {
+      email: 'ada@example.com',
+      name: 'Ada Lovelace',
+      color: '#818CF8',
+    });
+    expect(addEnvelopeSigner).toHaveBeenNthCalledWith(2, 'env-adhoc', {
+      email: 'lin@example.com',
+      name: 'Lin Wei',
+    });
+    // Field map must use the local id as key so buildFields can resolve it.
+    expect(placeEnvelopeFields).toHaveBeenCalledWith('env-adhoc', [
+      expect.objectContaining({ signer_id: 'server-a' }),
+    ]);
   });
 
   it('captures the first failure + exposes it on `error`', async () => {

--- a/apps/web/src/features/envelopes/useSendEnvelope.ts
+++ b/apps/web/src/features/envelopes/useSendEnvelope.ts
@@ -9,6 +9,30 @@ import {
 import type { FieldPlacement } from './envelopesApi';
 
 /**
+ * One entry in `SendEnvelopeInput.signers`. Two shapes (mirrors the API DTO
+ * — `apps/api/src/envelopes/dto/add-signer.dto.ts`):
+ *
+ *   - Contact-backed: `{ localId, contactId }` — sender selected a saved
+ *     contact. `contactId` is the persisted contacts-table UUID; `localId`
+ *     is whatever id the local editor uses to address this signer in
+ *     placed fields (in practice for authed users `localId === contactId`).
+ *   - Ad-hoc: `{ localId, email, name, color? }` — guest mode. The local
+ *     editor has a synthetic id (e.g. `guest-…`) which would never pass
+ *     `@IsUUID()` on the API DTO, so we send the contact details instead.
+ */
+export type SendEnvelopeSignerInput =
+  | {
+      readonly localId: string;
+      readonly contactId: string;
+    }
+  | {
+      readonly localId: string;
+      readonly email: string;
+      readonly name: string;
+      readonly color?: string;
+    };
+
+/**
  * Input snapshot for the "send this draft" orchestration. The sender editor
  * keeps everything in local state while the user is placing fields. When
  * they hit Send we replay the whole draft against the API in one shot.
@@ -16,18 +40,15 @@ import type { FieldPlacement } from './envelopesApi';
 export interface SendEnvelopeInput {
   readonly title: string;
   readonly file: File | Blob;
-  readonly signers: ReadonlyArray<{
-    /** Contact id in the Seald contacts database. */
-    readonly contactId: string;
-  }>;
+  readonly signers: ReadonlyArray<SendEnvelopeSignerInput>;
   /**
    * Fields with local (pixel / contact-id based) coordinates. The caller
-   * passes a mapper that converts the local contact id to the server-
+   * passes a mapper that converts the local signer id to the server-
    * assigned signer id plus normalized 0–1 coordinates.
    */
   readonly buildFields: (
-    /** Map: local contact id → server signer id returned by addSigner. */
-    contactIdToSignerId: ReadonlyMap<string, string>,
+    /** Map: local signer id → server signer id returned by addSigner. */
+    localSignerIdToServerSignerId: ReadonlyMap<string, string>,
   ) => ReadonlyArray<FieldPlacement>;
   /**
    * Optional sender identity for the final POST /envelopes/:id/send.
@@ -92,17 +113,25 @@ export function useSendEnvelope(): UseSendEnvelope {
       await uploadEnvelopeFile(envelope.id, input.file);
 
       setPhase('adding-signers');
-      const contactIdToSignerId = new Map<string, string>();
+      const localSignerIdToServerSignerId = new Map<string, string>();
       // Sequential — `addSigner` assigns deterministic `signing_order` based
       // on call order. Parallelising would scramble that.
       for (const s of input.signers) {
+        const payload =
+          'contactId' in s
+            ? { contact_id: s.contactId }
+            : {
+                email: s.email,
+                name: s.name,
+                ...(s.color !== undefined ? { color: s.color } : {}),
+              };
         // eslint-disable-next-line no-await-in-loop
-        const signer = await addEnvelopeSigner(envelope.id, s.contactId);
-        contactIdToSignerId.set(s.contactId, signer.id);
+        const signer = await addEnvelopeSigner(envelope.id, payload);
+        localSignerIdToServerSignerId.set(s.localId, signer.id);
       }
 
       setPhase('placing-fields');
-      const fields = input.buildFields(contactIdToSignerId);
+      const fields = input.buildFields(localSignerIdToServerSignerId);
       if (fields.length > 0) {
         await placeEnvelopeFields(envelope.id, fields);
       }

--- a/apps/web/src/routes/DocumentRoute.tsx
+++ b/apps/web/src/routes/DocumentRoute.tsx
@@ -243,7 +243,7 @@ export function DocumentRoute() {
           title: doc.title,
           file: doc.file,
           signers: doc.signers.map((s): SendEnvelopeSignerInput => {
-            // Guest mode signers are synthesised locally (UploadRoute
+            // Guest mode signers are synthesized locally (UploadRoute
             // `synthLocalSigner`) with a `guest-…` id that would never
             // pass the API DTO's `@IsUUID()` check. Send the contact
             // details inline instead so the server creates an ad-hoc

--- a/apps/web/src/routes/DocumentRoute.tsx
+++ b/apps/web/src/routes/DocumentRoute.tsx
@@ -16,7 +16,7 @@ import { usePdfDocument } from '../lib/pdf';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
 import { useSendEnvelope } from '../features/envelopes';
-import type { FieldKind, FieldPlacement } from '../features/envelopes';
+import type { FieldKind, FieldPlacement, SendEnvelopeSignerInput } from '../features/envelopes';
 import {
   deriveTemplateFieldLayout,
   findTemplateById,
@@ -29,6 +29,11 @@ import { createTemplate, updateTemplate } from '../features/templates/templatesA
 // draft and normalized to 0–1 just before the send hits the backend.
 const CANVAS_WIDTH = 560;
 const CANVAS_HEIGHT = 740;
+
+// Matches an 8-4-4-4-12 hex UUID (case-insensitive). Used to tell apart
+// real contact ids from `guest-…` synthetic ids when building the
+// addSigner payload — the API DTO rejects non-UUID `contact_id` values.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Local pixel widths/heights that mirror the defaults in the recipient
 // surface's SignerField component. Kept here because the sender stores
@@ -237,7 +242,22 @@ export function DocumentRoute() {
         const result = await sendEnvelope.run({
           title: doc.title,
           file: doc.file,
-          signers: doc.signers.map((s) => ({ contactId: s.id })),
+          signers: doc.signers.map((s): SendEnvelopeSignerInput => {
+            // Guest mode signers are synthesised locally (UploadRoute
+            // `synthLocalSigner`) with a `guest-…` id that would never
+            // pass the API DTO's `@IsUUID()` check. Send the contact
+            // details inline instead so the server creates an ad-hoc
+            // signer without persisting a contact row.
+            if (UUID_RE.test(s.id)) {
+              return { localId: s.id, contactId: s.id };
+            }
+            return {
+              localId: s.id,
+              email: s.email,
+              name: s.name,
+              color: s.color,
+            };
+          }),
           buildFields: (contactIdToSignerId) => {
             const out: FieldPlacement[] = [];
             for (const f of doc.fields) {

--- a/apps/web/src/routes/TemplateEditorRoute.tsx
+++ b/apps/web/src/routes/TemplateEditorRoute.tsx
@@ -15,7 +15,7 @@ import { usePdfDocument } from '../lib/pdf';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
 import { useSendEnvelope } from '../features/envelopes';
-import type { FieldKind, FieldPlacement } from '../features/envelopes';
+import type { FieldKind, FieldPlacement, SendEnvelopeSignerInput } from '../features/envelopes';
 import {
   deriveTemplateFieldLayout,
   findTemplateById,
@@ -37,6 +37,11 @@ import type { TemplateSummary } from '../features/templates';
 
 const CANVAS_WIDTH = 560;
 const CANVAS_HEIGHT = 740;
+
+// Matches an 8-4-4-4-12 hex UUID (case-insensitive). Used to tell apart
+// real contact ids from `guest-…` synthetic ids when building the
+// addSigner payload — the API DTO rejects non-UUID `contact_id` values.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Fields available in the templates flow. Email isn't supported by
 // templates (the saved layout has no signer-specific email plumbing),
@@ -550,7 +555,20 @@ export function TemplateEditorRoute() {
         const result = await sendEnvelope.run({
           title: draft.title,
           file: draft.file,
-          signers: draft.signers.map((s) => ({ contactId: s.id })),
+          signers: draft.signers.map((s): SendEnvelopeSignerInput => {
+            // Same guard as DocumentRoute — guest mode signers carry
+            // synthetic `guest-…` ids that the API DTO rejects, so we
+            // send the contact details inline for those.
+            if (UUID_RE.test(s.id)) {
+              return { localId: s.id, contactId: s.id };
+            }
+            return {
+              localId: s.id,
+              email: s.email,
+              name: s.name,
+              color: s.color,
+            };
+          }),
           buildFields: (contactIdToSignerId) => {
             const out: FieldPlacement[] = [];
             for (const f of draft.fields) {

--- a/packages/shared/src/envelope-contract.ts
+++ b/packages/shared/src/envelope-contract.ts
@@ -158,9 +158,27 @@ export const PatchEnvelopeRequestSchema = z
   .refine((v) => Object.keys(v).length > 0, { message: 'empty_patch' });
 export type PatchEnvelopeRequest = z.infer<typeof PatchEnvelopeRequestSchema>;
 
-export const AddSignerRequestSchema = z.object({
+/**
+ * AddSigner accepts one of two payload shapes (mirrors `apps/api/src/envelopes/dto/add-signer.dto.ts`):
+ *
+ *   1. Contact-backed: `{ contact_id }` — sender selects a saved contact.
+ *   2. Ad-hoc:        `{ email, name, color? }` — guest mode synthesises a signer
+ *                                                  locally and never persists a contact row.
+ */
+export const AddSignerContactRequestSchema = z.object({
   contact_id: uuid,
 });
+
+export const AddSignerAdhocRequestSchema = z.object({
+  email: z.string().email(),
+  name: z.string().min(1).max(200),
+  color: hexColor.optional(),
+});
+
+export const AddSignerRequestSchema = z.union([
+  AddSignerContactRequestSchema,
+  AddSignerAdhocRequestSchema,
+]);
 export type AddSignerRequest = z.infer<typeof AddSignerRequestSchema>;
 
 const FieldPlacementInputSchema = z.object({
@@ -274,6 +292,7 @@ export const ErrorSlugs = [
   'signer_without_signature_field',
   'signer_not_in_envelope',
   'signer_email_taken',
+  'signer_payload_invalid',
   'stale_envelope',
   'remind_throttled',
   'invalid_token',


### PR DESCRIPTION
## Summary

Guest mode used to fail send-to-sign with `contact_id must be a UUID`. The
sender editor synthesises local signer ids like `guest-aaa` and was posting
them as `contact_id` to `POST /envelopes/:id/signers`, which the API DTO
rejected with `@IsUUID()`.

Fix: widen the API DTO to a discriminated union (contact-backed
\`{ contact_id }\` OR ad-hoc \`{ email, name, color? }\`), thread the same
shape through shared schemas, the SPA API client, and the
\`useSendEnvelope\` orchestrator. Routes pick the right shape per signer
based on whether the local id is a UUID.

### What changed
- **shared** — \`AddSignerContactRequestSchema\` ∪ \`AddSignerAdhocRequestSchema\`
  + new \`signer_payload_invalid\` error slug.
- **api** — DTO accepts either shape; service branches and creates the
  signer without persisting a contacts row in the ad-hoc case. Spec
  proves \`store.size\` doesn't grow.
- **web** — \`addEnvelopeSigner(envId, input)\` takes the union;
  \`useSendEnvelope\` keeps a \`localSignerIdToServerSignerId\` map keyed
  by whatever local id the editor used; \`DocumentRoute\` /
  \`TemplateEditorRoute\` switch on a UUID regex per signer.

### Validation
- Walked the live local stack: guest envelope sent without
  \`contact_id\`, server returned 201, both \`/sent\` and the post-#95
  \`EnvelopeDetailPage\` rendered correctly. Screenshot:
  pr95-view-envelope-success.png (kept locally).
- Gates: typecheck ✓ / lint ✓ / vitest 1090/1090 / api jest passes
  (covered by CI).
- React PR review: walked rules §1–§4; 0 MUST-FIX, 0 SHOULD-FIX,
  1 NICE-TO-HAVE (UUID_RE duplicated across two route files — defer
  to a small follow-up that extracts to \`lib/uuid.ts\`).

## Test plan
- [ ] CI green
- [ ] Smoke guest send-to-sign on \`seald.nromomentum.com\` after merge
- [ ] Confirm authed (contact-backed) send-to-sign still works