### PR TITLE
fix(deploy): rewrite /m/* and /templates to SPA shell

### DIFF
--- a/apps/landing/_worker.js
+++ b/apps/landing/_worker.js
@@ -19,10 +19,19 @@ const SPA_EXACT = new Set([
   '/documents',
   '/signers',
   '/contacts',
+  '/templates',
 ]);
 
 // Trailing slash matters: '/auth/' matches '/auth/foo' and '/auth' itself.
-const SPA_PREFIXES = ['/auth/', '/debug/', '/verify/', '/sign/', '/document/'];
+const SPA_PREFIXES = [
+  '/auth/',
+  '/debug/',
+  '/verify/',
+  '/sign/',
+  '/document/',
+  '/templates/',
+  '/m/',
+];
 
 function isSpaRoute(pathname) {
   if (SPA_EXACT.has(pathname)) return true;

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -87,6 +87,14 @@ function SigningRouteRoot() {
 /**
  * The routed tree without a `Router` wrapper — so tests can mount the app
  * with a `MemoryRouter` to drive navigation through `initialEntries`.
+ *
+ * IMPORTANT: every top-level path declared below must also be listed in
+ * `apps/landing/_worker.js` (`SPA_EXACT` for exact matches, `SPA_PREFIXES`
+ * for prefixes). The Cloudflare Pages deploy serves the landing site at
+ * `/` and uses that worker to rewrite SPA routes to the SPA's HTML shell.
+ * A path missing from the worker silently falls through to the landing
+ * dist and serves the wrong HTML — production outage on 2026-05-02 was
+ * exactly this (`/m/send` and `/templates` returned the landing page).
  */
 export function AppRoutes() {
   return (


### PR DESCRIPTION
## Summary
- `_worker.js` was missing `/m/` (new mobile sender flow from PR #108) and `/templates` from its rewrite list, so production was serving the landing page HTML at those URLs instead of the SPA shell.
- Verified with `curl -sI`: `/m/send` and `/templates` both returned the same etag as `/` (landing's index), while `/signin` correctly returned the SPA shell's etag.
- Added `/templates` to `SPA_EXACT` and `/m/` + `/templates/` to `SPA_PREFIXES` so the worker covers every route declared in `apps/web/src/AppRoutes.tsx`.

## Test plan
- [ ] Deploy job (Cloudflare Pages) succeeds on this PR's merge.
- [ ] After merge, `curl -sI https://seald.nromomentum.com/m/send` returns the SPA etag (not the landing etag).
- [ ] `curl -sI https://seald.nromomentum.com/templates` returns the SPA etag.
- [ ] `curl -sI https://seald.nromomentum.com/` still returns the landing etag (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)