### PR TITLE
fix(mobile): swap AppShell to slim MWMobileNav on ≤640 px viewport

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,18 @@ at 1440 / 1920 / 2560 / 3440. Skip a layer only when it genuinely
 doesn't apply (e.g. backend-only change skips UI), and document the
 skip in the report.
 
+### Production bug-fix / feature loop
+
+Whenever the user reports a production bug, asks to add a feature, or
+asks to change a UI component on the live app, invoke the
+[`seald-prod-bug-loop` skill](~/.claude/skills/seald-prod-bug-loop/SKILL.md)
+and run its 6-phase loop: (1) verify on prod with screenshots,
+(2) write a failing test, (3) fix, (4) PR + CI + merge, (5) re-verify
+on prod after deploy with fresh screenshots, (6) loop back if any bug
+regressed. The loop is not complete until every reported bug shows
+postfix proof from production. Use parallel agents and worktrees for
+multi-bug batches.
+
 ### Phase 3 deferrals
 
 All five MVP deferrals were resolved on 2026-04-24. See

--- a/apps/web/src/layout/AppShell.mobile-nav.test.tsx
+++ b/apps/web/src/layout/AppShell.mobile-nav.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { AppShell } from './AppShell';
+
+// Production bug (2026-05-03): every authed surface inside AppShell
+// (`/documents`, `/templates`, `/signers`, `/document/<id>`, `/document/new`)
+// rendered the desktop NavBar at 390 px because AppShell wired NavBar
+// unconditionally — no useIsMobileViewport branch. The slim 52 px
+// MWMobileNav only existed inside MobileSendPage. The result was a
+// `Documents | Sign | Templates` tab row with "Templates" clipped at the
+// right edge on every authed mobile route.
+//
+// Lock the rule in: when useIsMobileViewport is true, AppShell must
+// render the slim mobile chrome (logo + hamburger only) — not the
+// desktop tab row.
+
+vi.mock('@/features/account', () => ({
+  useAccountActions: () => ({
+    exportData: vi.fn(),
+    deleteAccount: vi.fn(),
+    isExporting: false,
+    isDeleting: false,
+  }),
+}));
+
+let mobileViewport = false;
+
+vi.mock('../hooks/useIsMobileViewport', () => ({
+  useIsMobileViewport: () => mobileViewport,
+  readIsMobileViewport: () => mobileViewport,
+  MOBILE_VIEWPORT_QUERY: '(max-width: 640px)',
+}));
+
+afterEach(() => {
+  mobileViewport = false;
+});
+
+function renderShell() {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={['/documents']}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/documents" element={<div>doc list</div>} />
+          <Route path="/signin" element={<div>sign in</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppShell — mobile-aware top chrome', () => {
+  it('renders the desktop NavBar with the full tab row on a desktop viewport', () => {
+    mobileViewport = false;
+    const { getByRole } = renderShell();
+    // The desktop NavBar exposes the primary tabs as nav items.
+    expect(getByRole('button', { name: /^documents$/i })).toBeInTheDocument();
+    expect(getByRole('button', { name: /^templates$/i })).toBeInTheDocument();
+  });
+
+  it('renders the slim mobile bar (Seald home + hamburger) on a mobile viewport — no desktop tab row', () => {
+    mobileViewport = true;
+    const { getByRole, queryByRole } = renderShell();
+    // Slim mobile chrome must show the hamburger trigger…
+    expect(getByRole('button', { name: /open menu/i })).toBeInTheDocument();
+    // …and the brand button (logo + word "Seald").
+    expect(getByRole('button', { name: /seald home/i })).toBeInTheDocument();
+    // The desktop tab row must NOT be in the DOM at this viewport.
+    expect(queryByRole('button', { name: /^templates$/i })).toBeNull();
+    expect(queryByRole('button', { name: /^sign$/i })).toBeNull();
+  });
+});

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -5,6 +5,8 @@ import { NavBar } from '../components/NavBar';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
 import { useAccountActions } from '@/features/account';
+import { useIsMobileViewport } from '../hooks/useIsMobileViewport';
+import { MWMobileNav } from '../pages/MobileSendPage/components/MWMobileNav';
 import { NAV_ITEMS, matchNavId } from './navItems';
 
 const Shell = styled.div`
@@ -112,6 +114,7 @@ export function AppShell() {
   const navigate = useNavigate();
   const location = useLocation();
   const activeNavId = matchNavId(location.pathname);
+  const isMobile = useIsMobileViewport();
 
   const handleSelectNavItem = useCallback(
     (id: string): void => {
@@ -152,22 +155,32 @@ export function AppShell() {
 
   const mode = !user && guest ? 'guest' : 'authed';
 
+  // 2026-05-03 — at ≤640 px the desktop NavBar's tab row overflows the
+  // viewport (Templates link clips, avatar/account menu unreachable). Swap
+  // to the slim MWMobileNav already shipping on /m/send so every authed
+  // mobile surface gets a hamburger-driven drawer instead of broken chrome.
+  // Guest mode keeps the desktop NavBar (the marketing-style sign-in/up
+  // pair has no equivalent in the slim bar yet).
   return (
     <Shell>
-      <NavBar
-        items={NAV_ITEMS}
-        activeItemId={activeNavId}
-        onSelectItem={handleSelectNavItem}
-        user={user ?? undefined}
-        mode={mode}
-        onSignIn={handleSignIn}
-        onSignUp={handleSignUp}
-        onSignOut={handleSignOut}
-        onExportData={mode === 'authed' ? account.exportData : undefined}
-        onDeleteAccount={mode === 'authed' ? account.deleteAccount : undefined}
-        isExporting={account.isExporting}
-        isDeleting={account.isDeleting}
-      />
+      {isMobile && mode === 'authed' ? (
+        <MWMobileNav onSignOut={handleSignOut} />
+      ) : (
+        <NavBar
+          items={NAV_ITEMS}
+          activeItemId={activeNavId}
+          onSelectItem={handleSelectNavItem}
+          user={user ?? undefined}
+          mode={mode}
+          onSignIn={handleSignIn}
+          onSignUp={handleSignUp}
+          onSignOut={handleSignOut}
+          onExportData={mode === 'authed' ? account.exportData : undefined}
+          onDeleteAccount={mode === 'authed' ? account.deleteAccount : undefined}
+          isExporting={account.isExporting}
+          isDeleting={account.isDeleting}
+        />
+      )}
       <Content>
         <Outlet />
       </Content>


### PR DESCRIPTION
## Summary

Production audit (2026-05-03) at 390×844 found that every authed surface
inside `AppShell` — `/documents`, `/templates`, `/signers`, `/document/<id>`,
`/document/new` — rendered the desktop `<NavBar>` because the shell wired it
unconditionally. Result: the "Documents | Sign | Templates" tab row clipped at
the right edge of the viewport on every authed mobile route, and the avatar /
account menu sat off-screen entirely. Only `/m/send` (which composes its own
slim chrome) escaped this.

This PR branches `AppShell` on `useIsMobileViewport()`. When mobile + authed,
it renders the existing `MWMobileNav` (52 px, logo + hamburger + bottom-sheet
drawer; per the 2026-05-03 product decision the drawer surfaces Documents +
Sign-out only). Guest mode keeps the desktop `NavBar` — the marketing-style
sign-in/up affordance pair has no equivalent in the slim bar.

`CLAUDE.md` also gains the standing `seald-prod-bug-loop` rule that surfaced
this audit (already wired locally for the previous bug PR; landing here so
the rule lives on `main`).

### Production baselines (broken — desktop nav at 390 px)
- `prod-mobile-nav-documents.png` — Templates link clipped
- `prod-mobile-nav-templates.png` — same
- `prod-mobile-nav-signers.png` — same
- `prod-mobile-nav-document-new.png` — same
- `prod-mobile-nav-document-detail.png` — title char-stacks vertically (separate detail-page bug, deferred)
- `prod-mobile-nav-msend.png` — slim 52 px bar (the only correct surface)

### Failing test
`apps/web/src/layout/AppShell.mobile-nav.test.tsx` — two cases:
1. Desktop viewport → desktop tab row present (Documents + Templates buttons by accessible role).
2. Mobile viewport → slim bar present (Open menu hamburger + Seald-home brand button), desktop tab row absent.

RED before the AppShell branch, GREEN after.

## Test plan
- [x] typecheck / lint / vitest all green (1303 / 1303)
- [x] `seald-react-pr-review` walked — no MUST/SHOULD-FIX
- [ ] Post-deploy: re-verify each authed surface (`/documents`, `/templates`, `/signers`, `/document/<id>`, `/document/new`) at 390×844 on https://seald.nromomentum.com — header height ≤ 52 px and the desktop tab row gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)