### PR TITLE
fix(signer): mobile bottom-sheet + Not me confirm + dialog focus trap

### DIFF
--- a/apps/web/e2e/features/signer-mobile.feature
+++ b/apps/web/e2e/features/signer-mobile.feature
@@ -1,0 +1,24 @@
+Feature: Recipient signs from a phone-sized viewport
+  # Critical-path: "Open the email link on my phone, sign in 30 seconds
+  # without making an account." Top-frequency entry point — most signers
+  # open from a Gmail/iOS Mail link on mobile.
+
+  Background:
+    Given a sealed envelope ready for signing
+
+  @signer @smoke
+  Scenario: Recipient completes signing on a 375px viewport
+    Given the viewport is set to a 375x667 phone
+    When the recipient signs and submits the envelope
+    Then the signing-done page is shown
+
+  @signer @smoke
+  Scenario: The bottom-sheet Apply button stays reachable on a phone
+    # Regression for the iOS-keyboard / safe-area bug — the bottom sheet
+    # used to put its footer below the visual viewport, leaving the user
+    # with no way to commit a typed value or dismiss the modal.
+    Given the viewport is set to a 375x667 phone
+    When the recipient opens the signing link and lands on the prep page
+    And the recipient agrees and continues to fill
+    And the recipient opens the signature sheet
+    Then the sheet "Apply" button is visible inside the viewport

--- a/apps/web/e2e/features/signer-not-me.feature
+++ b/apps/web/e2e/features/signer-not-me.feature
@@ -1,0 +1,20 @@
+Feature: Recipient guards against accidentally tapping "Not me?"
+  # Critical-path: "Decline cleanly with a reason and never get spammed
+  # again." A mistakenly-tapped Not me used to fire a one-shot decline
+  # with no confirmation, terminating the envelope. The fix mirrors the
+  # confirm dialog used for "Decline this request".
+
+  Background:
+    Given a sealed envelope ready for signing
+
+  @signer @smoke @regression
+  Scenario: Tapping Not me by accident does not decline the envelope
+    When the recipient opens the signing link and lands on the prep page
+    And the recipient taps "Not me?" but cancels the confirmation
+    Then the recipient stays on the prep page
+
+  @signer @regression
+  Scenario: Confirming Not me declines and routes to the declined page
+    When the recipient opens the signing link and lands on the prep page
+    And the recipient taps "Not me?" and confirms the dialog
+    Then the signing-declined page is shown

--- a/apps/web/e2e/steps/signer-mobile.steps.ts
+++ b/apps/web/e2e/steps/signer-mobile.steps.ts
@@ -1,0 +1,45 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+// Reuses `Given a sealed envelope ready for signing` from
+// signer-happy.steps.ts.
+const { Given, When, Then } = createBdd(test);
+
+/**
+ * Phone-sized viewport so layout & sticky-CTA assertions reflect the
+ * iOS Safari case the bug-fix targets. 375x667 = iPhone SE (smallest
+ * mainstream viewport we support).
+ */
+Given('the viewport is set to a 375x667 phone', async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 667 });
+});
+
+When(
+  'the recipient opens the signing link and lands on the prep page',
+  async ({ signingEntryPage, signedEnvelope }) => {
+    await signingEntryPage.goto(signedEnvelope.id);
+    await signingEntryPage.startSigning();
+  },
+);
+
+When('the recipient agrees and continues to fill', async ({ signingPrepPage, page }) => {
+  await signingPrepPage.agreeAndContinue();
+  await page.waitForURL(/\/sign\/[^/]+\/fill/);
+});
+
+When('the recipient opens the signature sheet', async ({ page }) => {
+  await page
+    .getByRole('button', { name: /sign here/i })
+    .first()
+    .click();
+});
+
+Then('the sheet "Apply" button is visible inside the viewport', async ({ page }) => {
+  // The Apply button must be inside the visual viewport. Without the dvh
+  // / safe-area fix the button sat below the viewport on a phone-sized
+  // window and `toBeInViewport` fails.
+  const apply = page.getByRole('button', { name: /^apply$/i });
+  await expect(apply).toBeVisible();
+  await expect(apply).toBeInViewport();
+});

--- a/apps/web/e2e/steps/signer-not-me.steps.ts
+++ b/apps/web/e2e/steps/signer-not-me.steps.ts
@@ -1,0 +1,28 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { When, Then } = createBdd(test);
+
+When('the recipient taps "Not me?" but cancels the confirmation', async ({ page }) => {
+  // Native confirm — Playwright's dialog handler can dismiss before the
+  // click commits. dismiss() simulates the user clicking Cancel.
+  page.once('dialog', (d) => {
+    void d.dismiss();
+  });
+  await page.getByRole('button', { name: /not me\?/i }).click();
+});
+
+When('the recipient taps "Not me?" and confirms the dialog', async ({ page }) => {
+  page.once('dialog', (d) => {
+    void d.accept();
+  });
+  await page.getByRole('button', { name: /not me\?/i }).click();
+});
+
+Then('the recipient stays on the prep page', async ({ page }) => {
+  // URL must still match `/sign/<id>/prep` and the Start signing CTA
+  // must still be visible — no navigation occurred.
+  await expect(page).toHaveURL(/\/sign\/[^/]+\/prep/);
+  await expect(page.getByRole('button', { name: /start signing/i })).toBeVisible();
+});

--- a/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.styles.ts
+++ b/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.styles.ts
@@ -3,6 +3,14 @@ import styled from 'styled-components';
 export const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  /* Bind the backdrop to the visual viewport on iOS Safari so the soft
+     keyboard's appearance shrinks the available area instead of pushing
+     the bottom sheet offscreen. \`dvh\` (dynamic) reflects the browser
+     chrome AND keyboard; \`svh\` is the safe fallback. \`100vh\` alone
+     was the bug — the sheet's footer sat under the iOS keyboard. */
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
   background: rgba(11, 18, 32, 0.5);
   z-index: ${({ theme }) => theme.z.modal};
   display: flex;
@@ -13,9 +21,18 @@ export const Backdrop = styled.div`
 export const Sheet = styled.div`
   width: 100%;
   max-width: 560px;
+  /* Cap the sheet to the visual viewport so the footer (Apply / Cancel)
+     stays reachable when content + keyboard would otherwise overflow.
+     \`overflow-y: auto\` lets the user scroll inside the sheet rather
+     than the page jumping. */
+  max-height: 100dvh;
+  overflow-y: auto;
   background: ${({ theme }) => theme.color.paper};
   border-radius: 20px 20px 0 0;
-  padding: ${({ theme }) => theme.space[6]} 28px 28px;
+  /* Reserve space for the iPhone home indicator (the 34pt strip below
+     the bottom edge). \`env(safe-area-inset-bottom)\` is 0 on devices
+     without a notch, so this is safe everywhere. */
+  padding: ${({ theme }) => theme.space[6]} 28px calc(28px + env(safe-area-inset-bottom, 0px));
   box-shadow: 0 -10px 40px rgba(11, 18, 32, 0.2);
 `;
 

--- a/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.test.tsx
+++ b/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.test.tsx
@@ -103,4 +103,102 @@ describe('FieldInputDrawer', () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  describe('mobile-keyboard / safe-area regression', () => {
+    // BUG FIX: the bottom sheet was a fixed 100vh backdrop with no max-height
+    // or scroll on the inner Sheet. On iOS Safari the visual viewport
+    // shrinks under the on-screen keyboard but `vh` units do not reflect
+    // it, so the Apply button sat below the keyboard, unreachable. The
+    // sheet now uses dynamic-viewport units, allows the inner sheet to
+    // scroll, and reserves padding for the iPhone home-indicator
+    // (safe-area-inset-bottom).
+    it('Sheet has overflow scroll and dvh max-height so the footer stays reachable on mobile', () => {
+      const { getByRole } = renderWithTheme(
+        <FieldInputDrawer
+          open
+          kind="text"
+          label="Job title"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      const dialog = getByRole('dialog');
+      // The Sheet is the dialog's only direct element child (Backdrop > Sheet).
+      const sheet = dialog.firstElementChild as HTMLElement;
+      const styles = window.getComputedStyle(sheet);
+      // jsdom does not honour the @supports(env()) call, so we assert on
+      // the rendered CSSOM properties directly. Both `max-height` and
+      // `overflow-y: auto` must be present so the footer is reachable
+      // even when the visual viewport shrinks under the soft keyboard.
+      expect(sheet.style.cssText + styles.cssText).toMatch(/max-height/i);
+      expect(sheet.style.cssText + styles.cssText).toMatch(/overflow/i);
+    });
+
+    it('traps Tab focus inside the dialog (a11y regression)', async () => {
+      // BUG FIX: aria-modal="true" was set but Tab navigation was not
+      // trapped. Keyboard users could Tab outside the open dialog and
+      // interact with the page underneath, defeating the modal contract.
+      // The fix adds a Tab-cycle handler so focus stays within the sheet.
+      // We render an external focusable element to assert it never receives
+      // keyboard focus while the dialog is open.
+      const { getByRole, getByTestId } = renderWithTheme(
+        <>
+          <button data-testid="external" type="button">
+            Outside
+          </button>
+          <FieldInputDrawer
+            open
+            kind="text"
+            label="Job title"
+            onCancel={() => {}}
+            onApply={() => {}}
+          />
+        </>,
+      );
+      const dialog = getByRole('dialog');
+      const external = getByTestId('external');
+      // Type a value so the Apply button is no longer disabled (disabled
+      // controls are skipped by browser tab order).
+      await userEvent.type(getByRole('textbox', { name: 'Job title' }), 'Engineer');
+      const apply = getByRole('button', { name: /apply/i });
+      apply.focus();
+      expect(document.activeElement).toBe(apply);
+      // Tab forward from the last focusable inside the sheet — focus
+      // should wrap back into the dialog, NOT escape to the external btn.
+      await userEvent.tab();
+      expect(document.activeElement).not.toBe(external);
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    it('Backdrop uses dynamic-viewport height so the iOS keyboard does not push the sheet offscreen', () => {
+      const { getByRole } = renderWithTheme(
+        <FieldInputDrawer
+          open
+          kind="text"
+          label="Job title"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      const dialog = getByRole('dialog');
+      // Read the raw CSS text — jsdom drops `100dvh` from the computed
+      // style, but the literal source is preserved in the styled
+      // component's injected stylesheet, accessible via .cssText.
+      const allStyles = Array.from(document.styleSheets)
+        .flatMap((s) => {
+          try {
+            return Array.from(s.cssRules);
+          } catch {
+            return [];
+          }
+        })
+        .map((r) => r.cssText)
+        .join('\n');
+      // Match either the modern `dvh` unit or a fallback `height: 100%` with
+      // `min-height: 100%` — both keep the backdrop bound to the visual
+      // viewport instead of the layout viewport on iOS Safari.
+      expect(allStyles).toMatch(/dvh|svh/i);
+      void dialog;
+    });
+  });
 });

--- a/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.tsx
+++ b/apps/web/src/components/FieldInputDrawer/FieldInputDrawer.tsx
@@ -42,11 +42,27 @@ function validate(kind: FieldInputKind, value: string): string | null {
  * L2 bottom-sheet for typing a text / email / date / name value. Used by the
  * fill page for every non-signature field.
  */
+/**
+ * BUG FIX (a11y): the dialog had `aria-modal="true"` but no Tab trap, so
+ * keyboard users could escape the modal and interact with the page
+ * underneath. This selector enumerates the focusable controls inside the
+ * sheet so we can wrap Tab / Shift+Tab at the boundaries.
+ */
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
 export const FieldInputDrawer = forwardRef<HTMLDivElement, FieldInputDrawerProps>((props, ref) => {
   const { open, label, kind, initialValue, onCancel, onApply, ...rest } = props;
   const [value, setValue] = useState<string>(initialValue ?? '');
   const [touched, setTouched] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const sheetRef = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -54,7 +70,31 @@ export const FieldInputDrawer = forwardRef<HTMLDivElement, FieldInputDrawerProps
     setTouched(false);
     const t = setTimeout(() => inputRef.current?.focus(), 0);
     function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onCancel();
+      if (e.key === 'Escape') {
+        onCancel();
+        return;
+      }
+      // Focus trap: when Tab / Shift+Tab would land outside the sheet,
+      // wrap to the other end. Without this, aria-modal="true" is a lie
+      // because keyboard focus can leak to the page underneath.
+      if (e.key !== 'Tab') return;
+      const sheet = sheetRef.current;
+      if (!sheet) return;
+      const focusables = Array.from(sheet.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+        (el) => !el.hasAttribute('inert'),
+      );
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) return;
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey && (active === first || !sheet.contains(active))) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && (active === last || !sheet.contains(active))) {
+        e.preventDefault();
+        first.focus();
+      }
     }
     document.addEventListener('keydown', onKey);
     return () => {
@@ -83,7 +123,7 @@ export const FieldInputDrawer = forwardRef<HTMLDivElement, FieldInputDrawerProps
       ref={ref}
       {...rest}
     >
-      <Sheet onClick={(e) => e.stopPropagation()}>
+      <Sheet onClick={(e) => e.stopPropagation()} ref={sheetRef}>
         <HeaderRow>
           <Title>{label}</Title>
           <CloseBtn type="button" onClick={onCancel} aria-label="Cancel">

--- a/apps/web/src/components/SignatureCapture/SignatureCapture.styles.ts
+++ b/apps/web/src/components/SignatureCapture/SignatureCapture.styles.ts
@@ -3,6 +3,13 @@ import styled from 'styled-components';
 export const Backdrop = styled.div`
   position: fixed;
   inset: 0;
+  /* Same dvh+safe-area treatment as FieldInputDrawer — without it the
+     bottom action row (Apply / Cancel) sat behind the iOS keyboard or
+     home indicator on iPhone 13/14/15 viewports. \`100vh\` reflects the
+     LAYOUT viewport on iOS, not the visual viewport. */
+  height: 100vh;
+  height: 100svh;
+  height: 100dvh;
   background: rgba(11, 18, 32, 0.5);
   z-index: ${({ theme }) => theme.z.modal};
   display: flex;
@@ -13,9 +20,14 @@ export const Backdrop = styled.div`
 export const Sheet = styled.div`
   width: 100%;
   max-width: 680px;
+  /* Cap to the visual viewport so the draw canvas + tabs + apply button
+     all stay reachable on a 667px-tall iPhone with the keyboard up.
+     Inner scroll keeps focus management predictable. */
+  max-height: 100dvh;
+  overflow-y: auto;
   background: ${({ theme }) => theme.color.paper};
   border-radius: 20px 20px 0 0;
-  padding: ${({ theme }) => theme.space[6]} 28px 28px;
+  padding: ${({ theme }) => theme.space[6]} 28px calc(28px + env(safe-area-inset-bottom, 0px));
   box-shadow: 0 -10px 40px rgba(11, 18, 32, 0.2);
 `;
 

--- a/apps/web/src/pages/SigningPrepPage/SigningPrepPage.test.tsx
+++ b/apps/web/src/pages/SigningPrepPage/SigningPrepPage.test.tsx
@@ -236,10 +236,12 @@ describe('SigningPrepPage', () => {
     expect(alert).toHaveTextContent(/could not record your acceptance/i);
   });
 
-  it('NotMe button POSTs decline with reason "not-the-recipient" and routes to /declined', async () => {
-    // "Not me?" is a soft decline — handled silently (no confirm), but
-    // it must POST /sign/decline with the dedicated reason so the audit
-    // trail distinguishes it from a deliberate decline.
+  it('NotMe button confirms first, then POSTs decline with reason "not-the-recipient" and routes to /declined', async () => {
+    // BUG FIX: "Not me?" was previously a one-tap destructive action with
+    // no confirmation. On mobile the small target near the avatar made
+    // accidental decline trivial. We now require confirmation before
+    // sending the audit-logged decline.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     post.mockResolvedValueOnce(okResponse({ status: 'declined', envelope_status: 'declined' }));
     renderPrep();
     await userEvent.click(await screen.findByRole('button', { name: /not me\?/i }));
@@ -257,9 +259,20 @@ describe('SigningPrepPage', () => {
     });
   });
 
+  it('NotMe button cancelled at confirm does NOT POST and stays on /prep', async () => {
+    // BUG FIX (regression): tapping Not me by accident must be undoable
+    // via the native confirm dialog before any audit event lands.
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    renderPrep();
+    await userEvent.click(await screen.findByRole('button', { name: /not me\?/i }));
+    expect(post).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('__pathname__')).toBeNull();
+  });
+
   it('NotMe button swallows API failure and re-enables the rest of the UI', async () => {
     // The intentionally-quiet handleNotMe `catch {}` branch — failure
     // unsticks `busy` so the signer can still decline/withdraw normally.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     post.mockRejectedValueOnce(new Error('network down'));
     renderPrep();
     await userEvent.click(await screen.findByRole('button', { name: /not me\?/i }));

--- a/apps/web/src/pages/SigningPrepPage/SigningPrepPage.tsx
+++ b/apps/web/src/pages/SigningPrepPage/SigningPrepPage.tsx
@@ -115,7 +115,20 @@ function Content() {
   const handleNotMe = useCallback(() => {
     // Treat "Not me" as a decline with a specific reason. Simpler than a
     // dedicated endpoint and surfaces the same audit event on the backend.
+    //
+    // BUG FIX: previously fired immediately on click — a small target near
+    // the user's avatar made accidental decline trivial on mobile. Confirm
+    // the destructive action just like `handleDecline` does. The audit
+    // event is irreversible (and emails the sender), so the one-tap UX
+    // failure mode was real.
     if (busy) return;
+    // eslint-disable-next-line no-alert -- native confirm is appropriate; mirrors handleDecline above.
+    const confirmed = window.confirm(
+      'Are you not the intended recipient?\n\n' +
+        "We'll let the sender know to send a fresh link to the right person. " +
+        'This is recorded in the audit trail and cannot be undone.',
+    );
+    if (!confirmed) return;
     (async () => {
       setBusy(true);
       try {


### PR DESCRIPTION
## Summary

QA audit of the signer journey (entry → prep → fill → review → done / declined) at 375x667 + larger viewports surfaced **3 real bugs** with test-before-fix coverage and **4 new BDD scenarios** (2 marked `@smoke`).

### Bugs found

| # | Severity | Lens | Description |
|---|---|---|---|
| 1 | **Critical** | UI / mobile | `FieldInputDrawer` + `SignatureCapture` bottom sheets used `100vh` + no `max-height` + no `safe-area-inset-bottom`. On iOS Safari with the soft keyboard up, the Apply button sat below the visual viewport with no way to commit a value. Notched iPhones clipped the action row under the home indicator. |
| 2 | **High** | UX / logic | `SigningPrepPage.handleNotMe` fired an irreversible `decline('not-the-recipient')` audit event the instant the user tapped the small "Not me?" button next to their avatar. No confirmation. One-tap accidental decline. |
| 3 | **High** | a11y | `FieldInputDrawer` set `aria-modal="true"` but had no Tab focus trap. Keyboard users could Tab outside the open dialog and operate the page underneath. |

### Fixes

- `FieldInputDrawer.styles.ts` + `SignatureCapture.styles.ts` — `100vh / 100svh / 100dvh` cascade on the backdrop, `max-height: 100dvh` + `overflow-y: auto` on the inner sheet, `padding-bottom: calc(28px + env(safe-area-inset-bottom, 0px))`.
- `SigningPrepPage.tsx` — `handleNotMe` now mirrors `handleDecline`'s `window.confirm` pattern; cancelling exits early before any POST.
- `FieldInputDrawer.tsx` — Tab / Shift+Tab key handler wraps focus at the first / last focusable inside the sheet.

### BDD scenarios added

- `apps/web/e2e/features/signer-mobile.feature`
  - `@smoke` Recipient completes signing on a 375x667 viewport
  - `@smoke` The bottom-sheet Apply button stays reachable on a phone
- `apps/web/e2e/features/signer-not-me.feature`
  - `@smoke` Tapping Not me by accident does not decline the envelope
  - `@regression` Confirming Not me declines and routes to the declined page

## Test plan

- [x] `pnpm --filter web typecheck` (clean)
- [x] `pnpm --filter web lint` (clean)
- [x] `pnpm --filter web test` (1178 passed)
- [x] `pnpm --filter web exec playwright test --project=chromium-bdd -g "@signer"` (8 passed including 4 new)
- [x] Native pre-commit hook: prettier + lint-staged + repo-wide typecheck

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)