### PR TITLE
fix(web): close 3 audit gaps in auth + nav guards (T-auth-audit)

### DIFF
--- a/apps/web/e2e/features/auth-checkemail-a11y.feature
+++ b/apps/web/e2e/features/auth-checkemail-a11y.feature
@@ -1,0 +1,20 @@
+Feature: Check-email confirmation announces success accessibly
+
+  # Bug C regression (audit 2026-05-02): the post-submit confirmation
+  # ("we sent a link to <email>") used to render as a plain paragraph.
+  # Screen-reader users navigating from /forgot-password lost all
+  # context — the page heading "Check your email" repeats verbatim
+  # across the reset and signup variants. The body must be a polite
+  # live region with a mode-specific aria-label so AT can announce it
+  # immediately on route entry. WCAG 2.1 SC 4.1.3 (Status Messages).
+
+  @auth @a11y @smoke
+  Scenario: Reset confirmation is exposed as a live region after a forgot-password submit
+    Given the password-reset API will succeed
+    When the user requests a reset for "alice@example.com"
+    Then a polite live region announces the reset link was sent to "alice@example.com"
+
+  @auth @a11y @smoke
+  Scenario: Signup confirmation uses the signup-specific live-region label
+    When the user lands on the signup confirmation for "alice@example.com"
+    Then a polite live region announces the confirmation link was sent

--- a/apps/web/e2e/features/nav-active.feature
+++ b/apps/web/e2e/features/nav-active.feature
@@ -1,0 +1,29 @@
+Feature: Primary nav active-tab indicator follows the IA
+
+  Background:
+    Given the user is signed in as "alice@example.com"
+
+  @nav @smoke
+  Scenario: Documents tab stays active on the dashboard
+    When the user opens the Documents dashboard
+    Then the primary nav highlights "Documents"
+
+  # Bug A regression (audit 2026-05-02): existing-envelope detail and the
+  # post-send confirmation are entered from Documents — they must not
+  # mis-light the "Sign" tab.
+  @nav @smoke
+  Scenario: Documents tab stays active on an existing envelope detail page
+    When the user opens the envelope detail page for "abc-123"
+    Then the primary nav highlights "Documents"
+    And the primary nav does not highlight "Sign"
+
+  @nav @smoke
+  Scenario: Documents tab stays active on the post-send confirmation
+    When the user opens the sent confirmation page for "abc-123"
+    Then the primary nav highlights "Documents"
+    And the primary nav does not highlight "Sign"
+
+  @nav @smoke
+  Scenario: Sign tab is active only on the new-envelope upload entry
+    When the user opens the new envelope upload page
+    Then the primary nav highlights "Sign"

--- a/apps/web/e2e/steps/auth-checkemail-a11y.steps.ts
+++ b/apps/web/e2e/steps/auth-checkemail-a11y.steps.ts
@@ -1,0 +1,34 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { When, Then } = createBdd(test);
+
+/**
+ * BDD steps for the CheckEmailPage live-region announcement (Bug C
+ * regression — see `apps/web/src/pages/CheckEmailPage/CheckEmailPage.test.tsx`
+ * for the unit-level coverage of the role/label).
+ *
+ * The "Given the password-reset API will succeed" + "When the user
+ * requests a reset for {email}" steps are reused from auth-forgot.steps.ts.
+ */
+
+When('the user lands on the signup confirmation for {string}', async ({ page }, email: string) => {
+  await page.goto(`/check-email?email=${encodeURIComponent(email)}&mode=signup`);
+});
+
+Then(
+  'a polite live region announces the reset link was sent to {string}',
+  async ({ page }, email: string) => {
+    const status = page.getByRole('status', { name: /password reset link sent/i });
+    await expect(status).toBeVisible();
+    await expect(status).toHaveAttribute('aria-live', 'polite');
+    await expect(status).toContainText(email);
+  },
+);
+
+Then('a polite live region announces the confirmation link was sent', async ({ page }) => {
+  const status = page.getByRole('status', { name: /confirmation link sent/i });
+  await expect(status).toBeVisible();
+  await expect(status).toHaveAttribute('aria-live', 'polite');
+});

--- a/apps/web/e2e/steps/nav-active.steps.ts
+++ b/apps/web/e2e/steps/nav-active.steps.ts
@@ -1,0 +1,68 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { Given, When, Then } = createBdd(test);
+
+/**
+ * BDD steps for the primary-nav active-tab indicator (Bug A regression
+ * — see `apps/web/src/layout/navItems.test.ts` for the unit-level
+ * coverage). These run inside `RequireAuth → AppShell` so the seeded
+ * Supabase session lets the guard fall through.
+ */
+
+Given('the user is signed in as {string}', async ({ seededUser, mockedApi }, email: string) => {
+  await seededUser.signInAs({
+    id: '00000000-0000-4000-8000-000000000a11',
+    email,
+    fullName: 'Alice Example',
+  });
+  // Stub the dashboard + envelope APIs so each route renders without a
+  // live backend.
+  mockedApi.on('GET', /\/api\/envelopes(\?|$)/, { json: { items: [] } });
+  mockedApi.on('GET', /\/api\/envelopes\/[^/]+$/, {
+    json: {
+      id: 'abc-123',
+      title: 'Test envelope',
+      status: 'sent',
+      createdAt: '2026-04-25T10:00:00Z',
+      updatedAt: '2026-04-25T10:00:00Z',
+      recipients: [],
+      events: [],
+      documents: [],
+    },
+  });
+});
+
+When('the user opens the Documents dashboard', async ({ page }) => {
+  await page.goto('/documents');
+});
+
+When(
+  'the user opens the envelope detail page for {string}',
+  async ({ page }, envelopeId: string) => {
+    await page.goto(`/document/${envelopeId}`);
+  },
+);
+
+When(
+  'the user opens the sent confirmation page for {string}',
+  async ({ page }, envelopeId: string) => {
+    await page.goto(`/document/${envelopeId}/sent`);
+  },
+);
+
+When('the user opens the new envelope upload page', async ({ page }) => {
+  await page.goto('/document/new');
+});
+
+Then('the primary nav highlights {string}', async ({ page }, label: string) => {
+  // Active tab is rendered with `aria-current="page"` (NavBar.tsx).
+  const tab = page.getByRole('button', { name: new RegExp(`^${label}$`, 'i') });
+  await expect(tab).toHaveAttribute('aria-current', 'page');
+});
+
+Then('the primary nav does not highlight {string}', async ({ page }, label: string) => {
+  const tab = page.getByRole('button', { name: new RegExp(`^${label}$`, 'i') });
+  await expect(tab).not.toHaveAttribute('aria-current', 'page');
+});

--- a/apps/web/src/layout/navItems.test.ts
+++ b/apps/web/src/layout/navItems.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { matchNavId } from './navItems';
+
+/**
+ * Audit gap (2026-05-02): the previous `matchNavId` lit up the "Sign"
+ * tab for ANY pathname under `/document/...`, including the
+ * EnvelopeDetailPage at `/document/:id` and the SentConfirmationPage at
+ * `/document/:id/sent`. Both surfaces are entered from the Documents
+ * tab (clicking a row on the dashboard, or finishing a send) and should
+ * keep the user oriented with "Documents" highlighted — only the
+ * new-envelope upload + editor flow at `/document/new` is part of the
+ * "Sign" tab proper. Without this distinction the active-tab indicator
+ * silently mis-reports the user's position in the IA.
+ */
+describe('matchNavId', () => {
+  it('returns "documents" for the dashboard', () => {
+    expect(matchNavId('/documents')).toBe('documents');
+  });
+
+  it('returns "sign" for the new-envelope upload entry', () => {
+    expect(matchNavId('/document/new')).toBe('sign');
+  });
+
+  it('returns "templates" for the templates list', () => {
+    expect(matchNavId('/templates')).toBe('templates');
+  });
+
+  it('returns "templates" inside the templates wizard', () => {
+    expect(matchNavId('/templates/abc/use')).toBe('templates');
+    expect(matchNavId('/templates/abc/edit')).toBe('templates');
+  });
+
+  it('returns "signers" for the contacts/signers tab', () => {
+    expect(matchNavId('/signers')).toBe('signers');
+  });
+
+  // Bug A regression: existing-envelope detail must NOT highlight Sign.
+  it('returns "documents" for an existing envelope detail (/document/:id)', () => {
+    expect(matchNavId('/document/abc-123')).toBe('documents');
+  });
+
+  it('returns "documents" for the sent-confirmation page (/document/:id/sent)', () => {
+    expect(matchNavId('/document/abc-123/sent')).toBe('documents');
+  });
+
+  it('still returns "sign" while the user is mid-flight on /document/new', () => {
+    // The upload/editor handoff replaces the URL with /document/<draftId>
+    // ONLY after sending — during the in-flight create flow we'd be on
+    // /document/new and the Sign tab must stay lit.
+    expect(matchNavId('/document/new')).toBe('sign');
+  });
+});

--- a/apps/web/src/layout/navItems.ts
+++ b/apps/web/src/layout/navItems.ts
@@ -19,14 +19,29 @@ export const NAV_ITEMS: ReadonlyArray<NavItemEntry> = [
 ];
 
 /**
- * Derive the NavBar's active item id from the current pathname. The "Sign" tab
- * stays active throughout the signature request flow (upload → editor → sent
- * confirmation); the "Templates" tab covers `/templates` and its
- * `/templates/:id/use` apply-flow surface; everything else maps via a simple
- * prefix match.
+ * Derive the NavBar's active item id from the current pathname.
+ *
+ * IA contract:
+ *  - `/document/new` is the "Sign" tab (new-envelope upload + editor).
+ *    Once the user sends, the URL transitions to `/document/:id/sent`
+ *    which is reached from the Documents tab — `Sign` no longer applies.
+ *  - `/document/:id` (EnvelopeDetailPage) and `/document/:id/sent`
+ *    (SentConfirmationPage) are surfaced from the Documents dashboard,
+ *    so they keep "Documents" highlighted.
+ *  - `/templates` and any nested wizard surface
+ *    (`/templates/:id/use`, `/templates/:id/edit`) keep "Templates" lit.
+ *  - Everything else falls through to the simple prefix match against
+ *    NAV_ITEMS, defaulting to "documents".
+ *
+ * Audit gap (2026-05-02): previously the "Sign" tab was lit for ANY
+ * `/document/...` path, so reading an existing envelope or watching the
+ * sent-confirmation flash mis-highlighted "Sign" instead of "Documents".
  */
 export function matchNavId(pathname: string): string {
-  if (pathname === '/document/new' || pathname.startsWith('/document/')) {
+  // The new-envelope flow only owns the literal `/document/new` URL —
+  // checking equality (rather than a prefix) avoids stealing ownership
+  // of `/document/:id` from the Documents tab.
+  if (pathname === '/document/new') {
     return 'sign';
   }
   if (pathname === '/templates' || pathname.startsWith('/templates/')) {

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.test.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.test.tsx
@@ -101,4 +101,28 @@ describe('CheckEmailPage', () => {
     await user.click(resend);
     expect(resetPassword).not.toHaveBeenCalled();
   });
+
+  // Bug C regression (audit 2026-05-02): the success copy that confirms
+  // a reset / signup link was sent is the page's most important message,
+  // but it was rendered as a plain paragraph with no live-region role.
+  // Screen-reader users who land here from a `navigate()` transition
+  // hear the new heading and lose all context for what just happened.
+  // Per WAI-ARIA 1.2 + WCAG 2.1 SC 4.1.3 the confirmation must be in a
+  // polite live region so AT can announce it.
+  it('exposes the success copy as a polite live-region status', () => {
+    renderAt('/check-email?email=jamie%40seald.app&mode=reset');
+    const status = screen.getByRole('status', { name: /password reset link sent/i });
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    // The address itself must be inside the announced region so AT
+    // reads it as part of the confirmation.
+    expect(status).toHaveTextContent(/jamie@seald\.app/);
+  });
+
+  it('switches the live-region label to the signup-confirmation phrasing', () => {
+    renderAt('/check-email?email=jamie%40seald.app&mode=signup');
+    const status = screen.getByRole('status', { name: /confirmation link sent/i });
+    expect(status).toBeInTheDocument();
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
 });

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.tsx
@@ -47,6 +47,17 @@ export function CheckEmailPage() {
       </>
     );
 
+  // Bug C fix (audit 2026-05-02): the confirmation copy is the single
+  // most important message on the page — without role=status + aria-live
+  // the user (especially on a screen reader, who only hears the new
+  // heading after the route transition) loses all context for what just
+  // happened. The aria-label is mode-specific so the role announcement
+  // is meaningful even before the body text is read.
+  const statusLabel =
+    mode === 'signup'
+      ? 'Confirmation link sent — check your email'
+      : 'Password reset link sent — check your email';
+
   return (
     <AuthShell>
       <Wrap>
@@ -54,7 +65,9 @@ export function CheckEmailPage() {
           <Icon icon={MailCheck} size={26} />
         </IconBadge>
         <Title>Check your email</Title>
-        <Body>{body}</Body>
+        <Body role="status" aria-live="polite" aria-label={statusLabel}>
+          {body}
+        </Body>
         <Actions>
           <Secondary type="button" onClick={handleBack}>
             Back to sign in

--- a/apps/web/src/providers/AuthProvider.test.tsx
+++ b/apps/web/src/providers/AuthProvider.test.tsx
@@ -207,4 +207,50 @@ describe('AuthProvider', () => {
     );
     expect(view.getByText('hello')).toBeInTheDocument();
   });
+
+  // Bug B regression (audit 2026-05-02): a guest who already has a live
+  // anonymous session can hit the AppShell "Sign in" → "Skip" loop. The
+  // previous implementation called `signInAnonymously()` unconditionally
+  // and Supabase returned a brand-new anon user with a different
+  // `user.id`, orphaning every envelope the previous guest had drafted.
+  // `enterGuestMode()` must be idempotent when a usable session already
+  // exists.
+  it('enterGuestMode is a no-op when an anonymous Supabase session is already present', async () => {
+    // Hydration path: anonymous session already in storage.
+    // Subsequent calls (the one made inside enterGuestMode itself)
+    // continue to return the same anon session so the idempotency check
+    // can read it.
+    supabaseAuth.getSession.mockResolvedValue({ data: { session: makeAnonSession() } });
+    window.localStorage.setItem('sealed.guest', '1');
+
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Hydration path already consumed (or skipped) the signInAnonymously
+    // call. Reset so the assertion below isolates the enterGuestMode call.
+    supabaseAuth.signInAnonymously.mockClear();
+
+    await act(async () => {
+      await result.current.enterGuestMode();
+    });
+
+    // The previous guest's session must be preserved — no new anon user.
+    expect(supabaseAuth.signInAnonymously).not.toHaveBeenCalled();
+    expect(result.current.guest).toBe(true);
+    expect(window.localStorage.getItem('sealed.guest')).toBe('1');
+  });
+
+  it('enterGuestMode still mints a new anonymous session when none exists', async () => {
+    // The opposite case: no session yet, so the call must go through.
+    const { result } = renderHook(() => useAuth(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    supabaseAuth.signInAnonymously.mockClear();
+
+    await act(async () => {
+      await result.current.enterGuestMode();
+    });
+
+    expect(supabaseAuth.signInAnonymously).toHaveBeenCalledTimes(1);
+    expect(result.current.guest).toBe(true);
+  });
 });

--- a/apps/web/src/providers/AuthProvider.tsx
+++ b/apps/web/src/providers/AuthProvider.tsx
@@ -226,6 +226,20 @@ export function AuthProvider(props: AuthProviderProps) {
     // the Supabase project (Authentication → Providers → Anonymous); the
     // underlying error is re-surfaced so the caller can toast it.
     //
+    // Bug B fix (audit 2026-05-02): if an anonymous session is ALREADY
+    // present (e.g. user clicked "Sign in" from the AppShell, then hit
+    // "Skip" on the auth page) we must NOT call `signInAnonymously()`
+    // again — Supabase mints a brand-new anon user with a different
+    // `user.id`, orphaning every envelope the previous guest had drafted.
+    // The flag-only update is enough; the existing session keeps the
+    // Bearer JWT valid for the apiClient.
+    const { data: existing } = await supabase.auth.getSession();
+    if (existing.session?.user.is_anonymous) {
+      setGuest(true);
+      writeGuestFlag(true);
+      return;
+    }
+
     // We flip the guest flag *before* the network call so the
     // `onAuthStateChange` listener (which already filters anonymous
     // sessions out of its guest=false branch) has a coherent view if it


### PR DESCRIPTION
## Summary

Three real bugs surfaced during the parallel auth + onboarding + nav-guards audit on 2026-05-02. All three have test-before-fix coverage and BDD smoke scenarios.

| # | Severity | Class | Where |
|---|---|---|---|
| A | High | UI / IA | `apps/web/src/layout/navItems.ts` — primary nav active-tab |
| B | High | Logic / data-loss | `apps/web/src/providers/AuthProvider.tsx` — `enterGuestMode()` |
| C | Medium | UI / A11y | `apps/web/src/pages/CheckEmailPage/CheckEmailPage.tsx` — confirmation copy |

### Bug A — "Sign" tab steals focus from existing-envelope surfaces (UI)
`matchNavId('/document/abc-123')` → `'sign'` instead of `'documents'`. The "Sign" tab owns the new-envelope upload at `/document/new`; viewing an existing envelope (EnvelopeDetailPage) and the post-send confirmation (SentConfirmationPage) are both reached from the Documents dashboard and must keep "Documents" lit. Fixed via an equality check on `/document/new` instead of a `startsWith('/document/')` swallow.

### Bug B — guest-mode "Sign in → Skip" loop orphans the guest's documents (logic / data-loss)
When a guest in the AppShell clicks "Sign in" the AppShell calls `exitGuestMode()` (clears the local flag) but does NOT call `supabase.auth.signOut()` — the anonymous Supabase session lives on. If the user then clicks "Skip" on the auth page, `enterGuestMode()` was calling `signInAnonymously()` unconditionally, minting a brand-new anon user with a different `user.id` and orphaning every envelope the previous guest had drafted. Fix: short-circuit when an anonymous session is already present.

### Bug C — CheckEmailPage success copy is invisible to screen readers (a11y)
The "we sent a link to <email>" body was a plain `<p>`. AT users navigating from forgot-password heard only the new heading "Check your email" (which repeats verbatim across reset and signup variants) and lost all context. Wrapped in `role="status"` + `aria-live="polite"` + a mode-specific `aria-label` per WCAG 2.1 SC 4.1.3 (Status Messages).

## BDD scenarios added

- `apps/web/e2e/features/nav-active.feature` — 4 `@smoke` scenarios for Bug A (Documents stays lit on dashboard / detail / sent; Sign only on `/document/new`).
- `apps/web/e2e/features/auth-checkemail-a11y.feature` — 2 `@smoke` scenarios for Bug C (reset + signup confirmation live regions).
- Bug B is asserted at the unit level (`apps/web/src/providers/AuthProvider.test.tsx`) — the BDD harness can't observe Supabase RPC counts and the user-visible state is identical pre/post.

## Test plan

- [x] `pnpm --filter web exec vitest run src/layout/navItems.test.ts` — 8/8
- [x] `pnpm --filter web exec vitest run src/providers/AuthProvider.test.tsx` — 10/10
- [x] `pnpm --filter web exec vitest run src/pages/CheckEmailPage` — 9/9
- [x] `pnpm --filter web exec vitest run` — 1186/1186 (full SPA suite)
- [x] `pnpm -r typecheck` — clean (web / api / shared / landing)
- [x] `pnpm --filter web lint` — 0 errors / 0 warnings
- [ ] CI green on this PR (post-push validator)

## Skill audits

- `react-best-practices` rules walked against the staged diff — clean (no MUST-FIX).
- `seald-react-pr-review` verdict: commit gates green, MUST-FIX list empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)