### PR TITLE
fix(templates,contacts): close 3 QA-audit bugs + BDD coverage

### DIFF
--- a/apps/web/e2e/features/contacts-keyboard.feature
+++ b/apps/web/e2e/features/contacts-keyboard.feature
@@ -1,0 +1,28 @@
+Feature: Sender adds a signer using only the keyboard
+
+  The contacts dialog is the fastest path to a new signer for power
+  users. Bug B (regression closed 2026-05-02) blocked Enter-to-submit
+  inside the dialog because the inputs lacked any keydown handler;
+  Bug C surfaced the wrong field's validation error. These scenarios
+  guard the keyboard-only happy path + keyboard-only validation
+  feedback so neither regresses.
+
+  Background:
+    Given a signed-in sender on the contacts page with the API ready to accept "Carla" "carla@example.com"
+
+  @sender @smoke
+  Scenario: Sender adds a signer by pressing Enter inside the dialog
+    When the sender opens the add-signer dialog
+    And the sender types "Carla" into the name field
+    And the sender types "carla@example.com" into the email field
+    And the sender presses Enter
+    Then the add-signer dialog closes
+    And "Carla" appears in the contacts list
+
+  @sender @smoke
+  Scenario: Validation error attaches to the field that caused it
+    When the sender opens the add-signer dialog
+    And the sender types "carla@example.com" into the email field
+    And the sender submits the dialog
+    Then the name field shows the "Please enter a name." error
+    And the email field has no error

--- a/apps/web/e2e/features/template-delete.feature
+++ b/apps/web/e2e/features/template-delete.feature
@@ -1,0 +1,19 @@
+Feature: Sender confirms or dismisses template deletion
+
+  The templates list lets a sender remove a template they no longer
+  reuse. The destructive action is gated behind a confirmation modal.
+  Bug A (regression closed 2026-05-02) blocked Escape from dismissing
+  the modal — keyboard-only users had no way out short of confirming
+  the destructive action, violating WCAG 2.1.2 (No Keyboard Trap).
+  This scenario guards the dismissal path.
+
+  Background:
+    Given a signed-in sender on the templates page with a template named "Quarterly NDA"
+
+  @sender @smoke
+  Scenario: Sender dismisses delete confirmation with Escape
+    When the sender clicks Delete on the "Quarterly NDA" template
+    Then the delete confirmation for "Quarterly NDA" is open
+    When the sender presses Escape
+    Then the delete confirmation for "Quarterly NDA" is closed
+    And the "Quarterly NDA" template is still in the list

--- a/apps/web/e2e/fixtures/test.ts
+++ b/apps/web/e2e/fixtures/test.ts
@@ -12,6 +12,7 @@ import { UploadPage } from '../pages/UploadPage';
 import { DocumentEditorPage } from '../pages/DocumentEditorPage';
 import { SentConfirmationPage } from '../pages/SentConfirmationPage';
 import { ContactsPage } from '../pages/ContactsPage';
+import { TemplatesListPage } from '../pages/TemplatesListPage';
 import { SigningEntryPage } from '../pages/SigningEntryPage';
 import { SigningPrepPage } from '../pages/SigningPrepPage';
 import { SigningFillPage } from '../pages/SigningFillPage';
@@ -56,6 +57,7 @@ type Fixtures = {
   documentEditorPage: DocumentEditorPage;
   sentConfirmationPage: SentConfirmationPage;
   contactsPage: ContactsPage;
+  templatesListPage: TemplatesListPage;
   signingEntryPage: SigningEntryPage;
   signingPrepPage: SigningPrepPage;
   signingFillPage: SigningFillPage;
@@ -121,6 +123,9 @@ export const test = base.extend<Fixtures>({
   },
   contactsPage: async ({ page }, use) => {
     await use(new ContactsPage(page));
+  },
+  templatesListPage: async ({ page }, use) => {
+    await use(new TemplatesListPage(page));
   },
   signingEntryPage: async ({ page }, use) => {
     await use(new SigningEntryPage(page));

--- a/apps/web/e2e/pages/TemplatesListPage.ts
+++ b/apps/web/e2e/pages/TemplatesListPage.ts
@@ -47,8 +47,13 @@ export class TemplatesListPage {
   }
 
   async expectTemplateVisible(name: string): Promise<void> {
-    // Template names render inside an `aria-labelledby="tpl-name-..."`
-    // article — querying by accessible name picks that up.
-    await expect(this.page.getByRole('article', { name: new RegExp(name, 'i') })).toBeVisible();
+    // The TemplateCard root carries `role="button"` +
+    // `aria-labelledby="tpl-name-<id>"` so its accessible name resolves
+    // to the displayed template name. Multiple cards on the page may
+    // match (e.g. when the user navigates Use vs Edit), so .first()
+    // keeps the assertion focused on existence rather than uniqueness.
+    await expect(
+      this.page.getByRole('button', { name: new RegExp(`^${name}$`, 'i') }).first(),
+    ).toBeVisible();
   }
 }

--- a/apps/web/e2e/pages/TemplatesListPage.ts
+++ b/apps/web/e2e/pages/TemplatesListPage.ts
@@ -1,0 +1,54 @@
+import { expect, type Page } from '@playwright/test';
+
+/**
+ * Page Object for `/templates` (TemplatesListPage). Mirrors the rest of
+ * the e2e Page Objects: thin wrapper over `page` exposing semantic
+ * affordances (rule 4.6 — query by accessible role/name only).
+ *
+ * Scope is intentionally narrow — only the actions the templates BDD
+ * scenarios in this folder exercise:
+ *   - navigating to the page
+ *   - opening the delete-confirmation modal for a named template
+ *   - asserting the modal is open / closed
+ *   - asserting a template is still listed (used by the Bug A regression
+ *     scenario to prove that pressing Escape did not delete it)
+ */
+export class TemplatesListPage {
+  constructor(private readonly page: Page) {}
+
+  async goto(): Promise<void> {
+    await this.page.goto('/templates');
+  }
+
+  async expectVisible(): Promise<void> {
+    // Page header always renders the "Create a new template" CreateCard,
+    // even when the list is empty.
+    await expect(this.page.getByRole('button', { name: /create a new template/i })).toBeVisible();
+  }
+
+  /** Opens the delete-confirmation modal by clicking the row's Delete button. */
+  async openDeleteModal(name: string): Promise<void> {
+    await this.page
+      .getByRole('button', { name: new RegExp(`^delete ${name}$`, 'i') })
+      .first()
+      .click();
+  }
+
+  async expectDeleteModalOpen(name: string): Promise<void> {
+    await expect(
+      this.page.getByRole('dialog', { name: new RegExp(`delete ${name}`, 'i') }),
+    ).toBeVisible();
+  }
+
+  async expectDeleteModalClosed(name: string): Promise<void> {
+    await expect(
+      this.page.getByRole('dialog', { name: new RegExp(`delete ${name}`, 'i') }),
+    ).toHaveCount(0);
+  }
+
+  async expectTemplateVisible(name: string): Promise<void> {
+    // Template names render inside an `aria-labelledby="tpl-name-..."`
+    // article — querying by accessible name picks that up.
+    await expect(this.page.getByRole('article', { name: new RegExp(name, 'i') })).toBeVisible();
+  }
+}

--- a/apps/web/e2e/steps/contacts-keyboard.steps.ts
+++ b/apps/web/e2e/steps/contacts-keyboard.steps.ts
@@ -1,0 +1,100 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { Given, When, Then } = createBdd(test);
+
+Given(
+  'a signed-in sender on the contacts page with the API ready to accept {string} {string}',
+  async ({ seededUser, mockedApi, contactsPage }, name: string, email: string) => {
+    await seededUser.signInAs();
+    mockedApi.on('GET', /\/api\/contacts(\?|$)/, { json: [] });
+    mockedApi.on('POST', /\/api\/contacts$/, {
+      json: {
+        id: `c_${name.toLowerCase()}`,
+        owner_id: '00000000-0000-4000-8000-000000000a11',
+        name,
+        email,
+        color: '#3b82f6',
+        created_at: '2026-05-02T10:00:00Z',
+        updated_at: '2026-05-02T10:00:00Z',
+      },
+    });
+    await contactsPage.goto();
+  },
+);
+
+/**
+ * BDD step defs for `features/contacts-keyboard.feature`. Covers Bug B
+ * (Enter inside the add-signer dialog must submit) and Bug C (a single
+ * `error` slot was painting name-validation errors under the email
+ * field). Steps query by accessible role/name only (rule 4.6).
+ *
+ * The shared `Given a signed-in sender on the contacts page` lives in
+ * `sender-contacts.steps.ts` — playwright-bdd auto-discovers every
+ * `*.steps.ts` so we don't need to (and must not) re-declare it here.
+ * The shared Given already mocks GET /api/contacts → [] and POST
+ * /api/contacts → a fixture row whose name happens to be "Dana"; the
+ * existing scenario also adds a "Dana"/"dana@example.com" pair, so the
+ * mocked POST response is shape-compatible with any add-signer flow
+ * regardless of the typed payload (the SPA renders what came back).
+ */
+
+When('the sender opens the add-signer dialog', async ({ page }) => {
+  await page
+    .getByRole('button', { name: /^add signer$/i })
+    .first()
+    .click();
+  await expect(page.getByRole('dialog', { name: /add signer/i })).toBeVisible();
+});
+
+When('the sender types {string} into the name field', async ({ page }, value: string) => {
+  const dialog = page.getByRole('dialog', { name: /add signer/i });
+  await dialog.getByRole('textbox', { name: /^name$/i }).fill(value);
+});
+
+When('the sender types {string} into the email field', async ({ page }, value: string) => {
+  const dialog = page.getByRole('dialog', { name: /add signer/i });
+  await dialog.getByRole('textbox', { name: /^email$/i }).fill(value);
+});
+
+When('the sender presses Enter', async ({ page }) => {
+  // Focus is already inside the email field (fill leaves the caret there);
+  // the page wires Enter-to-submit on each input via onKeyDown.
+  await page.keyboard.press('Enter');
+});
+
+When('the sender submits the dialog', async ({ page }) => {
+  await page
+    .getByRole('dialog', { name: /add signer/i })
+    .getByRole('button', { name: /^add signer$/i })
+    .click();
+});
+
+Then('the add-signer dialog closes', async ({ page }) => {
+  await expect(page.getByRole('dialog', { name: /add signer/i })).toHaveCount(0);
+});
+
+// Note: `Then '{string} appears in the contacts list'` already lives in
+// `sender-contacts.steps.ts`; playwright-bdd auto-discovers all step
+// files so re-declaring it here would throw a duplicate-step error.
+
+Then('the name field shows the {string} error', async ({ page }, message: string) => {
+  const dialog = page.getByRole('dialog', { name: /add signer/i });
+  const nameInput = dialog.getByRole('textbox', { name: /^name$/i });
+  // The TextField wires `aria-describedby` → `<input>-err` only when
+  // `error` is set, so resolving the id back to its element gives us
+  // both "the name field is the one being flagged" and "the error
+  // text matches what the user sees".
+  const describedBy = await nameInput.getAttribute('aria-describedby');
+  expect(describedBy, 'name field has no aria-describedby — error not attached').toBeTruthy();
+  if (!describedBy) return;
+  const errorEl = page.locator(`#${describedBy}`);
+  await expect(errorEl).toHaveText(new RegExp(message.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'));
+});
+
+Then('the email field has no error', async ({ page }) => {
+  const dialog = page.getByRole('dialog', { name: /add signer/i });
+  const emailInput = dialog.getByRole('textbox', { name: /^email$/i });
+  await expect(emailInput).not.toHaveAttribute('aria-invalid', 'true');
+});

--- a/apps/web/e2e/steps/template-delete.steps.ts
+++ b/apps/web/e2e/steps/template-delete.steps.ts
@@ -20,17 +20,26 @@ Given(
   'a signed-in sender on the templates page with a template named {string}',
   async ({ seededUser, mockedApi, templatesListPage }, name: string) => {
     await seededUser.signInAs();
+    // Mirror the wire shape the Nest TemplatesController returns
+    // (`apps/web/src/features/templates/templatesApi.ts#ApiTemplate`).
+    // Crucially: `title` (not `name`) — the SPA maps `title` → summary.name,
+    // and the per-card aria-label is `Delete ${name}` — without `title`
+    // the Delete button's accessible name would be empty.
     mockedApi.on('GET', /\/api\/templates(\?|$)/, {
       json: [
         {
           id: 'tpl_qnda',
           owner_id: '00000000-0000-4000-8000-000000000a11',
-          name,
+          title: name,
+          description: 'Mutual NDA used quarterly with vendor onboarding.',
+          cover_color: '#EEF2FF',
+          field_layout: [],
           tags: ['legal'],
-          page_count: 2,
-          // The list page only renders summary fields; sticking to the
-          // observed shape from the API integration tests.
-          created_at: '2026-05-02T10:00:00Z',
+          last_signers: [],
+          has_example_pdf: false,
+          uses_count: 3,
+          last_used_at: '2026-04-15T10:00:00Z',
+          created_at: '2026-04-01T10:00:00Z',
           updated_at: '2026-05-02T10:00:00Z',
         },
       ],

--- a/apps/web/e2e/steps/template-delete.steps.ts
+++ b/apps/web/e2e/steps/template-delete.steps.ts
@@ -1,0 +1,70 @@
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { Given, When, Then } = createBdd(test);
+
+/**
+ * BDD step defs for `features/template-delete.feature`. Covers Bug A
+ * (Escape must dismiss the delete-confirmation modal — WCAG 2.1.2 No
+ * Keyboard Trap). Steps query by accessible role/name only (rule 4.6).
+ *
+ * The mocks build a single `GET /api/templates` response with one
+ * template so the templates list renders a card the user can target.
+ * No DELETE handler is registered: if the modal were ever confirmed,
+ * the test would surface "no mock registered" and fail loudly — but the
+ * flow under test deliberately *dismisses* the modal, so the DELETE
+ * must never fire.
+ */
+
+Given(
+  'a signed-in sender on the templates page with a template named {string}',
+  async ({ seededUser, mockedApi, templatesListPage }, name: string) => {
+    await seededUser.signInAs();
+    mockedApi.on('GET', /\/api\/templates(\?|$)/, {
+      json: [
+        {
+          id: 'tpl_qnda',
+          owner_id: '00000000-0000-4000-8000-000000000a11',
+          name,
+          tags: ['legal'],
+          page_count: 2,
+          // The list page only renders summary fields; sticking to the
+          // observed shape from the API integration tests.
+          created_at: '2026-05-02T10:00:00Z',
+          updated_at: '2026-05-02T10:00:00Z',
+        },
+      ],
+    });
+    await templatesListPage.goto();
+    await templatesListPage.expectVisible();
+  },
+);
+
+When(
+  'the sender clicks Delete on the {string} template',
+  async ({ templatesListPage }, name: string) => {
+    await templatesListPage.openDeleteModal(name);
+  },
+);
+
+When('the sender presses Escape', async ({ page }) => {
+  await page.keyboard.press('Escape');
+});
+
+Then(
+  'the delete confirmation for {string} is open',
+  async ({ templatesListPage }, name: string) => {
+    await templatesListPage.expectDeleteModalOpen(name);
+  },
+);
+
+Then(
+  'the delete confirmation for {string} is closed',
+  async ({ templatesListPage }, name: string) => {
+    await templatesListPage.expectDeleteModalClosed(name);
+  },
+);
+
+Then('the {string} template is still in the list', async ({ templatesListPage }, name: string) => {
+  await templatesListPage.expectTemplateVisible(name);
+});

--- a/apps/web/src/pages/ContactsPage/ContactsPage.dialog-ux.test.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.dialog-ux.test.tsx
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ContactsPage } from './ContactsPage';
+import { renderWithProviders } from '../../test/renderWithProviders';
+
+/**
+ * Regression coverage discovered by the templates+contacts QA audit
+ * (qa/templates-contacts-bdd, 2026-05-02).
+ *
+ * Bug B — Pressing Enter inside the Name or Email field of the
+ *         add-signer dialog must submit the form. Power senders type
+ *         a name, tab to email, type, then press Enter to save —
+ *         keeping their hands on the keyboard. Previously the dialog
+ *         had no <form> wrapper and Enter did nothing.
+ *
+ * Bug C — When validation fails because the *name* field is empty,
+ *         the error message ("Please enter a name.") was being rendered
+ *         under the *email* field because the `error` prop was wired
+ *         only to the email TextField. The error must surface against
+ *         the field that triggered it.
+ */
+vi.mock('../../lib/api/apiClient', () => {
+  const SEED = [
+    {
+      id: 'c1',
+      owner_id: 't',
+      name: 'Eliran Azulay',
+      email: 'eliran@azulay.co',
+      color: '#F472B6',
+      created_at: '',
+      updated_at: '',
+    },
+  ];
+  return {
+    apiClient: {
+      get: vi.fn(async (url: string) => {
+        if (url === '/contacts') return { data: SEED, status: 200 };
+        return { data: {}, status: 200 };
+      }),
+      post: vi.fn(async (_url: string, body: { name: string; email: string; color: string }) => ({
+        data: {
+          id: `c_new_${Date.now()}`,
+          owner_id: 't',
+          name: body.name,
+          email: body.email,
+          color: body.color,
+          created_at: '',
+          updated_at: '',
+        },
+        status: 201,
+      })),
+      patch: vi.fn(async (url: string, body: Record<string, unknown>) => ({
+        data: { id: url.split('/').pop(), owner_id: 't', ...body, created_at: '', updated_at: '' },
+        status: 200,
+      })),
+      delete: vi.fn(async () => ({ data: null, status: 204 })),
+    },
+  };
+});
+
+function renderContacts() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/signers']}>
+      <ContactsPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ContactsPage — add-signer dialog UX (regression)', () => {
+  it('Bug B — pressing Enter inside the email field submits the dialog', async () => {
+    renderContacts();
+    await screen.findByText(/eliran azulay/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /^add signer$/i }));
+    const dialog = screen.getByRole('dialog', { name: /^add signer$/i });
+    // Query by accessible name (rule 4.6) — the TextField wires
+    // <label htmlFor> so getByRole('textbox') resolves cleanly.
+    const nameInput = within(dialog).getByRole('textbox', {
+      name: /^name$/i,
+    }) as HTMLInputElement;
+    const emailInput = within(dialog).getByRole('textbox', {
+      name: /^email$/i,
+    }) as HTMLInputElement;
+
+    await userEvent.type(nameInput, 'Keyboard Carla');
+    await userEvent.type(emailInput, 'carla@example.com{Enter}');
+
+    // Dialog should close and the new signer should appear in the table.
+    expect(await screen.findByText(/keyboard carla/i)).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: /^add signer$/i })).toBeNull();
+  });
+
+  it('Bug C — empty name submission shows the name-validation error against the name field', async () => {
+    renderContacts();
+    await screen.findByText(/eliran azulay/i);
+
+    await userEvent.click(screen.getByRole('button', { name: /^add signer$/i }));
+    const dialog = screen.getByRole('dialog', { name: /^add signer$/i });
+    // Query by accessible name (rule 4.6) — the TextField wires
+    // <label htmlFor> so getByRole('textbox') resolves cleanly.
+    const nameInput = within(dialog).getByRole('textbox', {
+      name: /^name$/i,
+    }) as HTMLInputElement;
+    const emailInput = within(dialog).getByRole('textbox', {
+      name: /^email$/i,
+    }) as HTMLInputElement;
+
+    // Leave name blank, type a valid email, attempt to submit.
+    await userEvent.type(emailInput, 'someone@example.com');
+    await userEvent.click(within(dialog).getByRole('button', { name: /^add signer$/i }));
+
+    // The "please enter a name" error must appear and must be associated
+    // with the Name field via `aria-describedby`/`aria-errormessage`, not
+    // attached to the email field where the user wasn't asked for input.
+    const nameError = await within(dialog).findByText(/please enter a name/i);
+    expect(nameError).toBeInTheDocument();
+
+    // The Name input is the one in error — its aria-describedby points
+    // at the same node as the rendered error message.
+    const describedBy = nameInput.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toBe(nameError.getAttribute('id'));
+  });
+});

--- a/apps/web/src/pages/ContactsPage/ContactsPage.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.tsx
@@ -120,19 +120,33 @@ export function ContactsPage() {
   const [dialog, setDialog] = useState<DialogState>({ mode: 'closed' });
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
-  const [error, setError] = useState<string | null>(null);
+  /**
+   * Per-field error state. Previously the dialog held a single `error`
+   * string and bound it to the email TextField's `error` prop — so a
+   * "Please enter a name." validation message rendered under the wrong
+   * field, confusing the user into editing the email when their name
+   * was the actual problem. Tracking each field independently lets us
+   * point screen readers + sighted users at the field that failed.
+   */
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [emailError, setEmailError] = useState<string | null>(null);
+
+  const resetFieldErrors = (): void => {
+    setNameError(null);
+    setEmailError(null);
+  };
 
   const openAdd = (): void => {
     setName('');
     setEmail('');
-    setError(null);
+    resetFieldErrors();
     setDialog({ mode: 'add' });
   };
 
   const openEdit = (contact: AddSignerContact): void => {
     setName(contact.name);
     setEmail(contact.email);
-    setError(null);
+    resetFieldErrors();
     setDialog({ mode: 'edit', contact });
   };
 
@@ -146,15 +160,16 @@ export function ContactsPage() {
     if (submitting) return;
     const trimmedName = name.trim();
     const trimmedEmail = email.trim();
-    if (!trimmedName) {
-      setError('Please enter a name.');
-      return;
-    }
-    if (!isValidEmail(trimmedEmail)) {
-      setError('Please enter a valid email address.');
-      return;
-    }
-    setError(null);
+    // Validate both fields up front so the user sees every issue at
+    // once rather than fixing one only to discover the next on resubmit.
+    const nextNameError = trimmedName ? null : 'Please enter a name.';
+    const nextEmailError = isValidEmail(trimmedEmail)
+      ? null
+      : 'Please enter a valid email address.';
+    setNameError(nextNameError);
+    setEmailError(nextEmailError);
+    if (nextNameError || nextEmailError) return;
+
     setSubmitting(true);
     try {
       if (dialog.mode === 'add') {
@@ -180,7 +195,10 @@ export function ContactsPage() {
       } else {
         message = 'Could not save contact. Something went wrong — please try again.';
       }
-      setError(message);
+      // Server-side errors are most often email-related (duplicate,
+      // syntactic), so attach to the email field. Pure name validation
+      // is caught client-side above.
+      setEmailError(message);
     } finally {
       setSubmitting(false);
     }
@@ -258,21 +276,56 @@ export function ContactsPage() {
             onClick={(e) => e.stopPropagation()}
           >
             <DialogTitle>{dialog.mode === 'add' ? 'Add signer' : 'Edit signer'}</DialogTitle>
+            {/*
+              We deliberately don't wrap the inputs in a <form>:
+              DialogCard above stops click propagation (so the
+              backdrop doesn't close the modal when the user clicks
+              inside), which also stops the browser from delivering
+              the implicit `submit` event after a click on a
+              type="submit" button. Instead we wire Enter handling
+              directly on the inputs and call `handleSubmit()` from
+              both the button click and the keydown — keyboard users
+              still get one-press submission without depending on
+              implicit form submission.
+            */}
             <FieldStack>
-              <TextField label="Name" value={name} onChange={(next) => setName(next)} autoFocus />
+              <TextField
+                label="Name"
+                value={name}
+                onChange={(next) => setName(next)}
+                autoFocus
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void handleSubmit();
+                  }
+                }}
+                {...(nameError ? { error: nameError } : {})}
+              />
               <TextField
                 label="Email"
                 type="email"
                 value={email}
                 onChange={(next) => setEmail(next)}
-                {...(error ? { error } : {})}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    void handleSubmit();
+                  }
+                }}
+                {...(emailError ? { error: emailError } : {})}
               />
             </FieldStack>
             <DialogFooter>
               <Button variant="ghost" onClick={closeDialog}>
                 Cancel
               </Button>
-              <Button variant="primary" onClick={handleSubmit}>
+              <Button
+                variant="primary"
+                onClick={() => {
+                  void handleSubmit();
+                }}
+              >
                 {dialog.mode === 'add' ? 'Add signer' : 'Save changes'}
               </Button>
             </DialogFooter>

--- a/apps/web/src/pages/TemplatesListPage/TemplatesListPage.modal-a11y.test.tsx
+++ b/apps/web/src/pages/TemplatesListPage/TemplatesListPage.modal-a11y.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { TemplatesListPage } from './TemplatesListPage';
+import { SAMPLE_TEMPLATES as TEMPLATES } from '../../test/templateFixtures';
+import { renderWithProviders } from '../../test/renderWithProviders';
+
+/**
+ * Regression coverage discovered by the templates+contacts QA audit
+ * (qa/templates-contacts-bdd, 2026-05-02).
+ *
+ * Bug A — The delete-confirmation modal previously trapped users:
+ *         clicking the backdrop closed it, but pressing Escape did
+ *         nothing. Per WCAG 2.1.2 (No Keyboard Trap) and the project's
+ *         own a11y standards, all modal dialogs must close on Escape.
+ */
+
+function renderPage() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/templates']}>
+      <Routes>
+        <Route path="/templates" element={<TemplatesListPage initialTemplates={TEMPLATES} />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('TemplatesListPage — delete modal a11y (regression)', () => {
+  it('Bug A — Escape closes the delete confirmation modal without deleting the template', async () => {
+    renderPage();
+    const original = TEMPLATES[0]!;
+    const before = screen.getAllByRole('heading', { level: 3 }).length;
+
+    await userEvent.click(screen.getByRole('button', { name: `Delete ${original.name}` }));
+    const dialog = await screen.findByRole('dialog', {
+      name: new RegExp(`delete ${original.name}`, 'i'),
+    });
+    expect(within(dialog).getByText(/delete this template\?/i)).toBeInTheDocument();
+
+    // Escape must dismiss the modal — NOT delete.
+    await userEvent.keyboard('{Escape}');
+
+    expect(
+      screen.queryByRole('dialog', { name: new RegExp(`delete ${original.name}`, 'i') }),
+    ).not.toBeInTheDocument();
+    // Template card is still present.
+    expect(screen.getByRole('heading', { level: 3, name: original.name })).toBeInTheDocument();
+    expect(screen.getAllByRole('heading', { level: 3 }).length).toBe(before);
+  });
+});

--- a/apps/web/src/pages/TemplatesListPage/TemplatesListPage.tsx
+++ b/apps/web/src/pages/TemplatesListPage/TemplatesListPage.tsx
@@ -294,6 +294,24 @@ export function TemplatesListPage({ initialTemplates }: TemplatesListPageProps =
     [editTagsFor, templates],
   );
 
+  /**
+   * Escape closes the delete confirmation modal — WCAG 2.1.2 (No
+   * Keyboard Trap). Previously the modal could only be dismissed via
+   * the backdrop click or the Cancel button; keyboard-only users had
+   * no way out short of confirming the destructive action. Bound at
+   * the document level so it fires regardless of focus location
+   * inside the modal; teardown is gated on `confirmDelete` so the
+   * listener exists only while the modal is open.
+   */
+  useEffect(() => {
+    if (!confirmDelete) return undefined;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setConfirmDelete(null);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [confirmDelete]);
+
   const isFiltered = query.length > 0 || activeTags.length > 0;
 
   const newTemplateTile = (


### PR DESCRIPTION
## Summary

QA audit of the templates+contacts surface surfaced three real bugs (1 a11y/UI, 2 UX/logic). All three are reproduced by test-before-fix vitest specs and locked behind `@smoke` BDD scenarios.

| # | Severity | Surface | Bug | Fix |
|---|---|---|---|---|
| A | UI / a11y | `TemplatesListPage` delete-confirmation modal | Escape didn't close the modal — WCAG 2.1.2 (No Keyboard Trap) | `useEffect` listens for Escape while `confirmDelete` is set |
| B | UX / keyboard | `ContactsPage` add-signer dialog | No Enter-to-submit (missing `<form>`; can't add one because `DialogCard.stopPropagation` blocks the implicit submit event) | Wire `onKeyDown` on each `TextField`; `handleSubmit()` from both keydown + button click |
| C | UX / a11y | `ContactsPage` add-signer dialog | A single `error` slot was bound only to the email field, so "Please enter a name." rendered under the wrong input | Split into `nameError` / `emailError`; each field gets its own `aria-describedby` + `aria-invalid` |

## React PR review block

- Files touched: 9 (2 src edits, 2 src tests, 5 e2e infra)
- MUST-FIX applied (rule 4.6 — accessible queries in new vitest spec)
- SHOULD-FIX: none
- Gates: `pnpm -r typecheck` ✓, `pnpm -r lint` ✓, web vitest 1177/1177 ✓, api jest 779/779 ✓, bddgen ✓

## Tests

- `apps/web/src/pages/ContactsPage/ContactsPage.dialog-ux.test.tsx` — Bugs B + C
- `apps/web/src/pages/TemplatesListPage/TemplatesListPage.modal-a11y.test.tsx` — Bug A
- `apps/web/e2e/features/contacts-keyboard.feature` — `@smoke` Enter-to-submit + per-field error attachment
- `apps/web/e2e/features/template-delete.feature` — `@smoke` Escape dismisses delete-confirmation

## Test plan

- [x] Local pre-commit gates green
- [ ] CI green on PR
- [ ] No regressions in adjacent flows (auth, signing, dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)