### PR TITLE
fix(security): close pentest findings F-001 (XSS) + F-002 (CSP)

### DIFF
--- a/apps/api/src/email/template.service.escape.spec.ts
+++ b/apps/api/src/email/template.service.escape.spec.ts
@@ -1,0 +1,109 @@
+// Regression: F-001 (HIGH) — email template HTML injection.
+//
+// `TemplateService.interpolate()` historically substituted `{{var}}`
+// placeholders verbatim. Variables like `envelope_title` and `sender_name`
+// originate from authenticated user DTOs and reach `<strong>{{envelope_title}}</strong>`
+// inside transactional HTML bodies. An attacker could inject `<a href=...>`
+// or other markup that some mail clients render. The fix: escape every
+// substituted value in the HTML body, with a carve-out for keys whose name
+// ends with `_html` (those are produced by `template-fragments.ts` whose
+// builders already escape their inputs and intentionally emit live markup).
+//
+// Plain-text and subject channels stay raw — there is no HTML rendering
+// context to defend.
+//
+// See memory/security_report_2026-05-02.md F-001.
+import { TemplateService } from './template.service';
+
+describe('TemplateService — HTML escaping (F-001)', () => {
+  let svc: TemplateService;
+
+  // Minimal vars set covering everything the `invite` template references.
+  const baseInviteVars: Record<string, string | number> = {
+    sender_name: 'Ada Lovelace',
+    sender_email: 'ada@example.com',
+    envelope_title: 'NDA v1',
+    sign_url: 'https://seald.nromomentum.com/sign/abc?t=xyz',
+    verify_url: 'https://seald.nromomentum.com/verify/abcde12345',
+    short_code: 'abcde12345xyz',
+    public_url: 'https://seald.nromomentum.com',
+    legal_entity: 'Seald, Inc.',
+    legal_postal: 'Postal address available on request — write to legal@seald.test.',
+    privacy_url: 'https://seald.nromomentum.com/legal/privacy',
+    preferences_url: 'mailto:privacy@seald.nromomentum.com?subject=Email%20preferences',
+  };
+
+  beforeAll(() => {
+    svc = new TemplateService();
+    svc.onModuleInit();
+  });
+
+  it('escapes HTML metacharacters in user-controlled vars when rendering body.html', () => {
+    const malicious = '<img src=x onerror=alert(1)><script>alert(2)</script>';
+    const out = svc.render('invite', {
+      ...baseInviteVars,
+      envelope_title: malicious,
+      sender_name: '"><svg/onload=alert(3)>',
+    });
+
+    // The escaped form must appear in the HTML body.
+    expect(out.html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+    expect(out.html).toContain('&lt;script&gt;alert(2)&lt;/script&gt;');
+    expect(out.html).toContain('&quot;&gt;&lt;svg/onload=alert(3)&gt;');
+
+    // The raw injection must NOT appear anywhere in the HTML body.
+    expect(out.html).not.toContain('<img src=x onerror');
+    expect(out.html).not.toContain('<script>alert(2)');
+    expect(out.html).not.toContain('<svg/onload=alert(3)');
+  });
+
+  it('does NOT escape `*_html` keys — fragment builders pre-escape and emit trusted markup', () => {
+    const trustedFragment =
+      '<table role="presentation" class="signers"><tr><td>Ada</td></tr></table>';
+    const out = svc.render('reminder', {
+      ...baseInviteVars,
+      expires_at_readable: '2026-05-24 00:00 UTC',
+      // `signer_list_html` is the fragment-builder output. It must reach
+      // the rendered body as live HTML, otherwise the email shows angle
+      // brackets to the user.
+      signer_list_html: trustedFragment,
+    });
+    expect(out.html).toContain(trustedFragment);
+    // And it must NOT have been escaped to entities.
+    expect(out.html).not.toContain('&lt;table');
+  });
+
+  it('does NOT escape body.txt or subject — those have no HTML rendering context', () => {
+    const out = svc.render('invite', {
+      ...baseInviteVars,
+      envelope_title: '<b>Q1 Roadmap & Pricing</b>',
+      sender_name: 'Ada & Co.',
+    });
+    // Subject is plain-text in the mail header — escaping would mangle it.
+    expect(out.subject).toContain('<b>Q1 Roadmap & Pricing</b>');
+    expect(out.subject).toContain('Ada & Co.');
+    // body.txt is plain-text — same reasoning.
+    expect(out.text).toContain('<b>Q1 Roadmap & Pricing</b>');
+    expect(out.text).toContain('Ada & Co.');
+  });
+
+  it('preserves URL safety — `*_url` keys still get escaped so `"` cannot break out of an href attribute', () => {
+    // If a URL ever sneaks through validation containing a quote, the
+    // escape must still neutralize attribute-context breakouts.
+    const out = svc.render('invite', {
+      ...baseInviteVars,
+      sign_url: 'https://seald.nromomentum.com/sign/abc"><script>alert(1)</script>',
+    });
+    expect(out.html).not.toContain('"><script>alert(1)</script>');
+    expect(out.html).toContain('&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('still substitutes safe content unchanged after escaping', () => {
+    const out = svc.render('invite', baseInviteVars);
+    expect(out.html).toContain('Ada Lovelace');
+    expect(out.html).toContain('NDA v1');
+    expect(out.html).toContain(baseInviteVars.sign_url as string);
+    // No leftover placeholders.
+    expect(out.html).not.toMatch(/\{\{[^}]+\}\}/);
+  });
+});

--- a/apps/api/src/email/template.service.ts
+++ b/apps/api/src/email/template.service.ts
@@ -140,11 +140,17 @@ ${fragment}
     if (!tpl) {
       throw new Error(`TemplateService: unknown template kind '${kind}'`);
     }
-    const interp = (s: string) => interpolate(s, vars, this.log, kind);
     return {
-      html: interp(tpl.html),
-      text: interp(tpl.text),
-      subject: interp(tpl.subject),
+      // HTML body: escape every substituted value to neutralize stored XSS
+      // / phishing-grade content injection (F-001). `*_html` keys are
+      // pre-built by the trusted fragment builders in template-fragments.ts
+      // and intentionally emit live markup — those are NOT escaped.
+      html: interpolate(tpl.html, vars, this.log, kind, true),
+      // Plain-text and subject channels have no HTML rendering context;
+      // escaping them would mangle legitimate ampersands and angle
+      // brackets in user content (e.g. "Q1 Roadmap & Pricing").
+      text: interpolate(tpl.text, vars, this.log, kind, false),
+      subject: interpolate(tpl.subject, vars, this.log, kind, false),
     };
   }
 
@@ -171,18 +177,51 @@ function prettyTitle(kind: string): string {
 
 const VAR_PATTERN = /\{\{\s*([a-zA-Z0-9_]+)\s*\}\}/g;
 
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+/**
+ * Escape HTML metacharacters in `input`. Mirrors the helper in
+ * `template-fragments.ts`; duplicated locally to keep the two modules
+ * decoupled (each owns its own trust boundary).
+ */
+function escapeHtml(input: string): string {
+  return input.replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch] ?? ch);
+}
+
+/**
+ * `_html`-suffixed keys carry pre-built, fragment-builder-emitted markup
+ * whose dynamic content has already been escaped at the boundary in
+ * `template-fragments.ts`. They MUST reach the rendered HTML body
+ * unchanged — escaping them would render visible angle brackets to the
+ * recipient instead of the styled signer-list / timeline blocks.
+ */
+function isTrustedHtmlKey(key: string): boolean {
+  return key.endsWith('_html');
+}
+
 function interpolate(
   source: string,
   vars: Readonly<Record<string, string | number>>,
   log: Logger,
   kind: string,
+  escapeForHtml: boolean,
 ): string {
   return source.replace(VAR_PATTERN, (_m: string, key: string): string => {
     const v = vars[key];
-    if (v !== undefined) {
-      return typeof v === 'number' ? String(v) : v;
+    if (v === undefined) {
+      log.warn(`template '${kind}' missing variable '${key}' — rendered as empty string`);
+      return '';
     }
-    log.warn(`template '${kind}' missing variable '${key}' — rendered as empty string`);
-    return '';
+    const stringified = typeof v === 'number' ? String(v) : v;
+    if (escapeForHtml && !isTrustedHtmlKey(key)) {
+      return escapeHtml(stringified);
+    }
+    return stringified;
   });
 }

--- a/apps/landing/public/_headers
+++ b/apps/landing/public/_headers
@@ -7,6 +7,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self' mailto:; frame-ancestors 'self'; img-src 'self' data: https://static.cloudflareinsights.com; script-src 'self' https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; connect-src 'self' https://cloudflareinsights.com https://*.supabase.co https://api.seald.nromomentum.com; object-src 'none'; upgrade-insecure-requests
 
 # Long-cache hashed build assets
 /assets/*

--- a/apps/landing/public/scripts/dsar.js
+++ b/apps/landing/public/scripts/dsar.js
@@ -1,0 +1,59 @@
+// DSAR form — serializes the privacy-request form into a structured
+// `mailto:` URL pointed at privacy@seald.nromomentum.com.
+//
+// Extracted from `apps/landing/src/pages/dsar.astro` so the landing
+// site can ship a strict CSP without `'unsafe-inline'` in script-src.
+// See memory/security_report_2026-05-02.md F-002.
+(function () {
+  var form = document.getElementById('dsar-form');
+  if (!form) return;
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    var data = new FormData(form);
+    var name = String(data.get('name') || '').trim();
+    var email = String(data.get('email') || '').trim();
+    var juris = String(data.get('jurisdiction') || '').trim();
+    var details = String(data.get('details') || '').trim();
+    var agent = String(data.get('agent') || 'No');
+    var types = data.getAll('type').map(String);
+
+    if (!name || !email || !juris) {
+      alert('Please fill in your name, email, and jurisdiction.');
+      return;
+    }
+    if (types.length === 0) {
+      alert('Please select at least one request type.');
+      return;
+    }
+
+    var subject = 'DSAR — ' + types.join(', ');
+    var body =
+      'Submitted via the Seald privacy form (https://seald.nromomentum.com/dsar)\n\n' +
+      'Name: ' +
+      name +
+      '\n' +
+      'Email: ' +
+      email +
+      '\n' +
+      'Jurisdiction: ' +
+      juris +
+      '\n' +
+      'Authorized agent: ' +
+      agent +
+      '\n' +
+      'Request type(s): ' +
+      types.join(', ') +
+      '\n\n' +
+      'Details:\n' +
+      (details || '(none provided)') +
+      '\n';
+
+    var href =
+      'mailto:privacy@seald.nromomentum.com?subject=' +
+      encodeURIComponent(subject) +
+      '&body=' +
+      encodeURIComponent(body);
+
+    window.location.href = href;
+  });
+})();

--- a/apps/landing/src/pages/dsar.astro
+++ b/apps/landing/src/pages/dsar.astro
@@ -136,61 +136,10 @@ const VERSION = 'dsar_v0.1';
     </article>
   </main>
 
-  <script is:inline>
-    (function () {
-      var form = document.getElementById('dsar-form');
-      if (!form) return;
-      form.addEventListener('submit', function (e) {
-        e.preventDefault();
-        var data = new FormData(form);
-        var name = String(data.get('name') || '').trim();
-        var email = String(data.get('email') || '').trim();
-        var juris = String(data.get('jurisdiction') || '').trim();
-        var details = String(data.get('details') || '').trim();
-        var agent = String(data.get('agent') || 'No');
-        var types = data.getAll('type').map(String);
-
-        if (!name || !email || !juris) {
-          alert('Please fill in your name, email, and jurisdiction.');
-          return;
-        }
-        if (types.length === 0) {
-          alert('Please select at least one request type.');
-          return;
-        }
-
-        var subject = 'DSAR — ' + types.join(', ');
-        var body =
-          'Submitted via the Seald privacy form (https://seald.nromomentum.com/dsar)\n\n' +
-          'Name: ' +
-          name +
-          '\n' +
-          'Email: ' +
-          email +
-          '\n' +
-          'Jurisdiction: ' +
-          juris +
-          '\n' +
-          'Authorized agent: ' +
-          agent +
-          '\n' +
-          'Request type(s): ' +
-          types.join(', ') +
-          '\n\n' +
-          'Details:\n' +
-          (details || '(none provided)') +
-          '\n';
-
-        var href =
-          'mailto:privacy@seald.nromomentum.com?subject=' +
-          encodeURIComponent(subject) +
-          '&body=' +
-          encodeURIComponent(body);
-
-        window.location.href = href;
-      });
-    })();
-  </script>
+  <!-- Externalized to /scripts/dsar.js so the landing site can ship a
+       strict CSP (script-src 'self' only, no 'unsafe-inline'). See
+       memory/security_report_2026-05-02.md F-002. -->
+  <script defer src="/scripts/dsar.js"></script>
 
   <style>
     .dsar-form {

--- a/apps/web/src/test/dsarForm.test.ts
+++ b/apps/web/src/test/dsarForm.test.ts
@@ -14,27 +14,26 @@
  * so we can assert the exact mailto URL it produces and the alert messages
  * it surfaces.
  *
- * Approach: the script is an IIFE inlined in the .astro page. We read the
- * source from disk, slice out the `<script is:inline>…</script>` body, and
- * eval it after staging a minimal DOM that mirrors the form's structure.
- * That keeps the production code untouched while still asserting the user
- * contract.
+ * Approach: the handler is an IIFE shipped as `apps/landing/public/scripts/
+ * dsar.js` (externalized in F-002 so the landing site can ship a strict
+ * CSP without `'unsafe-inline'` in script-src). We read the file from
+ * disk and eval it after staging a minimal DOM that mirrors the form's
+ * structure. That keeps the production code untouched while still
+ * asserting the user contract.
+ *
+ * As a side regression for F-002, this test also asserts that the
+ * `dsar.astro` page references the external script (and does NOT carry
+ * an inline `<script is:inline>` block any more) — if someone re-inlines
+ * the handler, the CSP gate would silently break in production.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve as resolvePath } from 'node:path';
 
+const SCRIPT_PATH = resolvePath(process.cwd(), '../landing/public/scripts/dsar.js');
+const SCRIPT = readFileSync(SCRIPT_PATH, 'utf8');
 const ASTRO_PATH = resolvePath(process.cwd(), '../landing/src/pages/dsar.astro');
 const ASTRO_SRC = readFileSync(ASTRO_PATH, 'utf8');
-
-function extractInlineScript(): string {
-  // The page has exactly one `<script is:inline>` block — the submit handler.
-  // If that ever stops being true, this test fails loudly and we can adjust.
-  const m = ASTRO_SRC.match(/<script is:inline>([\s\S]*?)<\/script>/);
-  if (!m) throw new Error('Could not find <script is:inline> in dsar.astro');
-  return m[1]!;
-}
-const SCRIPT = extractInlineScript();
 
 interface FormFieldsInput {
   readonly name?: string;
@@ -257,5 +256,14 @@ describe('DSAR form submit handler — mailto generation', () => {
     expect(body).toContain('Email: jane@example.com');
     expect(body).toContain('Jurisdiction: GDPR (European Union)');
     expect(body).toContain('some detail');
+  });
+});
+
+describe('DSAR page CSP posture (F-002)', () => {
+  it('references the externalized handler and carries no inline <script> block', () => {
+    // Strict CSP (script-src 'self' only) blocks `<script is:inline>`.
+    // The handler must live at /scripts/dsar.js and be loaded by URL.
+    expect(ASTRO_SRC).toContain('src="/scripts/dsar.js"');
+    expect(ASTRO_SRC).not.toMatch(/<script\s+is:inline\s*>/);
   });
 });


### PR DESCRIPTION
## Summary

Pentest → fix → re-pentest loop ran via the `seald-pentest` + `seald-vuln-fixer` skills. Loop exited successfully after 1 fix iteration: **0 critical / 0 high** remaining.

Full report: `~/.claude/projects/-Users-eliranazulay-Documents-projects-seald/memory/security_report_2026-05-02.md`

### Findings closed

- **F-001 (HIGH, CWE-79)** — Email HTML body interpolated `${name}` / `${title}` / etc. unescaped. Fixed in `ab796a1` by escaping user-controlled vars in `template.service.ts`. 5/5 escape spec cases GREEN; 784/784 jest tests pass.
- **F-002 (MEDIUM, CWE-1021/693)** — Landing site shipped no `Content-Security-Policy` / `X-Frame-Options` / nosniff headers. Fixed in `1afa56e` by adding strict CSP via `apps/landing/public/_headers` and externalizing the inline DSAR script. 11/11 vitest cases GREEN.

### Deferred (do not block per skill spec)

- F-003 (Low), F-004 (Low) — defense-in-depth items, scheduled for follow-up
- F-005 (Info) — false positive

## Test plan

- [x] `pnpm --filter api test` — 784/784 GREEN
- [x] `pnpm --filter web vitest run` — landing CSP cases GREEN
- [x] `pnpm audit --audit-level=high` — clean
- [x] `actionlint .github/workflows/*.yml` — clean
- [ ] CI: lint + typecheck + unit + web + e2e + PAdES verifier all green
- [ ] DAST manual smoke: confirm CSP header live on `seald.nromomentum.com` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)