### PR TITLE
qa(auth+contacts): close 2 silent-failure bugs surfaced by user-perspective audit

### DIFF
--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.redirects.test.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.redirects.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { AuthCallbackPage } from './AuthCallbackPage';
+
+// Audit gap (2026-05-02): the original AuthCallbackPage.test.tsx only
+// asserts that the loading screen renders. The page also owns two
+// navigation behaviors that previously had ZERO assertions:
+//
+//  1. `?error=<anything>` from the OAuth provider → bounce to
+//     `/signin?error=oauth` so the sign-in page can surface the failure.
+//  2. Once the AuthProvider observes a real session (`!loading && user`)
+//     → navigate to `/documents`.
+//
+// Both are critical to the OAuth flow — a regression here either traps
+// the user on a blank loading screen forever (loading=true never
+// settled) or silently swallows provider errors (#1 above).
+
+function renderAt(initialPath: string, auth: Parameters<typeof renderWithProviders>[1]) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/auth/callback" element={<AuthCallbackPage />} />
+        <Route path="/signin" element={<h1>Sign-in landing</h1>} />
+        <Route path="/documents" element={<h1>Documents dashboard</h1>} />
+      </Routes>
+    </MemoryRouter>,
+    auth,
+  );
+}
+
+describe('AuthCallbackPage — provider redirects', () => {
+  it('redirects to /signin?error=oauth when the provider returned ?error=...', async () => {
+    renderAt('/auth/callback?error=access_denied&error_description=User+denied', {
+      auth: { user: null, loading: false },
+    });
+    expect(await screen.findByRole('heading', { name: /sign-in landing/i })).toBeInTheDocument();
+  });
+
+  it('redirects to /documents once a real session resolves', async () => {
+    renderAt('/auth/callback', {
+      auth: {
+        user: { id: 'u1', email: 'ada@example.com', name: 'Ada' },
+        loading: false,
+      },
+    });
+    expect(
+      await screen.findByRole('heading', { name: /documents dashboard/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('stays on the loading screen while the AuthProvider is still resolving the session', () => {
+    renderAt('/auth/callback', { auth: { user: null, loading: true } });
+    // No redirect yet — loading screen visible.
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /sign-in|documents/i })).not.toBeInTheDocument();
+  });
+
+  it('error redirect wins over the user redirect when both could fire (defence in depth)', async () => {
+    // If a provider error AND a hydrated user happened to coincide
+    // (e.g. stale session in storage + new OAuth call that errored), the
+    // user must end up on /signin so they see the failure rather than
+    // being silently dropped on the dashboard.
+    renderAt('/auth/callback?error=server_error', {
+      auth: {
+        user: { id: 'u1', email: 'ada@example.com', name: 'Ada' },
+        loading: false,
+      },
+    });
+    expect(await screen.findByRole('heading', { name: /sign-in landing/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.tsx
@@ -18,16 +18,19 @@ export function AuthCallbackPage() {
   const { user, loading } = useAuth();
 
   useEffect(() => {
+    // Defence in depth: when the provider returns an error AND a stale
+    // session somehow co-exists, the error redirect must win — otherwise
+    // we'd silently land the user on /documents and swallow the failure.
+    // Run both checks in a single effect with explicit precedence so the
+    // outcome doesn't depend on effect-flush order.
     if (params.get('error')) {
       navigate('/signin?error=oauth', { replace: true });
+      return;
     }
-  }, [params, navigate]);
-
-  useEffect(() => {
     if (!loading && user) {
       navigate('/documents', { replace: true });
     }
-  }, [loading, user, navigate]);
+  }, [params, loading, user, navigate]);
 
   return <AuthLoadingScreen />;
 }

--- a/apps/web/src/pages/ContactsPage/ContactsPage.error-handling.test.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.error-handling.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ContactsPage } from './ContactsPage';
+import { renderWithProviders } from '../../test/renderWithProviders';
+
+vi.mock('../../lib/api/apiClient', () => {
+  const SEED = [
+    {
+      id: 'c1',
+      owner_id: 't',
+      name: 'Eliran Azulay',
+      email: 'eliran@azulay.co',
+      color: '#F472B6',
+      created_at: '',
+      updated_at: '',
+    },
+  ];
+  return {
+    apiClient: {
+      get: vi.fn(async (url: string) => {
+        if (url === '/contacts') return { data: SEED, status: 200 };
+        return { data: {}, status: 200 };
+      }),
+      post: vi.fn(async (_url: string, body: { name: string; email: string; color: string }) => ({
+        data: {
+          id: `c_new_${Date.now()}`,
+          owner_id: 't',
+          name: body.name,
+          email: body.email,
+          color: body.color,
+          created_at: '',
+          updated_at: '',
+        },
+        status: 201,
+      })),
+      patch: vi.fn(async (url: string, body: Record<string, unknown>) => ({
+        data: { id: url.split('/').pop(), owner_id: 't', ...body, created_at: '', updated_at: '' },
+        status: 200,
+      })),
+      delete: vi.fn(async () => ({ data: null, status: 204 })),
+    },
+  };
+});
+
+function renderContacts() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/signers']}>
+      <ContactsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ContactsPage — mutation error surface (regression)', () => {
+  it('keeps the add dialog open and surfaces an error when create fails (e.g. duplicate-email 409)', async () => {
+    const apiClientModule = await import('../../lib/api/apiClient');
+    const postSpy = vi.mocked(apiClientModule.apiClient.post);
+    postSpy.mockRejectedValueOnce(
+      Object.assign(new Error('Request failed with status code 409'), {
+        isAxiosError: true,
+        response: { status: 409, data: { error: 'email_taken' } },
+      }),
+    );
+
+    renderContacts();
+    await screen.findByText(/eliran azulay/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /^add signer$/i }));
+    let dialog = screen.getByRole('dialog', { name: /^add signer$/i });
+    const inputs = dialog.querySelectorAll('input');
+    await userEvent.type(inputs[0] as HTMLInputElement, 'Eliran Dup');
+    await userEvent.type(inputs[1] as HTMLInputElement, 'eliran@azulay.co');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^add signer$/i }));
+
+    dialog = await screen.findByRole('dialog', { name: /^add signer$/i });
+    expect(dialog).toBeInTheDocument();
+    expect(
+      await within(dialog).findByText(
+        /already (in use|exists)|email.*taken|that email is already/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the edit dialog open and surfaces an error when update fails (server error)', async () => {
+    const apiClientModule = await import('../../lib/api/apiClient');
+    const patchSpy = vi.mocked(apiClientModule.apiClient.patch);
+    patchSpy.mockRejectedValueOnce(
+      Object.assign(new Error('Request failed with status code 500'), {
+        isAxiosError: true,
+        response: { status: 500, data: { error: 'internal_error' } },
+      }),
+    );
+
+    renderContacts();
+    await screen.findByText(/eliran azulay/i);
+
+    const editButtons = screen.getAllByRole('button', { name: /^edit /i });
+    await userEvent.click(editButtons[0]!);
+    let dialog = screen.getByRole('dialog', { name: /^edit signer$/i });
+    const inputs = dialog.querySelectorAll('input');
+    await userEvent.clear(inputs[0] as HTMLInputElement);
+    await userEvent.type(inputs[0] as HTMLInputElement, 'Eliran Updated');
+    await userEvent.click(within(dialog).getByRole('button', { name: /save changes/i }));
+
+    dialog = await screen.findByRole('dialog', { name: /^edit signer$/i });
+    expect(dialog).toBeInTheDocument();
+    expect(
+      await within(dialog).findByText(
+        /could not save|something went wrong|please try again|failed to save/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('accepts unicode in name + email when adding a contact', async () => {
+    renderContacts();
+    await screen.findByText(/eliran azulay/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /^add signer$/i }));
+    const dialog = screen.getByRole('dialog', { name: /^add signer$/i });
+    const inputs = dialog.querySelectorAll('input');
+    const unicodeName = '李雷 Лев Толстой';
+    const unicodeEmail = 'unicode@example.jp';
+    await userEvent.type(inputs[0] as HTMLInputElement, unicodeName);
+    await userEvent.type(inputs[1] as HTMLInputElement, unicodeEmail);
+    await userEvent.click(within(dialog).getByRole('button', { name: /^add signer$/i }));
+
+    expect(await screen.findByText(unicodeName)).toBeInTheDocument();
+    expect(screen.getByText(unicodeEmail)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/ContactsPage/ContactsPage.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.tsx
@@ -140,7 +140,10 @@ export function ContactsPage() {
     setDialog({ mode: 'closed' });
   };
 
-  const handleSubmit = (): void => {
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (): Promise<void> => {
+    if (submitting) return;
     const trimmedName = name.trim();
     const trimmedEmail = email.trim();
     if (!trimmedName) {
@@ -151,12 +154,36 @@ export function ContactsPage() {
       setError('Please enter a valid email address.');
       return;
     }
-    if (dialog.mode === 'add') {
-      addContact(trimmedName, trimmedEmail);
-    } else if (dialog.mode === 'edit') {
-      updateContact(dialog.contact.id, { name: trimmedName, email: trimmedEmail });
+    setError(null);
+    setSubmitting(true);
+    try {
+      if (dialog.mode === 'add') {
+        await addContact(trimmedName, trimmedEmail);
+      } else if (dialog.mode === 'edit') {
+        await updateContact(dialog.contact.id, { name: trimmedName, email: trimmedEmail });
+      }
+      closeDialog();
+    } catch (err) {
+      // Bug found 2026-05-02 audit: previously the page fired the mutation
+      // and synchronously closed the dialog, so any rejection (duplicate
+      // email 409, server 500, network drop) became an unhandled promise
+      // rejection and the user saw the optimistic row appear and then
+      // vanish with no explanation. Keep the dialog open and surface the
+      // error so the user can correct + retry.
+      const status = (err as { response?: { status?: number } })?.response?.status;
+      const apiError = (err as { response?: { data?: { error?: string } } })?.response?.data?.error;
+      let message: string;
+      if (status === 409 || apiError === 'email_taken') {
+        message = 'That email is already in use by another contact.';
+      } else if (err instanceof Error && err.message) {
+        message = `Could not save contact — ${err.message}. Please try again.`;
+      } else {
+        message = 'Could not save contact. Something went wrong — please try again.';
+      }
+      setError(message);
+    } finally {
+      setSubmitting(false);
     }
-    closeDialog();
   };
 
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);

--- a/apps/web/src/pages/SignInPage/SignInPage.guest-error.test.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.guest-error.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { SignInPage } from './SignInPage';
+
+// Audit gap (2026-05-02): SignInPage.test.tsx covered the static OAuth
+// banner via ?error=oauth, but never exercised the dynamic "Skip" path
+// where enterGuestMode rejects (project has anonymous sign-ins disabled,
+// quota hit, network drop). The page handles this with a banner, but
+// the wiring had no assertion — a regression in error-message plumbing
+// would silently leave the user with a disabled-looking Skip button and
+// no explanation.
+
+function renderAt(initialPath: string, auth: Parameters<typeof renderWithProviders>[1]) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/signin" element={<SignInPage />} />
+        <Route path="/document/new" element={<h1>Guest document workspace</h1>} />
+      </Routes>
+    </MemoryRouter>,
+    auth,
+  );
+}
+
+describe('SignInPage — Skip / guest-mode error', () => {
+  it('shows the rejection message in the alert banner when enterGuestMode fails', async () => {
+    const user = userEvent.setup();
+    const enterGuestMode = vi.fn(async () => {
+      throw new Error('Anonymous sign-ins are disabled for this project');
+    });
+    renderAt('/signin', { auth: { enterGuestMode } });
+
+    await user.click(screen.getByRole('button', { name: /skip — try it/i }));
+
+    const alert = await screen.findByRole('alert');
+    // SignInPage prefers the dynamic guest error over the static OAuth
+    // copy when both could apply (errorKey = guestError ? 'guest' : ...).
+    expect(alert).toHaveTextContent(/guest session|sign up to continue|disabled/i);
+  });
+
+  it('falls back to a generic message when enterGuestMode rejects with a non-Error', async () => {
+    const user = userEvent.setup();
+    const enterGuestMode = vi.fn(async () => {
+      // Defence in depth — Supabase historically threw plain objects in
+      // some edge cases; the page must not blow up on `err.message`
+      // being undefined.
+      throw 'boom' as unknown as Error;
+    });
+    renderAt('/signin', { auth: { enterGuestMode } });
+
+    await user.click(screen.getByRole('button', { name: /skip — try it/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    // Either the generic fallback OR the static "guest" copy — both
+    // satisfy the contract that the user is told something went wrong.
+    expect(alert.textContent ?? '').not.toBe('');
+  });
+
+  it('navigates to /document/new when enterGuestMode resolves', async () => {
+    const user = userEvent.setup();
+    const enterGuestMode = vi.fn(async () => undefined);
+    renderAt('/signin', { auth: { enterGuestMode } });
+
+    await user.click(screen.getByRole('button', { name: /skip — try it/i }));
+    expect(
+      await screen.findByRole('heading', { name: /guest document workspace/i }),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Feature coverage audit — auth + contacts + onboarding

User-perspective audit per the \`seald-feature-coverage-audit\` skill. Two
silent-failure defects + several coverage gaps closed.

### Phase 1 — Inventory
- Surface walked: \`/signin\`, \`/signup\`, \`/auth/callback\`, \`/signers\`
  (ContactsPage), AuthForm component, AuthProvider hooks, ContactsService /
  Controller / DTO + e2e
- Existing coverage was strong on AuthForm + Contacts CRUD happy paths;
  thin on cross-component wiring + mutation-error UX

### Phase 2 — Defects found
1. **fix(contacts): silent dialog dismiss on mutation failure**
   - \`ContactsPage.handleSubmit\` fired \`addContact\`/\`updateContact\`
     without \`await\` and called \`closeDialog()\` synchronously
   - 409 (duplicate email), 500, or network drop became an unhandled
     promise rejection — user saw the optimistic row appear and then
     vanish with no explanation
   - **Fix:** await the mutation, surface the rejection in the dialog
     (with friendly copy for \`email_taken\` 409), only close on success;
     \`submitting\` flag prevents double-click re-fires
2. **fix(auth): AuthCallback silently swallowed provider errors when a stale session existed**
   - Two independent \`useEffect\`s: one for \`?error=...\`, one for the
     resolved session. If both could fire (provider error + cached
     session), the user could land on \`/documents\` with no error shown
   - **Fix:** coalesce into one effect with explicit precedence — error
     redirect runs first and \`return\`s before the session redirect

### Phase 3 — Coverage gaps closed
- AuthCallbackPage: only \`renders loading screen\` was asserted. Added
  redirect-on-error, redirect-on-session, error-precedence, still-loading
- SignInPage: only static OAuth banner was asserted. Added Skip →
  enterGuestMode reject (Error + non-Error) + success paths
- ContactsPage: no unicode coverage at the page layer. Added unicode
  name + email assertion

### Phase 4 — Tests added
- 3 vitest test files (8 new tests total)
  - \`apps/web/src/pages/ContactsPage/ContactsPage.error-handling.test.tsx\` (3 tests)
  - \`apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.redirects.test.tsx\` (4 tests)
  - \`apps/web/src/pages/SignInPage/SignInPage.guest-error.test.tsx\` (3 tests)
- Each regression test was verified to FAIL on the broken code before the
  fix landed

### Gates
- \`pnpm --filter web typecheck\` ✓
- \`pnpm --filter web lint\` ✓ (eslint --max-warnings=0)
- \`pnpm --filter web vitest run\` ✓ (1100 passed / 0 failed)
- \`pnpm --filter api typecheck\` ✓

### Out-of-scope (deferred)
- E2E \`.feature\` files for auth-signin / auth-signup / sender-contacts
  remain single-scenario; expanding them is a follow-up PR
- Sealing area untouched (CLAUDE.md S.1–S.6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)