### PR TITLE
qa(signing): break-tests + fixes for done-snapshot validation and Done page upsell

### DIFF
--- a/apps/web/src/features/signing/doneSnapshot.test.ts
+++ b/apps/web/src/features/signing/doneSnapshot.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearDoneSnapshot,
+  readDoneSnapshot,
+  writeDoneSnapshot,
+  type DoneSnapshot,
+} from './doneSnapshot';
+
+const ENV_ID = '00000000-0000-4000-8000-000000000001';
+
+const VALID: DoneSnapshot = {
+  kind: 'submitted',
+  envelope_id: ENV_ID,
+  short_code: 'ABCDEF1234567',
+  title: 'Master Services Agreement',
+  sender_name: 'Eliran',
+  recipient_email: 'maya@example.com',
+  timestamp: '2026-04-24T00:00:00Z',
+};
+
+beforeEach(() => {
+  window.sessionStorage.clear();
+});
+
+afterEach(() => {
+  window.sessionStorage.clear();
+});
+
+describe('doneSnapshot — write/read round-trip', () => {
+  it('round-trips a complete snapshot', () => {
+    writeDoneSnapshot(VALID);
+    expect(readDoneSnapshot(ENV_ID)).toEqual(VALID);
+  });
+
+  it('returns null when nothing has been written', () => {
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when the stored snapshot belongs to a different envelope', () => {
+    writeDoneSnapshot(VALID);
+    expect(readDoneSnapshot('00000000-0000-4000-8000-000000000099')).toBeNull();
+  });
+
+  it('clearDoneSnapshot drops the stored value', () => {
+    writeDoneSnapshot(VALID);
+    clearDoneSnapshot();
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when the stored value is not valid JSON', () => {
+    window.sessionStorage.setItem('sealed.sign.last', '{not json');
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+});
+
+describe('doneSnapshot — defensive shape validation (regression)', () => {
+  // Regression: without runtime validation, a malformed snapshot (e.g. a
+  // crafted sessionStorage entry, or a partial write from a future-version
+  // client) was returned to the consumer as-is. The Done page then
+  // rendered `/verify/undefined` and `<b>{undefined}</b>` for the
+  // recipient email — neither of which crashes but both of which are
+  // visible-broken UX. Each test below pins one missing/invalid field
+  // and asserts the read returns null instead of the partial object.
+
+  it('returns null when `kind` is missing', () => {
+    window.sessionStorage.setItem(
+      'sealed.sign.last',
+      JSON.stringify({ ...VALID, kind: undefined }),
+    );
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when `kind` is not one of the known terminal states', () => {
+    window.sessionStorage.setItem(
+      'sealed.sign.last',
+      JSON.stringify({ ...VALID, kind: 'something-else' }),
+    );
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when `short_code` is missing', () => {
+    const partial: Record<string, unknown> = { ...VALID };
+    delete partial.short_code;
+    window.sessionStorage.setItem('sealed.sign.last', JSON.stringify(partial));
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when `recipient_email` is missing', () => {
+    const partial: Record<string, unknown> = { ...VALID };
+    delete partial.recipient_email;
+    window.sessionStorage.setItem('sealed.sign.last', JSON.stringify(partial));
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when `envelope_id` is missing entirely', () => {
+    const partial: Record<string, unknown> = { ...VALID };
+    delete partial.envelope_id;
+    window.sessionStorage.setItem('sealed.sign.last', JSON.stringify(partial));
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when the value is a JSON array (wrong root type)', () => {
+    window.sessionStorage.setItem('sealed.sign.last', JSON.stringify([VALID]));
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+
+  it('returns null when the value is null literal', () => {
+    window.sessionStorage.setItem('sealed.sign.last', 'null');
+    expect(readDoneSnapshot(ENV_ID)).toBeNull();
+  });
+});

--- a/apps/web/src/features/signing/doneSnapshot.ts
+++ b/apps/web/src/features/signing/doneSnapshot.ts
@@ -31,16 +31,47 @@ export function writeDoneSnapshot(snapshot: DoneSnapshot): void {
   window.sessionStorage.setItem(KEY, JSON.stringify(snapshot));
 }
 
+/**
+ * Runtime shape guard. The reader is the only consumer of the persisted
+ * payload and it is reachable from a sessionStorage write that any other
+ * tab on the same origin can perform; treat the payload as untrusted
+ * input. A missing `short_code` once made the Done page render
+ * `/verify/undefined`; a missing `recipient_email` rendered an empty
+ * `<b></b>`. Both failure modes are silent in production. Validate the
+ * minimum surface the consumers depend on, and return `null` when any of
+ * it is missing or wrong-typed so callers fall back to their no-snapshot
+ * path (a `<Navigate to="/sign/:id">` redirect).
+ */
+function isValidSnapshot(value: unknown): value is DoneSnapshot {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const v = value as Record<string, unknown>;
+  if (v.kind !== 'submitted' && v.kind !== 'declined') return false;
+  if (typeof v.envelope_id !== 'string' || v.envelope_id.length === 0) return false;
+  if (typeof v.short_code !== 'string') return false;
+  if (typeof v.recipient_email !== 'string' || v.recipient_email.length === 0) return false;
+  // `title`, `timestamp` may be empty strings (server-side fallback when
+  // the cached SignMe was already cleared); allow but require the type.
+  if (typeof v.title !== 'string') return false;
+  if (typeof v.timestamp !== 'string') return false;
+  // `sender_name` is `string | null` on the wire.
+  if (v.sender_name !== null && typeof v.sender_name !== 'string') return false;
+  return true;
+}
+
 export function readDoneSnapshot(envelope_id: string): DoneSnapshot | null {
   if (typeof window === 'undefined') return null;
   const raw = window.sessionStorage.getItem(KEY);
   if (!raw) return null;
+  let parsed: unknown;
   try {
-    const parsed = JSON.parse(raw) as DoneSnapshot;
-    return parsed.envelope_id === envelope_id ? parsed : null;
+    parsed = JSON.parse(raw);
   } catch {
     return null;
   }
+  if (!isValidSnapshot(parsed)) return null;
+  return parsed.envelope_id === envelope_id ? parsed : null;
 }
 
 export function clearDoneSnapshot(): void {

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.test.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.test.tsx
@@ -74,4 +74,127 @@ describe('SigningDonePage', () => {
       expect(screen.getByTestId('__pathname__').textContent).toBe('/signup');
     });
   });
+
+  describe('Save-my-copy — input validation (regression)', () => {
+    // Original bug: submitting an empty / whitespace-only / garbage-shaped
+    // email silently returned (no navigation, no error). The signer saw
+    // nothing happen when they clicked the button. Now the page surfaces
+    // an inline alert and stays on /done so the user knows what to fix.
+
+    it('does not navigate and shows an inline error when the email is empty', async () => {
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00010',
+        title: 'MSA',
+        sender_name: null,
+        recipient_email: 'maya@example.com',
+        timestamp: '',
+      });
+      renderDone();
+      const input = screen.getByLabelText(/your email/i);
+      // Clear the prefilled email so submission is the empty-input repro.
+      await userEvent.clear(input);
+      expect((input as HTMLInputElement).value).toBe('');
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      // The page must stay on /done — no redirect to /signup. The probe
+      // only mounts under the `*` fallback route, so its absence is the
+      // signal that we're still on the real /done route.
+      expect(screen.queryByTestId('__pathname__')).toBeNull();
+      const alert = await screen.findByRole('alert');
+      expect(alert).toHaveTextContent(/enter an email/i);
+    });
+
+    it('does not navigate and shows an inline error for whitespace-only input', async () => {
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00011',
+        title: 'MSA',
+        sender_name: null,
+        recipient_email: 'maya@example.com',
+        timestamp: '',
+      });
+      renderDone();
+      const input = screen.getByLabelText(/your email/i);
+      await userEvent.clear(input);
+      await userEvent.type(input, '   ');
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      expect(screen.queryByTestId('__pathname__')).toBeNull();
+      expect(await screen.findByRole('alert')).toHaveTextContent(/enter an email/i);
+    });
+
+    it('does not navigate and shows an inline error for clearly-invalid email shape', async () => {
+      // The original code passed any non-empty trimmed string straight
+      // through `encodeURIComponent` into `/signup?email=…`. A signer
+      // typing "hello" then clicking Save my copy ended up on a signup
+      // page with `email=hello`, which then errored at the form layer.
+      // Catch the bad shape on the Done page so the failure point is
+      // local to the field they typed in.
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00012',
+        title: 'MSA',
+        sender_name: null,
+        recipient_email: 'maya@example.com',
+        timestamp: '',
+      });
+      renderDone();
+      const input = screen.getByLabelText(/your email/i);
+      await userEvent.clear(input);
+      await userEvent.type(input, 'not an email');
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      expect(screen.queryByTestId('__pathname__')).toBeNull();
+      expect(await screen.findByRole('alert')).toHaveTextContent(/valid email/i);
+    });
+
+    it('navigates to /signup and trims surrounding whitespace from the email', async () => {
+      // Pasted addresses sometimes carry leading/trailing whitespace from
+      // the clipboard. Trim before encoding so the downstream signup
+      // page sees the canonical address.
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00013',
+        title: 'MSA',
+        sender_name: null,
+        recipient_email: 'maya@example.com',
+        timestamp: '',
+      });
+      renderDone();
+      const input = screen.getByLabelText(/your email/i);
+      await userEvent.clear(input);
+      await userEvent.type(input, '  maya@example.com  ');
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('__pathname__').textContent).toBe('/signup');
+      });
+    });
+
+    it('clears a previously-shown error once the user submits a valid email', async () => {
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00014',
+        title: 'MSA',
+        sender_name: null,
+        recipient_email: 'maya@example.com',
+        timestamp: '',
+      });
+      renderDone();
+      const input = screen.getByLabelText(/your email/i);
+      await userEvent.clear(input);
+      // First submission is empty → alert shown.
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      expect(await screen.findByRole('alert')).toBeInTheDocument();
+      // Now type a valid email and submit again — should navigate and
+      // the alert must be gone.
+      await userEvent.type(input, 'maya@example.com');
+      await userEvent.click(screen.getByRole('button', { name: /save my copy/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('__pathname__').textContent).toBe('/signup');
+      });
+    });
+  });
 });

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
@@ -142,6 +142,18 @@ const UpsellBtn = styled.button`
   cursor: pointer;
 `;
 
+const UpsellError = styled.div`
+  margin-top: 10px;
+  padding: 8px 12px;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  border-radius: ${({ theme }) => theme.radius.sm};
+  color: #fecaca;
+  font-size: ${({ theme }) => theme.font.size.micro};
+  line-height: 1.4;
+  text-align: left;
+`;
+
 const ExitLink = styled.button`
   margin-top: ${({ theme }) => theme.space[6]};
   background: transparent;
@@ -187,6 +199,7 @@ export function SigningDonePage() {
   const envelopeId = params.envelopeId ?? '';
   const snap = useMemo(() => readDoneSnapshot(envelopeId), [envelopeId]);
   const [email, setEmail] = useState(snap?.recipient_email ?? '');
+  const [saveError, setSaveError] = useState<string | null>(null);
 
   if (!snap || snap.kind !== 'submitted') {
     return <Navigate to={`/sign/${envelopeId}`} replace />;
@@ -195,7 +208,21 @@ export function SigningDonePage() {
   const handleSave = (e: React.FormEvent): void => {
     e.preventDefault();
     const trimmed = email.trim();
-    if (!trimmed) return;
+    // Original code silently `return`-ed on empty input and forwarded
+    // any non-empty string straight to `/signup?email=…`. Signers got
+    // zero feedback when they submitted blanks, and garbage like
+    // `hello` was happily encoded into the signup URL where it failed
+    // far from the field that produced it. Validate locally and surface
+    // an inline alert so the failure point matches the field.
+    if (!trimmed) {
+      setSaveError('Please enter an email address.');
+      return;
+    }
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setSaveError('Please enter a valid email address.');
+      return;
+    }
+    setSaveError(null);
     navigate(`/signup?email=${encodeURIComponent(trimmed)}`);
   };
 
@@ -257,7 +284,7 @@ export function SigningDonePage() {
             Create a free account to save this document, request signatures from others, and access
             your full signing history.
           </UpsellBody>
-          <UpsellForm onSubmit={handleSave}>
+          <UpsellForm onSubmit={handleSave} noValidate>
             <UpsellInput
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -267,6 +294,7 @@ export function SigningDonePage() {
             />
             <UpsellBtn type="submit">Save my copy</UpsellBtn>
           </UpsellForm>
+          {saveError ? <UpsellError role="alert">{saveError}</UpsellError> : null}
         </Upsell>
 
         <ExitLink type="button" onClick={() => navigate('/')}>


### PR DESCRIPTION
## Summary

Coverage-audit pass on the signer / signing-from-email flow per the `seald-feature-coverage-audit` skill. Two real defects found by reading the code from the signer's perspective; both reproduced as failing tests first, then fixed.

### Defect 1 — `doneSnapshot` had no runtime validation

`apps/web/src/features/signing/doneSnapshot.ts` returned whatever `JSON.parse(sessionStorage)` produced. A malformed payload (crafted entry, partial write from a future-version client, missing `short_code` after a server-side fallback) was returned to the consumer as-is. The Done page then rendered `/verify/undefined` and an empty `<b></b>` for the recipient — both silent-broken UX.

Fix: `isValidSnapshot` guard checks `kind` is one of the two terminal states, and that every required string field is the right type and non-empty where it must be. Returns `null` otherwise so callers fall back to the no-snapshot redirect path.

Tests added (`doneSnapshot.test.ts`): 12 total — round-trip happy path, cross-envelope null, JSON parse failure, plus 7 shape-violation regressions.

### Defect 2 — Done page "Save my copy" silently swallowed bad input

`apps/web/src/pages/SigningDonePage/SigningDonePage.tsx` `handleSave` `return`-ed on empty trimmed email (no feedback to the user) and forwarded any non-empty trimmed string to `/signup?email=...` without validation (so `hello` reached the signup page where it errored far from the field).

Fix: validate non-empty + basic email shape locally; render an inline `role="alert"` banner; clear the alert on a subsequent valid submit. Also `noValidate` on the form so the JS handler is the single source of truth (the native `type="email"` short-circuit was masking our own error path).

Tests added (`SigningDonePage.test.tsx`): 5 new in a `Save-my-copy — input validation (regression)` describe — empty submit, whitespace-only, "not an email", whitespace-trimming on a valid email, alert clears after recovery.

## Coverage delta

| File | Before | After |
|---|---|---|
| `features/signing/doneSnapshot.ts` | 0 dedicated tests | 12 tests |
| `pages/SigningDonePage/*` | 4 tests | 9 tests |

Both files now have first-line regression coverage for the silent-failure modes that were live in production behind the snapshot read and the upsell submit.

## Scoped gates

```
pnpm --filter web typecheck   # green
pnpm --filter web lint        # green
pnpm --filter web exec vitest run \
  src/features/signing/doneSnapshot \
  src/pages/SigningDonePage     # 21/21 green
```

## Rules cited

- `react-best-practices` 4.6 — every new query is by accessible role / label / alert; the only `__pathname__` testid usage is the sanctioned `renderSigningRoute` probe (and it's still a `queryByTestId(...).toBeNull()` negative-assertion in the no-redirect cases).
- `seald-react-pr-review` — test-before-fix on every runtime path change; both fixes have a failing test that drove the fix.
- CLAUDE.md "Never amend / never `--no-verify`" — followed; lint-staged + scoped gates ran clean on the commit hook.

## Out of scope

PAdES sealing (`apps/api/src/sealing/**`) is off-limits per CLAUDE.md S.1–S.6 and was not touched.

## Test plan

- [ ] CI green on `qa/signer-flow-break-tests`
- [ ] Squash-merge once green