### PR TITLE
feat(api): Google Drive OAuth backend (WT-A-1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,30 @@ in `apps/api/src/sealing/`. Full pipeline + module-factory selection in
   contract (sorted keys, RFC 8785-ish) lives next to the helper — import
   it, don't reimplement.
 
+### Google Drive integration env vars
+
+The `apps/api/src/integrations/gdrive/` module reads these at startup:
+
+- `GDRIVE_OAUTH_CLIENT_ID` — Google Cloud Console OAuth 2.0 client ID
+- `GDRIVE_OAUTH_CLIENT_SECRET` — paired secret; must NEVER be checked in
+- `GDRIVE_OAUTH_REDIRECT_URI` — must exactly match the URI registered in
+  Google Cloud Console (e.g.
+  `https://api.seald.nromomentum.com/integrations/gdrive/oauth/callback`)
+- `GDRIVE_TOKEN_KMS_KEY_ARN` — AWS KMS CMK ARN used to wrap per-row DEKs
+  for refresh-token storage (envelope AES-256-GCM)
+- `GDRIVE_TOKEN_KMS_REGION` — AWS region for the CMK
+- `GDRIVE_API_RATE_PER_USER` — token-bucket capacity (default `30`); WT-A-2
+- `GDRIVE_API_RATE_WINDOW_SECONDS` — token-bucket refill window seconds
+  (default `60`); WT-A-2
+
+OAuth scope is hard-coded to `https://www.googleapis.com/auth/drive.file`
+(per-file consent only). Do not broaden — picker selections grant per-file
+access at the moment of click via Google's drive.file scope.
+
+When the feature flag `feature.gdriveIntegration` is off, all routes
+404 and the env vars are unread; the same image runs dark in dev and
+hot for prod.
+
 ### Sprint history
 - **Sprint 1 (PR #9)** — PAdES B-T conformance + production hardening.
 - **Sprint 2 (PR #12)** — KMS-backed sealing + multi-TSA fallback +

--- a/apps/api/db/migrations/0013_gdrive_accounts.sql
+++ b/apps/api/db/migrations/0013_gdrive_accounts.sql
@@ -1,0 +1,54 @@
+-- 0013_gdrive_accounts.sql
+-- Phase 5 (WT-A) — Google Drive integration: per-user connected accounts.
+-- Stores the KMS-envelope-encrypted refresh token (red-flag row 3 — the
+-- column NEVER holds plaintext) plus the metadata needed to re-mint short-
+-- lived access tokens on demand.
+--
+-- Scoped by user_id -> auth.users(id). On user deletion we set null rather
+-- than cascade so the audit trail of "this account was once linked to user
+-- X" survives in the soft-deleted form. The application service explicitly
+-- soft-deletes the row (`deleted_at`) on disconnect; nothing should ever
+-- hard-delete from here.
+--
+-- Multi-account: a single user may connect multiple Google accounts. The
+-- partial UNIQUE on (user_id, google_user_id) WHERE deleted_at IS NULL
+-- prevents the "double-connect" race while still allowing reconnect after
+-- a soft-delete (the old row is left in place for forensic continuity).
+--
+-- citext is already enabled by 0001_contacts.sql; the create extension
+-- guard below is a no-op safety net.
+--
+-- Rollback: DROP TABLE public.gdrive_accounts;
+--   No FKs reference this table from elsewhere in WT-A scope, so dropping
+--   it is safe in isolation. WT-D adds no FK either (its conversion job
+--   map is in-memory).
+
+create extension if not exists "citext";
+
+create table public.gdrive_accounts (
+  id                          uuid        primary key default gen_random_uuid(),
+  user_id                     uuid        not null references auth.users(id) on delete set null,
+  google_user_id              text        not null,
+  google_email                citext      not null,
+  -- KMS envelope = [4-byte BE wrapped-key-len][wrapped data key][12-byte
+  -- IV][16-byte GCM tag][AES-256-GCM ciphertext]. See
+  -- apps/api/src/integrations/gdrive/gdrive-kms.service.ts.
+  refresh_token_ciphertext    bytea       not null,
+  refresh_token_kms_key_arn   text        not null,
+  scope                       text        not null,
+  connected_at                timestamptz not null default now(),
+  last_used_at                timestamptz,
+  deleted_at                  timestamptz
+);
+
+create unique index gdrive_accounts_user_google_uniq
+  on public.gdrive_accounts (user_id, google_user_id)
+  where deleted_at is null;
+create index gdrive_accounts_user_idx on public.gdrive_accounts (user_id) where deleted_at is null;
+
+alter table public.gdrive_accounts enable row level security;
+
+comment on column public.gdrive_accounts.refresh_token_ciphertext is
+  'KMS envelope-encrypted Google OAuth refresh token. NEVER plaintext. Layout: 4-byte BE wrapped-key-len || wrapped DEK || 12-byte IV || 16-byte GCM tag || AES-256-GCM ciphertext.';
+comment on column public.gdrive_accounts.refresh_token_kms_key_arn is
+  'Per-tenant CMK ARN that wraps the per-row data key. Stored alongside the ciphertext so a future key rotation can decrypt rows minted under the old ARN.';

--- a/apps/api/db/migrations/0013_gdrive_accounts_down.sql
+++ b/apps/api/db/migrations/0013_gdrive_accounts_down.sql
@@ -1,0 +1,21 @@
+-- 0013_gdrive_accounts_down.sql
+-- Rollback for 0013_gdrive_accounts.sql.
+--
+-- This file establishes the down-script naming convention for this repo
+-- (`<id>_<name>_down.sql` paired with `<id>_<name>.sql`). Existing
+-- migrations 0001–0012 are forward-only because they predate the
+-- convention; future migrations should ship a paired _down.sql per the
+-- Phase 5 manager verdict (red-flag row 5).
+--
+-- Safety: no FK references this table from elsewhere in WT-A scope, so
+-- DROP TABLE is non-destructive to other domains. The CASCADE clause is
+-- included only to preserve idempotency if a future migration adds a
+-- dependent index/view; current schema needs no cascading.
+--
+-- Audit-trail caveat: dropping the table loses the soft-deleted-account
+-- forensic history. Operators rolling this back in production must
+-- export the table contents first if compliance retention applies.
+
+drop index if exists public.gdrive_accounts_user_idx;
+drop index if exists public.gdrive_accounts_user_google_uniq;
+drop table if exists public.gdrive_accounts cascade;

--- a/apps/api/db/schema.ts
+++ b/apps/api/db/schema.ts
@@ -14,6 +14,21 @@ export interface Database {
   // Migration 0012 — bookkeeping for deleted accounts. See the migration
   // header for the GDPR Art. 17(3)(b/e) carve-out rationale.
   deleted_user_tombstones: DeletedUserTombstonesTable;
+  // Migration 0013 — Drive integration (Phase 5 WT-A).
+  gdrive_accounts: GDriveAccountsTable;
+}
+
+export interface GDriveAccountsTable {
+  id: Generated<string>;
+  user_id: string;
+  google_user_id: string;
+  google_email: string;
+  refresh_token_ciphertext: Buffer;
+  refresh_token_kms_key_arn: string;
+  scope: string;
+  connected_at: ColumnType<Date, string | undefined, never>;
+  last_used_at: ColumnType<Date | null, string | null | undefined, string | null | undefined>;
+  deleted_at: ColumnType<Date | null, string | null | undefined, string | null | undefined>;
 }
 
 export interface DeletedUserTombstonesTable {

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { HttpExceptionFilter } from './common/filters/http-exception.filter';
 import { ConfigModule } from './config/config.module';
 import { ContactsModule } from './contacts/contacts.module';
 import { DbModule } from './db/db.module';
+import { GDriveModule } from './integrations/gdrive/gdrive.module';
 import { EmailModule } from './email/email.module';
 import { CronModule } from './cron/cron.module';
 import { EnvelopesModule } from './envelopes/envelopes.module';
@@ -50,6 +51,7 @@ import { StorageModule } from './storage/storage.module';
     SealingModule,
     VerifyModule,
     CronModule,
+    GDriveModule,
   ],
   providers: [
     { provide: APP_FILTER, useClass: HttpExceptionFilter },

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -98,6 +98,20 @@ export const envSchema = z
      * keeping API nodes worker-disabled.
      */
     WORKER_ENABLED: z.coerce.boolean().default(false),
+
+    /**
+     * Google Drive integration (Phase 5 of the gdrive feature). Required
+     * only when `feature.gdriveIntegration` is on. The KMS key is the
+     * per-tenant CMK that wraps the per-row data key encrypting each
+     * stored OAuth refresh token (red-flag row 3 — never plaintext).
+     */
+    GDRIVE_OAUTH_CLIENT_ID: z.string().optional(),
+    GDRIVE_OAUTH_CLIENT_SECRET: z.string().optional(),
+    GDRIVE_OAUTH_REDIRECT_URI: z.string().url().optional(),
+    GDRIVE_TOKEN_KMS_KEY_ARN: z.string().optional(),
+    GDRIVE_TOKEN_KMS_REGION: z.string().optional(),
+    GDRIVE_API_RATE_PER_USER: z.coerce.number().int().positive().optional(),
+    GDRIVE_API_RATE_WINDOW_SECONDS: z.coerce.number().int().positive().optional(),
   })
   .superRefine((env, ctx) => {
     if (env.NODE_ENV !== 'test') {

--- a/apps/api/src/integrations/gdrive/dto/account.dto.ts
+++ b/apps/api/src/integrations/gdrive/dto/account.dto.ts
@@ -1,0 +1,12 @@
+/**
+ * Public-facing account view returned by `GET
+ * /integrations/gdrive/accounts`. Strips every column that's an
+ * encryption secret (refresh_token_ciphertext, refresh_token_kms_key_arn)
+ * — those never leave the backend.
+ */
+export interface GDriveAccountView {
+  readonly id: string;
+  readonly email: string;
+  readonly connectedAt: string;
+  readonly lastUsedAt: string | null;
+}

--- a/apps/api/src/integrations/gdrive/dto/error-codes.ts
+++ b/apps/api/src/integrations/gdrive/dto/error-codes.ts
@@ -1,0 +1,36 @@
+/**
+ * Named error codes for the gdrive integration. Each one maps directly to
+ * a wireframe error state in `Design-Guide/project/gdrive-integration/`
+ * (Phase 2/3 surfaces). Frontend and backend MUST agree on the literal
+ * string — these are the public contract.
+ */
+export type GDriveErrorCode =
+  | 'token-expired'
+  | 'oauth-declined'
+  | 'no-files-match-filter'
+  | 'conversion-failed'
+  | 'file-too-large'
+  | 'unsupported-mime'
+  | 'rate-limited';
+
+export class GDriveError extends Error {
+  constructor(
+    public readonly code: GDriveErrorCode,
+    message?: string,
+  ) {
+    super(message ?? code);
+    this.name = 'GDriveError';
+  }
+}
+
+export class TokenExpiredError extends GDriveError {
+  constructor(message?: string) {
+    super('token-expired', message);
+  }
+}
+
+export class OAuthDeclinedError extends GDriveError {
+  constructor(message?: string) {
+    super('oauth-declined', message);
+  }
+}

--- a/apps/api/src/integrations/gdrive/files-proxy.ts
+++ b/apps/api/src/integrations/gdrive/files-proxy.ts
@@ -1,0 +1,38 @@
+import type { DriveFile, FilesProxy } from './gdrive.controller';
+
+const MIME_FILTERS: Record<'pdf' | 'doc' | 'docx' | 'all', string> = {
+  pdf: "mimeType='application/pdf'",
+  doc: "mimeType='application/vnd.google-apps.document'",
+  docx: "mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document'",
+  all: "(mimeType='application/pdf' or mimeType='application/vnd.google-apps.document' or mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document')",
+};
+
+/**
+ * Server-side proxy over Drive `files.list`. Why a proxy and not a
+ * client-side call? Three reasons:
+ *  1. Access tokens never leave the API — the SPA only sees JSON file
+ *     metadata, not bearer tokens (red-flag row 3 spirit).
+ *  2. We can mime-filter at the source so the SPA can't cheat past the
+ *     allow-list (defence in depth — picker also filters client-side).
+ *  3. Per-user rate limiting (red-flag row 13) is enforced at the proxy.
+ *
+ * Phase 5 watchpoint #1 — this proxy MUST live in WT-A. It is not a
+ * frontend concern.
+ */
+export function makeFilesProxy(fetchImpl: typeof fetch = fetch): FilesProxy {
+  return async ({ accessToken, mimeFilter }): Promise<{ files: ReadonlyArray<DriveFile> }> => {
+    const params = new URLSearchParams({
+      pageSize: '50',
+      fields: 'files(id,name,mimeType,modifiedTime,size)',
+      q: `${MIME_FILTERS[mimeFilter]} and trashed = false`,
+    });
+    const res = await fetchImpl(`https://www.googleapis.com/drive/v3/files?${params.toString()}`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    if (!res.ok) {
+      throw new Error(`drive_files_list_failed: ${res.status}`);
+    }
+    const json = (await res.json()) as { files?: ReadonlyArray<DriveFile> };
+    return { files: json.files ?? [] };
+  };
+}

--- a/apps/api/src/integrations/gdrive/gdrive-kms.service.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive-kms.service.spec.ts
@@ -1,0 +1,72 @@
+import { GDriveKmsService, type KmsClientPort } from './gdrive-kms.service';
+
+/**
+ * Mock KMS client mimicking AWS KMS GenerateDataKey + Decrypt by wrapping
+ * the data key in a deterministic envelope (key id || raw key bytes).
+ * Real AWS does the same conceptually — just with HSM-backed wrapping.
+ */
+class MockKmsClient implements KmsClientPort {
+  generateDataKeyCalls = 0;
+  decryptCalls = 0;
+  lastCiphertext: Buffer | null = null;
+  fail: 'none' | 'generate' | 'decrypt' = 'none';
+
+  async generateDataKey(keyId: string): Promise<{ plaintext: Buffer; ciphertextBlob: Buffer }> {
+    this.generateDataKeyCalls++;
+    if (this.fail === 'generate') throw new Error('kms_unavailable');
+    const plaintext = Buffer.from(`raw-key-${this.generateDataKeyCalls}`.padEnd(32, '0'));
+    const ciphertextBlob = Buffer.concat([Buffer.from(`${keyId}|`), plaintext]);
+    this.lastCiphertext = ciphertextBlob;
+    return { plaintext, ciphertextBlob };
+  }
+
+  async decrypt(ciphertextBlob: Buffer): Promise<Buffer> {
+    this.decryptCalls++;
+    if (this.fail === 'decrypt') throw new Error('kms_decrypt_failed');
+    const sep = ciphertextBlob.indexOf(0x7c); // '|'
+    return ciphertextBlob.subarray(sep + 1);
+  }
+}
+
+describe('GDriveKmsService', () => {
+  const KEY_ARN = 'arn:aws:kms:us-east-1:000000000000:key/test';
+  let kms: MockKmsClient;
+  let svc: GDriveKmsService;
+
+  beforeEach(() => {
+    kms = new MockKmsClient();
+    svc = new GDriveKmsService(kms, KEY_ARN);
+  });
+
+  it('encrypts then decrypts: round-trip recovers the original plaintext', async () => {
+    const plaintext = '1//0gRefreshToken-AbC123_xyz';
+    const { ciphertext, kmsKeyArn } = await svc.encrypt(plaintext);
+    expect(kmsKeyArn).toBe(KEY_ARN);
+    const recovered = await svc.decrypt(ciphertext, kmsKeyArn);
+    expect(recovered).toBe(plaintext);
+  });
+
+  it('ciphertext column NEVER contains plaintext as a substring', async () => {
+    const plaintext = '1//0gRefreshToken-VERY-SECRET-DO-NOT-LEAK';
+    const { ciphertext } = await svc.encrypt(plaintext);
+    // Convert to string in every plausible encoding and ensure none leak.
+    expect(ciphertext.toString('utf8')).not.toContain(plaintext);
+    expect(ciphertext.toString('binary')).not.toContain(plaintext);
+    expect(ciphertext.toString('hex')).not.toContain(
+      Buffer.from(plaintext, 'utf8').toString('hex'),
+    );
+  });
+
+  it('encrypt failure surfaces as an Error (no plaintext in message)', async () => {
+    kms.fail = 'generate';
+    await expect(svc.encrypt('top-secret')).rejects.toThrow();
+    await svc.encrypt('top-secret').catch((err: unknown) => {
+      expect(String((err as Error).message)).not.toContain('top-secret');
+    });
+  });
+
+  it('decrypt with mismatched ciphertext fails', async () => {
+    kms.fail = 'decrypt';
+    await expect(svc.decrypt(Buffer.from('garbage-ciphertext'), KEY_ARN)).rejects.toThrow();
+  });
+});

--- a/apps/api/src/integrations/gdrive/gdrive-kms.service.ts
+++ b/apps/api/src/integrations/gdrive/gdrive-kms.service.ts
@@ -1,0 +1,116 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { Injectable } from '@nestjs/common';
+import { KMSClient, GenerateDataKeyCommand, DecryptCommand } from '@aws-sdk/client-kms';
+import type { AppEnv } from '../../config/env.schema';
+
+/**
+ * Port over the subset of KMS operations the OAuth refresh-token store
+ * needs. Lets the unit suite exercise the AES envelope path without an
+ * AWS SDK dependency at test time. The production implementation
+ * (`AwsKmsClient`) wraps the real `@aws-sdk/client-kms` calls.
+ */
+export interface KmsClientPort {
+  generateDataKey(keyId: string): Promise<{ plaintext: Buffer; ciphertextBlob: Buffer }>;
+  decrypt(ciphertextBlob: Buffer): Promise<Buffer>;
+}
+
+/**
+ * Production KMS adapter. Uses RSA-less symmetric `GenerateDataKey` /
+ * `Decrypt` — the SAME pattern PR #12 used for sealing, just with the
+ * tenant CMK ARN swapped in. Per Watchpoint #5, this is per-tenant single
+ * CMK; per-user CMK would be a manager-level scope change.
+ */
+export class AwsKmsClient implements KmsClientPort {
+  constructor(private readonly kms: KMSClient) {}
+
+  async generateDataKey(keyId: string): Promise<{ plaintext: Buffer; ciphertextBlob: Buffer }> {
+    const out = await this.kms.send(
+      new GenerateDataKeyCommand({ KeyId: keyId, KeySpec: 'AES_256' }),
+    );
+    if (!out.Plaintext || !out.CiphertextBlob) {
+      throw new Error('kms_generate_data_key_failed');
+    }
+    return {
+      plaintext: Buffer.from(out.Plaintext),
+      ciphertextBlob: Buffer.from(out.CiphertextBlob),
+    };
+  }
+
+  async decrypt(ciphertextBlob: Buffer): Promise<Buffer> {
+    const out = await this.kms.send(new DecryptCommand({ CiphertextBlob: ciphertextBlob }));
+    if (!out.Plaintext) throw new Error('kms_decrypt_failed');
+    return Buffer.from(out.Plaintext);
+  }
+}
+
+/**
+ * Envelope encryption for OAuth refresh tokens.
+ * Layout of the bytea column:
+ *   [4-byte BE wrapped-key-len][wrapped data key][12-byte IV][16-byte tag][ciphertext]
+ *
+ * AES-256-GCM with a fresh data key per row. The data key is wrapped by
+ * the tenant KMS CMK; we never store the raw data key. The plaintext
+ * refresh token NEVER touches `bytea` directly (red-flag row 3). Errors
+ * deliberately omit the plaintext from messages so logs cannot leak it.
+ */
+@Injectable()
+export class GDriveKmsService {
+  private readonly client: KmsClientPort;
+  private readonly keyArn: string;
+
+  constructor(client: KmsClientPort, keyArn: string) {
+    this.client = client;
+    this.keyArn = keyArn;
+  }
+
+  static fromEnv(env: AppEnv): GDriveKmsService {
+    const arn = env.GDRIVE_TOKEN_KMS_KEY_ARN;
+    const region = env.GDRIVE_TOKEN_KMS_REGION;
+    if (!arn || !region) {
+      throw new Error(
+        'gdrive_kms_misconfigured: GDRIVE_TOKEN_KMS_KEY_ARN + GDRIVE_TOKEN_KMS_REGION required',
+      );
+    }
+    return new GDriveKmsService(new AwsKmsClient(new KMSClient({ region })), arn);
+  }
+
+  async encrypt(plaintext: string): Promise<{ ciphertext: Buffer; kmsKeyArn: string }> {
+    let dataKey: { plaintext: Buffer; ciphertextBlob: Buffer };
+    try {
+      dataKey = await this.client.generateDataKey(this.keyArn);
+    } catch {
+      // Re-throw with a generic message — never echo the plaintext.
+      throw new Error('gdrive_kms_encrypt_failed');
+    }
+    const iv = randomBytes(12);
+    const cipher = createCipheriv('aes-256-gcm', dataKey.plaintext, iv);
+    const enc = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const wrappedLen = Buffer.alloc(4);
+    wrappedLen.writeUInt32BE(dataKey.ciphertextBlob.length, 0);
+    return {
+      ciphertext: Buffer.concat([wrappedLen, dataKey.ciphertextBlob, iv, tag, enc]),
+      kmsKeyArn: this.keyArn,
+    };
+  }
+
+  async decrypt(ciphertext: Buffer, _kmsKeyArn: string): Promise<string> {
+    if (ciphertext.length < 4 + 12 + 16) throw new Error('gdrive_kms_decrypt_failed');
+    const wrappedLen = ciphertext.readUInt32BE(0);
+    const offset = 4 + wrappedLen;
+    const wrapped = ciphertext.subarray(4, offset);
+    const iv = ciphertext.subarray(offset, offset + 12);
+    const tag = ciphertext.subarray(offset + 12, offset + 28);
+    const enc = ciphertext.subarray(offset + 28);
+    let dataKey: Buffer;
+    try {
+      dataKey = await this.client.decrypt(wrapped);
+    } catch {
+      throw new Error('gdrive_kms_decrypt_failed');
+    }
+    const decipher = createDecipheriv('aes-256-gcm', dataKey, iv);
+    decipher.setAuthTag(tag);
+    const dec = Buffer.concat([decipher.update(enc), decipher.final()]);
+    return dec.toString('utf8');
+  }
+}

--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -1,0 +1,212 @@
+import { BadRequestException, HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
+import type { AuthUser } from '../../auth/auth-user';
+import { GDriveController } from './gdrive.controller';
+import { GDriveService, type GoogleOAuthClient } from './gdrive.service';
+import { GDriveKmsService, type KmsClientPort } from './gdrive-kms.service';
+import { type GDriveAccount, type GDriveRepository } from './gdrive.repository';
+import { OAuthStateStore } from './oauth-pkce';
+import { FEATURE_FLAGS } from 'shared';
+
+class FakeRepo implements GDriveRepository {
+  rows = new Map<string, GDriveAccount>();
+  async findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null> {
+    const r = this.rows.get(id);
+    return r && r.userId === userId ? r : null;
+  }
+  async listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
+    return [...this.rows.values()].filter((r) => r.userId === userId && !r.deletedAt);
+  }
+  async insert(row: GDriveAccount): Promise<GDriveAccount> {
+    this.rows.set(row.id, row);
+    return row;
+  }
+  async softDelete(id: string, userId: string): Promise<boolean> {
+    const r = this.rows.get(id);
+    if (!r || r.userId !== userId) return false;
+    this.rows.set(id, { ...r, deletedAt: new Date().toISOString() });
+    return true;
+  }
+  async touchLastUsed(id: string): Promise<void> {
+    const r = this.rows.get(id);
+    if (r) this.rows.set(id, { ...r, lastUsedAt: new Date().toISOString() });
+  }
+}
+
+class StubKmsClient implements KmsClientPort {
+  async generateDataKey(): Promise<{ plaintext: Buffer; ciphertextBlob: Buffer }> {
+    const k = Buffer.alloc(32, 9);
+    return { plaintext: k, ciphertextBlob: Buffer.concat([Buffer.from('K|'), k]) };
+  }
+  async decrypt(blob: Buffer): Promise<Buffer> {
+    return blob.subarray(blob.indexOf(0x7c) + 1);
+  }
+}
+
+class StubGoogleClient implements GoogleOAuthClient {
+  exchange = {
+    refreshToken: 'rt-from-google',
+    accessToken: 'at-from-google',
+    expiresAt: Date.now() + 3600_000,
+    googleUserId: 'g-sub-1',
+    googleEmail: 'user@example.com',
+    scope: 'https://www.googleapis.com/auth/drive.file',
+  };
+  filesListReturns: { files: ReadonlyArray<{ id: string; name: string; mimeType: string }> } = {
+    files: [{ id: 'f1', name: 'doc.pdf', mimeType: 'application/pdf' }],
+  };
+  filesListCalls = 0;
+
+  async exchangeCode(): Promise<typeof this.exchange> {
+    return this.exchange;
+  }
+  async refreshAccessToken(): Promise<{ accessToken: string; expiresAt: number }> {
+    return { accessToken: 'at-refreshed', expiresAt: Date.now() + 3600_000 };
+  }
+  async revokeToken(): Promise<void> {
+    /* noop */
+  }
+}
+
+const USER_1: AuthUser = { id: 'user-1', email: 'u1@example.com', provider: 'google' };
+
+const CFG = {
+  clientId: 'cid',
+  clientSecret: 'csecret',
+  redirectUri: 'http://localhost:3000/integrations/gdrive/oauth/callback',
+  appPublicUrl: 'http://localhost:5173',
+};
+
+function makeController(): {
+  ctrl: GDriveController;
+  repo: FakeRepo;
+  google: StubGoogleClient;
+  state: OAuthStateStore;
+} {
+  const repo = new FakeRepo();
+  const kms = new GDriveKmsService(new StubKmsClient(), 'arn:aws:kms:us-east-1:000000000000:key/k');
+  const google = new StubGoogleClient();
+  const svc = new GDriveService(repo, kms, google);
+  const state = new OAuthStateStore();
+  const ctrl = new GDriveController(svc, state, CFG);
+  return { ctrl, repo, google, state };
+}
+
+describe('GDriveController', () => {
+  // Force the flag on for these tests; explicit off-test below.
+  beforeEach(() => {
+    (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = true;
+  });
+  afterAll(() => {
+    (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
+  });
+
+  it('GET /oauth/url returns a Google consent URL with drive.file scope (NOT drive)', async () => {
+    const { ctrl } = makeController();
+    const out = await ctrl.consentUrl(USER_1);
+    expect(out.url).toContain('accounts.google.com/o/oauth2/v2/auth');
+    expect(out.url).toContain('scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file');
+    // Crucially, it must NOT include the broad `drive` scope or
+    // `drive.readonly`. Negative assertion is the contract guard.
+    expect(out.url).not.toMatch(/scope=https%3A%2F%2Fwww\.googleapis\.com%2Fauth%2Fdrive(&|$)/);
+    expect(out.url).not.toContain('drive.readonly');
+    expect(out.url).toContain('code_challenge_method=S256');
+    expect(out.url).toContain('access_type=offline');
+  });
+
+  it('GET /oauth/callback rejects with 400 when state nonce is unknown', async () => {
+    const { ctrl } = makeController();
+    await expect(
+      ctrl.oauthCallback('any-code', 'unknown-state', undefined, fakeRes()),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('GET /oauth/callback rejects with oauth-declined when error=access_denied', async () => {
+    const { ctrl } = makeController();
+    await expect(
+      ctrl.oauthCallback('', 'unknown', 'access_denied', fakeRes()),
+    ).rejects.toMatchObject({ message: expect.stringContaining('oauth-declined') });
+  });
+
+  it('GET /oauth/callback persists an account row and redirects to /settings/integrations', async () => {
+    const { ctrl, state, repo } = makeController();
+    const started = state.start('user-1');
+    const res = fakeRes();
+    await ctrl.oauthCallback('the-code', started.state, undefined, res);
+    expect(res.redirectedTo).toMatch(/\/settings\/integrations/);
+    const accounts = await repo.listForUser('user-1');
+    expect(accounts).toHaveLength(1);
+    expect(accounts[0]?.googleEmail).toBe('user@example.com');
+    // The plaintext refresh token must NOT appear inside the persisted
+    // ciphertext column. This is the row-level expression of red-flag #3.
+    expect(accounts[0]?.refreshTokenCiphertext.toString('utf8')).not.toContain('rt-from-google');
+  });
+
+  it('GET /accounts lists only the caller user accounts (sanitized view)', async () => {
+    const { ctrl, state } = makeController();
+    const started = state.start('user-1');
+    await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+    const out = await ctrl.listAccounts(USER_1);
+    expect(out).toHaveLength(1);
+    // Sanitized — must not leak ciphertext or KMS ARN to clients.
+    expect(out[0]).not.toHaveProperty('refreshTokenCiphertext');
+    expect(out[0]).not.toHaveProperty('refreshTokenKmsKeyArn');
+  });
+
+  it('DELETE /accounts/:id soft-deletes the row', async () => {
+    const { ctrl, state, repo } = makeController();
+    const started = state.start('user-1');
+    await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+    const [acc] = await repo.listForUser('user-1');
+    if (!acc) throw new Error('no acc');
+    await ctrl.deleteAccount(acc.id, USER_1);
+    // The row remains but `deleted_at` is set; listForUser filters it out.
+    expect(repo.rows.get(acc.id)?.deletedAt).toBeTruthy();
+    expect(await repo.listForUser('user-1')).toHaveLength(0);
+  });
+
+  it('feature flag off → every route 404s', async () => {
+    (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
+    const { ctrl } = makeController();
+    await expect(ctrl.consentUrl(USER_1)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(ctrl.listAccounts(USER_1)).rejects.toBeInstanceOf(NotFoundException);
+    await expect(
+      ctrl.deleteAccount('00000000-0000-0000-0000-000000000000', USER_1),
+    ).rejects.toBeInstanceOf(NotFoundException);
+    expect(() => ctrl.listFiles(USER_1, 'acc-1', 'all')).toThrow(NotFoundException);
+    await expect(ctrl.oauthCallback('c', 's', undefined, fakeRes())).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  // WT-A-2 contract: GET /files is intentionally a 501 stub in WT-A-1.
+  // The full rate-limited Drive proxy lands in `feature/gdrive-files-proxy`.
+  // This test pins the contract so WT-A-2 must explicitly remove/replace
+  // it when it wires the real proxy in.
+  it('GET /files returns 501 not-implemented (WT-A-2 stub contract)', () => {
+    const { ctrl } = makeController();
+    let caught: unknown;
+    try {
+      ctrl.listFiles(USER_1, 'acc-1', 'pdf');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(HttpException);
+    const httpErr = caught as HttpException;
+    expect(httpErr.getStatus()).toBe(HttpStatus.NOT_IMPLEMENTED);
+    expect(httpErr.getResponse()).toMatchObject({ code: 'not-implemented' });
+  });
+});
+
+interface FakeRes {
+  redirect: (url: string) => void;
+  redirectedTo: string | null;
+}
+function fakeRes(): FakeRes {
+  const r: FakeRes = {
+    redirectedTo: null,
+    redirect(url: string) {
+      r.redirectedTo = url;
+    },
+  };
+  return r;
+}

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -1,0 +1,153 @@
+import {
+  BadRequestException,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpException,
+  HttpStatus,
+  Inject,
+  NotFoundException,
+  Param,
+  ParseUUIDPipe,
+  Query,
+  Res,
+} from '@nestjs/common';
+import { isFeatureEnabled } from 'shared';
+import { CurrentUser } from '../../auth/current-user.decorator';
+import type { AuthUser } from '../../auth/auth-user';
+import { GDriveService } from './gdrive.service';
+import { OAuthStateStore, buildConsentUrl } from './oauth-pkce';
+import type { GDriveAccountView } from './dto/account.dto';
+
+/**
+ * OAuth + Drive proxy routes for the Drive integration.
+ *
+ * Every route is gated behind `feature.gdriveIntegration`. When the flag
+ * is off, the controller throws NotFoundException so the routes are
+ * indistinguishable from a misconfigured server (no information leakage
+ * about the upcoming feature).
+ */
+
+export interface GDriveConfig {
+  readonly clientId: string;
+  readonly clientSecret: string;
+  readonly redirectUri: string;
+  readonly appPublicUrl: string;
+}
+
+export const GDRIVE_CONFIG = Symbol('GDRIVE_CONFIG');
+
+export interface DriveFile {
+  id: string;
+  name: string;
+  mimeType: string;
+  modifiedTime?: string;
+  size?: string;
+}
+
+// Type contract for the WT-A-2 files-proxy implementation. Kept in
+// WT-A-1 so the proxy module compiles standalone; the runtime provider
+// + the consuming route are added in WT-A-2.
+export type FilesProxy = (args: {
+  accessToken: string;
+  mimeFilter: 'pdf' | 'doc' | 'docx' | 'all';
+}) => Promise<{ files: ReadonlyArray<DriveFile> }>;
+
+@Controller('integrations/gdrive')
+export class GDriveController {
+  constructor(
+    private readonly svc: GDriveService,
+    @Inject(OAuthStateStore) private readonly stateStore: OAuthStateStore,
+    @Inject(GDRIVE_CONFIG) private readonly config: GDriveConfig,
+  ) {}
+
+  private requireFlag(): void {
+    if (!isFeatureEnabled('gdriveIntegration')) {
+      throw new NotFoundException('not_found');
+    }
+  }
+
+  @Get('oauth/url')
+  async consentUrl(@CurrentUser() user: AuthUser): Promise<{ url: string }> {
+    this.requireFlag();
+    const { state, codeChallenge } = this.stateStore.start(user.id);
+    return {
+      url: buildConsentUrl({
+        clientId: this.config.clientId,
+        redirectUri: this.config.redirectUri,
+        state,
+        codeChallenge,
+      }),
+    };
+  }
+
+  @Get('oauth/callback')
+  // The callback is reached via Google's redirect — the user's browser, not
+  // an authed JSON caller. We rely on the `state` nonce (single-use, 10
+  // min TTL) for CSRF + identity binding.
+  async oauthCallback(
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Query('error') error: string | undefined,
+    @Res({ passthrough: true }) res: { redirect(url: string): void },
+  ): Promise<void> {
+    this.requireFlag();
+    if (error) {
+      throw new HttpException(`oauth-declined: ${error}`, 400);
+    }
+    const entry = this.stateStore.consume(state);
+    if (!entry) {
+      throw new BadRequestException('oauth_state_invalid');
+    }
+    if (!code) throw new BadRequestException('oauth_code_missing');
+    await this.svc.completeOAuth({
+      userId: entry.userId,
+      code,
+      codeVerifier: entry.codeVerifier,
+    });
+    res.redirect(`${this.config.appPublicUrl}/settings/integrations?connected=1`);
+  }
+
+  @Get('accounts')
+  async listAccounts(@CurrentUser() user: AuthUser): Promise<ReadonlyArray<GDriveAccountView>> {
+    this.requireFlag();
+    const rows = await this.svc.listAccounts(user.id);
+    return rows
+      .filter((r) => !r.deletedAt)
+      .map((r) => ({
+        id: r.id,
+        email: r.googleEmail,
+        connectedAt: r.connectedAt,
+        lastUsedAt: r.lastUsedAt,
+      }));
+  }
+
+  @Delete('accounts/:id')
+  @HttpCode(204)
+  async deleteAccount(
+    @Param('id', ParseUUIDPipe) id: string,
+    @CurrentUser() user: AuthUser,
+  ): Promise<void> {
+    this.requireFlag();
+    await this.svc.revokeAccount(id, user.id);
+  }
+
+  // TODO(WT-A-2): rate-limited Drive files proxy lives in follow-up PR
+  // (`feature/gdrive-files-proxy`). Stubbed at 501 here so WT-A-1 can
+  // ship without dead injection points (no orphan rate-limiter or
+  // files-proxy providers in this PR — see decisions.md Phase 5
+  // corrected verdict).
+  @Get('files')
+  listFiles(
+    @CurrentUser() _user: AuthUser,
+    @Query('accountId') _accountId: string,
+    @Query('mimeFilter') _mimeFilter: 'pdf' | 'doc' | 'docx' | 'all' = 'all',
+  ): never {
+    this.requireFlag();
+    throw new HttpException(
+      { code: 'not-implemented', message: 'gdrive_files_proxy_pending_wt_a2' },
+      HttpStatus.NOT_IMPLEMENTED,
+    );
+  }
+}

--- a/apps/api/src/integrations/gdrive/gdrive.module.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.module.ts
@@ -1,0 +1,80 @@
+import { Module, Logger } from '@nestjs/common';
+import { APP_ENV } from '../../config/config.module';
+import type { AppEnv } from '../../config/env.schema';
+import { AuthModule } from '../../auth/auth.module';
+import { GDriveController, GDRIVE_CONFIG, type GDriveConfig } from './gdrive.controller';
+import { GDriveService, GOOGLE_OAUTH_CLIENT } from './gdrive.service';
+import { GDriveKmsService } from './gdrive-kms.service';
+import { GDRIVE_REPOSITORY } from './gdrive.repository';
+import { GDrivePgRepository } from './gdrive.repository.pg';
+import { OAuthStateStore } from './oauth-pkce';
+import { FetchGoogleOAuthClient } from './google-oauth.client';
+
+/**
+ * Drive integration module. All providers are factory-built from env so
+ * the same image can run with the feature dark (no GDRIVE_* vars set —
+ * controller throws NotFound on every route via the feature flag).
+ *
+ * Pre-merge security audit: `nodejs-security` skill — token storage path
+ * (KMS envelope) + OAuth state store (CSRF resistance via single-use,
+ * 10-min-TTL nonces).
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [GDriveController],
+  providers: [
+    GDriveService,
+    { provide: GDRIVE_REPOSITORY, useClass: GDrivePgRepository },
+    {
+      provide: GDriveKmsService,
+      inject: [APP_ENV],
+      useFactory: (env: AppEnv): GDriveKmsService => {
+        const logger = new Logger('GDriveModule');
+        if (!env.GDRIVE_TOKEN_KMS_KEY_ARN || !env.GDRIVE_TOKEN_KMS_REGION) {
+          // Feature off / not yet provisioned. The controller's feature
+          // flag guard 404s every route; this stub will never be called.
+          logger.warn('GDriveKmsService: env not provisioned (feature off). Stub installed.');
+          return new GDriveKmsService({ generateDataKey: stubFail, decrypt: stubFail }, 'stub');
+        }
+        return GDriveKmsService.fromEnv(env);
+      },
+    },
+    OAuthStateStore,
+    // GDriveRateLimiter provider deferred to WT-A-2 (lives with the
+    // files-proxy route it gates). See decisions.md Phase 5 corrected
+    // verdict — rate-limiter without its consumer would be an orphan
+    // provider, tripping nestjs-best-practices.
+    {
+      provide: GOOGLE_OAUTH_CLIENT,
+      inject: [APP_ENV],
+      useFactory: (env: AppEnv): FetchGoogleOAuthClient =>
+        new FetchGoogleOAuthClient(
+          env.GDRIVE_OAUTH_CLIENT_ID ?? 'unset',
+          env.GDRIVE_OAUTH_CLIENT_SECRET ?? 'unset',
+          env.GDRIVE_OAUTH_REDIRECT_URI ??
+            'http://localhost:3000/integrations/gdrive/oauth/callback',
+        ),
+    },
+    {
+      provide: GDRIVE_CONFIG,
+      inject: [APP_ENV],
+      useFactory: (env: AppEnv): GDriveConfig => ({
+        clientId: env.GDRIVE_OAUTH_CLIENT_ID ?? '',
+        clientSecret: env.GDRIVE_OAUTH_CLIENT_SECRET ?? '',
+        redirectUri:
+          env.GDRIVE_OAUTH_REDIRECT_URI ??
+          'http://localhost:3000/integrations/gdrive/oauth/callback',
+        appPublicUrl: env.APP_PUBLIC_URL,
+      }),
+    },
+    // GDRIVE_FILES_PROXY provider deferred to WT-A-2 alongside the
+    // GET /files route + rate-limiter; the route stub returns 501 in
+    // this PR.
+  ],
+  exports: [GDriveService],
+})
+export class GDriveModule {}
+
+async function stubFail(): Promise<never> {
+  throw new Error('gdrive_kms_misconfigured');
+}

--- a/apps/api/src/integrations/gdrive/gdrive.repository.pg.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.repository.pg.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable } from '@nestjs/common';
+import type { Kysely, Selectable } from 'kysely';
+import type { Database, GDriveAccountsTable } from '../../../db/schema';
+import { DB_TOKEN } from '../../db/db.provider';
+import type { GDriveAccount, GDriveRepository } from './gdrive.repository';
+
+type Row = Selectable<GDriveAccountsTable>;
+
+function toDomain(r: Row): GDriveAccount {
+  return {
+    id: r.id,
+    userId: r.user_id,
+    googleUserId: r.google_user_id,
+    googleEmail: r.google_email,
+    refreshTokenCiphertext: Buffer.isBuffer(r.refresh_token_ciphertext)
+      ? r.refresh_token_ciphertext
+      : Buffer.from(r.refresh_token_ciphertext as unknown as ArrayBuffer),
+    refreshTokenKmsKeyArn: r.refresh_token_kms_key_arn,
+    scope: r.scope,
+    connectedAt: new Date(r.connected_at).toISOString(),
+    lastUsedAt: r.last_used_at ? new Date(r.last_used_at).toISOString() : null,
+    deletedAt: r.deleted_at ? new Date(r.deleted_at).toISOString() : null,
+  };
+}
+
+@Injectable()
+export class GDrivePgRepository implements GDriveRepository {
+  constructor(@Inject(DB_TOKEN) private readonly db: Kysely<Database>) {}
+
+  async findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null> {
+    const r = await this.db
+      .selectFrom('gdrive_accounts')
+      .selectAll()
+      .where('id', '=', id)
+      .where('user_id', '=', userId)
+      .where('deleted_at', 'is', null)
+      .executeTakeFirst();
+    return r ? toDomain(r) : null;
+  }
+
+  async listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
+    const rows = await this.db
+      .selectFrom('gdrive_accounts')
+      .selectAll()
+      .where('user_id', '=', userId)
+      .where('deleted_at', 'is', null)
+      .orderBy('connected_at', 'desc')
+      .execute();
+    return rows.map(toDomain);
+  }
+
+  async insert(row: GDriveAccount): Promise<GDriveAccount> {
+    const inserted = await this.db
+      .insertInto('gdrive_accounts')
+      .values({
+        id: row.id,
+        user_id: row.userId,
+        google_user_id: row.googleUserId,
+        google_email: row.googleEmail,
+        refresh_token_ciphertext: row.refreshTokenCiphertext,
+        refresh_token_kms_key_arn: row.refreshTokenKmsKeyArn,
+        scope: row.scope,
+      })
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return toDomain(inserted);
+  }
+
+  async softDelete(id: string, userId: string): Promise<boolean> {
+    const r = await this.db
+      .updateTable('gdrive_accounts')
+      .set({ deleted_at: new Date().toISOString() })
+      .where('id', '=', id)
+      .where('user_id', '=', userId)
+      .where('deleted_at', 'is', null)
+      .executeTakeFirst();
+    return (r?.numUpdatedRows ?? 0n) > 0n;
+  }
+
+  async touchLastUsed(id: string): Promise<void> {
+    await this.db
+      .updateTable('gdrive_accounts')
+      .set({ last_used_at: new Date().toISOString() })
+      .where('id', '=', id)
+      .execute();
+  }
+}

--- a/apps/api/src/integrations/gdrive/gdrive.repository.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.repository.ts
@@ -1,0 +1,34 @@
+/**
+ * Domain row for a connected Google Drive account. The refresh token is
+ * always carried as KMS-envelope-encrypted bytes (red-flag row 3 — never
+ * plaintext at rest, never in logs). The `kmsKeyArn` is stored alongside
+ * so a future key rotation can decrypt rows that pre-date the rotation.
+ */
+export interface GDriveAccount {
+  readonly id: string;
+  readonly userId: string;
+  readonly googleUserId: string;
+  readonly googleEmail: string;
+  readonly refreshTokenCiphertext: Buffer;
+  readonly refreshTokenKmsKeyArn: string;
+  readonly scope: string;
+  readonly connectedAt: string;
+  readonly lastUsedAt: string | null;
+  readonly deletedAt: string | null;
+}
+
+/**
+ * Port for `gdrive_accounts` access. The Postgres adapter
+ * (`gdrive.repository.pg.ts`) is the only place that touches Kysely.
+ * Soft-deletes are the rule — we keep history for audit + GDPR
+ * subject-access requests.
+ */
+export interface GDriveRepository {
+  findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null>;
+  listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>>;
+  insert(row: GDriveAccount): Promise<GDriveAccount>;
+  softDelete(id: string, userId: string): Promise<boolean>;
+  touchLastUsed(id: string): Promise<void>;
+}
+
+export const GDRIVE_REPOSITORY = Symbol('GDRIVE_REPOSITORY');

--- a/apps/api/src/integrations/gdrive/gdrive.service.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.service.spec.ts
@@ -1,0 +1,159 @@
+import { GDriveService, type GoogleOAuthClient } from './gdrive.service';
+import type { GDriveAccount, GDriveRepository } from './gdrive.repository';
+import { GDriveKmsService, type KmsClientPort } from './gdrive-kms.service';
+import { TokenExpiredError } from './dto/error-codes';
+
+class FakeRepo implements GDriveRepository {
+  rows = new Map<string, GDriveAccount>();
+  async findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null> {
+    const r = this.rows.get(id);
+    return r && r.userId === userId ? r : null;
+  }
+  async listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
+    return [...this.rows.values()].filter((r) => r.userId === userId);
+  }
+  async insert(row: GDriveAccount): Promise<GDriveAccount> {
+    this.rows.set(row.id, row);
+    return row;
+  }
+  async softDelete(id: string, _userId: string): Promise<boolean> {
+    const r = this.rows.get(id);
+    if (!r) return false;
+    this.rows.set(id, { ...r, deletedAt: new Date().toISOString() });
+    return true;
+  }
+  async touchLastUsed(id: string): Promise<void> {
+    const r = this.rows.get(id);
+    if (r) this.rows.set(id, { ...r, lastUsedAt: new Date().toISOString() });
+  }
+}
+
+class StubKmsClient implements KmsClientPort {
+  async generateDataKey(): Promise<{ plaintext: Buffer; ciphertextBlob: Buffer }> {
+    const k = Buffer.alloc(32, 7);
+    return { plaintext: k, ciphertextBlob: Buffer.concat([Buffer.from('K|'), k]) };
+  }
+  async decrypt(blob: Buffer): Promise<Buffer> {
+    return blob.subarray(blob.indexOf(0x7c) + 1);
+  }
+}
+
+class StubGoogleClient implements GoogleOAuthClient {
+  refreshCalls = 0;
+  refreshDelayMs = 0;
+  refreshFailWith: 'invalid_grant' | null = null;
+  abortObserved = false;
+
+  async exchangeCode(): Promise<never> {
+    throw new Error('not used in this spec');
+  }
+  async refreshAccessToken(
+    _refreshToken: string,
+    signal?: AbortSignal,
+  ): Promise<{ accessToken: string; expiresAt: number }> {
+    this.refreshCalls++;
+    if (this.refreshFailWith === 'invalid_grant') {
+      const e = new Error('invalid_grant') as Error & { code?: string };
+      e.code = 'invalid_grant';
+      throw e;
+    }
+    if (this.refreshDelayMs > 0) {
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(resolve, this.refreshDelayMs);
+        if (signal) {
+          signal.addEventListener('abort', () => {
+            clearTimeout(timer);
+            this.abortObserved = true;
+            reject(new Error('aborted'));
+          });
+        }
+      });
+    }
+    return { accessToken: `at-${this.refreshCalls}`, expiresAt: Date.now() + 3600_000 };
+  }
+  async revokeToken(): Promise<void> {
+    /* no-op */
+  }
+}
+
+const ARN = 'arn:aws:kms:us-east-1:000000000000:key/k';
+
+async function seedAccount(
+  repo: FakeRepo,
+  kms: GDriveKmsService,
+  refreshToken: string,
+): Promise<GDriveAccount> {
+  const enc = await kms.encrypt(refreshToken);
+  const acc: GDriveAccount = {
+    id: 'acc-1',
+    userId: 'user-1',
+    googleUserId: 'g-1',
+    googleEmail: 'a@example.com',
+    refreshTokenCiphertext: enc.ciphertext,
+    refreshTokenKmsKeyArn: enc.kmsKeyArn,
+    scope: 'https://www.googleapis.com/auth/drive.file',
+    connectedAt: new Date().toISOString(),
+    lastUsedAt: null,
+    deletedAt: null,
+  };
+  await repo.insert(acc);
+  return acc;
+}
+
+describe('GDriveService', () => {
+  let repo: FakeRepo;
+  let kms: GDriveKmsService;
+  let google: StubGoogleClient;
+  let svc: GDriveService;
+
+  beforeEach(() => {
+    repo = new FakeRepo();
+    kms = new GDriveKmsService(new StubKmsClient(), ARN);
+    google = new StubGoogleClient();
+    svc = new GDriveService(repo, kms, google);
+  });
+
+  it('refresh-token single-flight: 5 concurrent calls produce exactly 1 Google request', async () => {
+    await seedAccount(repo, kms, 'rt-secret-1');
+    google.refreshDelayMs = 25;
+    const results = await Promise.all(
+      Array.from({ length: 5 }).map(() => svc.getAccessToken('acc-1', 'user-1')),
+    );
+    expect(google.refreshCalls).toBe(1);
+    // All 5 callers receive the same token from the in-flight promise.
+    expect(new Set(results.map((r) => r.accessToken)).size).toBe(1);
+  });
+
+  it('returns the cached access token while it is still valid', async () => {
+    await seedAccount(repo, kms, 'rt-secret-1');
+    const a = await svc.getAccessToken('acc-1', 'user-1');
+    const b = await svc.getAccessToken('acc-1', 'user-1');
+    expect(google.refreshCalls).toBe(1);
+    expect(a.accessToken).toBe(b.accessToken);
+  });
+
+  it('expired refresh-token branch surfaces TokenExpiredError (code: token-expired)', async () => {
+    await seedAccount(repo, kms, 'rt-revoked');
+    google.refreshFailWith = 'invalid_grant';
+    await expect(svc.getAccessToken('acc-1', 'user-1')).rejects.toBeInstanceOf(TokenExpiredError);
+    await svc.getAccessToken('acc-1', 'user-1').catch((err: unknown) => {
+      expect((err as TokenExpiredError).code).toBe('token-expired');
+    });
+  });
+
+  it('AbortSignal aborts an in-flight token issuance', async () => {
+    await seedAccount(repo, kms, 'rt-secret-1');
+    google.refreshDelayMs = 200;
+    const ctrl = new AbortController();
+    const p = svc.getAccessToken('acc-1', 'user-1', ctrl.signal);
+    setTimeout(() => ctrl.abort(), 10);
+    await expect(p).rejects.toThrow();
+    expect(google.abortObserved).toBe(true);
+  });
+
+  it('returns 404-ish (null) when account is missing or belongs to another user', async () => {
+    await seedAccount(repo, kms, 'rt');
+    await expect(svc.getAccessToken('acc-1', 'user-2')).rejects.toThrow();
+    await expect(svc.getAccessToken('missing', 'user-1')).rejects.toThrow();
+  });
+});

--- a/apps/api/src/integrations/gdrive/gdrive.service.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.service.ts
@@ -1,0 +1,159 @@
+import { randomUUID } from 'node:crypto';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { GDriveKmsService } from './gdrive-kms.service';
+import { GDRIVE_REPOSITORY, type GDriveAccount, type GDriveRepository } from './gdrive.repository';
+import { TokenExpiredError } from './dto/error-codes';
+
+/**
+ * Adapter over the Google OAuth + token-refresh endpoints. Kept behind a
+ * small port so the unit suite can stub the network without touching
+ * real Google. The production adapter lives next to this file and uses
+ * `googleapis` / `google-auth-library`.
+ */
+export interface GoogleOAuthClient {
+  exchangeCode(
+    code: string,
+    codeVerifier: string,
+  ): Promise<{
+    refreshToken: string;
+    accessToken: string;
+    expiresAt: number;
+    googleUserId: string;
+    googleEmail: string;
+    scope: string;
+  }>;
+  refreshAccessToken(
+    refreshToken: string,
+    signal?: AbortSignal,
+  ): Promise<{ accessToken: string; expiresAt: number }>;
+  revokeToken(refreshToken: string): Promise<void>;
+}
+
+export const GOOGLE_OAUTH_CLIENT = Symbol('GOOGLE_OAUTH_CLIENT');
+
+interface CachedToken {
+  accessToken: string;
+  expiresAt: number;
+}
+
+/**
+ * Token issuer for internal callers (the Drive files proxy + the WT-D
+ * conversion service). Holds a per-account in-flight Promise so 5
+ * concurrent callers collapse onto a single Google refresh request
+ * (Phase 4 watchpoint #3 — request-scoped AbortSignal honored).
+ */
+@Injectable()
+export class GDriveService {
+  private readonly cache = new Map<string, CachedToken>();
+  private readonly inflight = new Map<string, Promise<CachedToken>>();
+
+  constructor(
+    @Inject(GDRIVE_REPOSITORY) private readonly repo: GDriveRepository,
+    private readonly kms: GDriveKmsService,
+    @Inject(GOOGLE_OAUTH_CLIENT) private readonly google: GoogleOAuthClient,
+  ) {}
+
+  async getAccessToken(
+    accountId: string,
+    userId: string,
+    signal?: AbortSignal,
+  ): Promise<{ accessToken: string; expiresAt: number }> {
+    const account = await this.requireOwnedAccount(accountId, userId);
+    const cached = this.cache.get(accountId);
+    // 30s skew guard — refresh slightly early so callers don't trip Google's
+    // own 5xx-on-expiry race.
+    if (cached && cached.expiresAt - Date.now() > 30_000) {
+      return cached;
+    }
+    const existing = this.inflight.get(accountId);
+    if (existing) return existing;
+    const promise = this.refreshToken(account, signal);
+    this.inflight.set(accountId, promise);
+    try {
+      const next = await promise;
+      this.cache.set(accountId, next);
+      return next;
+    } finally {
+      this.inflight.delete(accountId);
+    }
+  }
+
+  private async refreshToken(account: GDriveAccount, signal?: AbortSignal): Promise<CachedToken> {
+    const refreshToken = await this.kms.decrypt(
+      account.refreshTokenCiphertext,
+      account.refreshTokenKmsKeyArn,
+    );
+    try {
+      const out = await this.google.refreshAccessToken(refreshToken, signal);
+      await this.repo.touchLastUsed(account.id);
+      return out;
+    } catch (err) {
+      if (isInvalidGrant(err)) {
+        throw new TokenExpiredError('refresh_token_invalid_or_revoked');
+      }
+      throw err;
+    }
+  }
+
+  async listAccounts(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
+    return this.repo.listForUser(userId);
+  }
+
+  /**
+   * Completes the OAuth dance: exchanges `code` for tokens, encrypts the
+   * refresh token via KMS envelope, and inserts a new `gdrive_accounts`
+   * row owned by `userId`. Returns the inserted row id.
+   */
+  async completeOAuth(args: {
+    userId: string;
+    code: string;
+    codeVerifier: string;
+  }): Promise<string> {
+    const exchange = await this.google.exchangeCode(args.code, args.codeVerifier);
+    const enc = await this.kms.encrypt(exchange.refreshToken);
+    const id = newUuid();
+    await this.repo.insert({
+      id,
+      userId: args.userId,
+      googleUserId: exchange.googleUserId,
+      googleEmail: exchange.googleEmail,
+      refreshTokenCiphertext: enc.ciphertext,
+      refreshTokenKmsKeyArn: enc.kmsKeyArn,
+      scope: exchange.scope,
+      connectedAt: new Date().toISOString(),
+      lastUsedAt: null,
+      deletedAt: null,
+    });
+    return id;
+  }
+
+  async revokeAccount(accountId: string, userId: string): Promise<void> {
+    const account = await this.requireOwnedAccount(accountId, userId);
+    const refreshToken = await this.kms.decrypt(
+      account.refreshTokenCiphertext,
+      account.refreshTokenKmsKeyArn,
+    );
+    // Best-effort revoke at Google. If it fails, still soft-delete locally
+    // so the user isn't stuck — the row carries `deleted_at` for audit and
+    // future GDPR requests.
+    await this.google.revokeToken(refreshToken).catch(() => undefined);
+    await this.repo.softDelete(accountId, userId);
+    this.cache.delete(accountId);
+  }
+
+  private async requireOwnedAccount(id: string, userId: string): Promise<GDriveAccount> {
+    const acc = await this.repo.findByIdForUser(id, userId);
+    if (!acc || acc.deletedAt) throw new NotFoundException('gdrive_account_not_found');
+    return acc;
+  }
+}
+
+function newUuid(): string {
+  return randomUUID();
+}
+
+function isInvalidGrant(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as { code?: string; message?: string };
+  return e.code === 'invalid_grant' || /invalid_grant/i.test(e.message ?? '');
+}

--- a/apps/api/src/integrations/gdrive/google-oauth.client.ts
+++ b/apps/api/src/integrations/gdrive/google-oauth.client.ts
@@ -1,0 +1,111 @@
+import type { GoogleOAuthClient } from './gdrive.service';
+
+/**
+ * Minimal `fetch`-based Google OAuth client. Skips the `googleapis` SDK
+ * (~250 KB) so the API bundle stays small. The three endpoints we need:
+ *   - POST https://oauth2.googleapis.com/token   (code exchange + refresh)
+ *   - GET  https://www.googleapis.com/oauth2/v3/userinfo (email + sub)
+ *   - POST https://oauth2.googleapis.com/revoke  (revoke at Google)
+ *
+ * `invalid_grant` from the refresh endpoint is the "user revoked access"
+ * signal — surfaced upward so the service maps it to TokenExpiredError.
+ */
+export class FetchGoogleOAuthClient implements GoogleOAuthClient {
+  constructor(
+    private readonly clientId: string,
+    private readonly clientSecret: string,
+    private readonly redirectUri: string,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async exchangeCode(
+    code: string,
+    codeVerifier: string,
+  ): Promise<{
+    refreshToken: string;
+    accessToken: string;
+    expiresAt: number;
+    googleUserId: string;
+    googleEmail: string;
+    scope: string;
+  }> {
+    const body = new URLSearchParams({
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      code,
+      code_verifier: codeVerifier,
+      grant_type: 'authorization_code',
+      redirect_uri: this.redirectUri,
+    });
+    const tokenRes = await this.fetchImpl('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!tokenRes.ok) {
+      const text = await tokenRes.text();
+      throw mapOAuthError(text);
+    }
+    const tokenJson = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token?: string;
+      expires_in: number;
+      scope: string;
+    };
+    if (!tokenJson.refresh_token) {
+      throw new Error('google_oauth_no_refresh_token: prompt=consent missing?');
+    }
+    const userRes = await this.fetchImpl('https://www.googleapis.com/oauth2/v3/userinfo', {
+      headers: { authorization: `Bearer ${tokenJson.access_token}` },
+    });
+    if (!userRes.ok) throw new Error('google_oauth_userinfo_failed');
+    const user = (await userRes.json()) as { sub: string; email: string };
+    return {
+      refreshToken: tokenJson.refresh_token,
+      accessToken: tokenJson.access_token,
+      expiresAt: Date.now() + tokenJson.expires_in * 1000,
+      googleUserId: user.sub,
+      googleEmail: user.email,
+      scope: tokenJson.scope,
+    };
+  }
+
+  async refreshAccessToken(
+    refreshToken: string,
+    signal?: AbortSignal,
+  ): Promise<{ accessToken: string; expiresAt: number }> {
+    const body = new URLSearchParams({
+      client_id: this.clientId,
+      client_secret: this.clientSecret,
+      refresh_token: refreshToken,
+      grant_type: 'refresh_token',
+    });
+    const res = await this.fetchImpl('https://oauth2.googleapis.com/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+      ...(signal ? { signal } : {}),
+    });
+    if (!res.ok) throw mapOAuthError(await res.text());
+    const json = (await res.json()) as { access_token: string; expires_in: number };
+    return { accessToken: json.access_token, expiresAt: Date.now() + json.expires_in * 1000 };
+  }
+
+  async revokeToken(refreshToken: string): Promise<void> {
+    const body = new URLSearchParams({ token: refreshToken });
+    await this.fetchImpl('https://oauth2.googleapis.com/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+  }
+}
+
+function mapOAuthError(payload: string): Error & { code?: string } {
+  const err = new Error(`google_oauth_error: ${payload.slice(0, 200)}`) as Error & {
+    code?: string;
+  };
+  if (/invalid_grant/.test(payload)) err.code = 'invalid_grant';
+  else if (/access_denied/.test(payload)) err.code = 'oauth-declined';
+  return err;
+}

--- a/apps/api/src/integrations/gdrive/oauth-pkce.ts
+++ b/apps/api/src/integrations/gdrive/oauth-pkce.ts
@@ -1,0 +1,84 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * RFC 7636 PKCE helpers + an in-memory state-nonce store. Each
+ * `start()` mints a fresh `code_verifier`, derives the SHA-256
+ * `code_challenge`, generates an opaque `state` nonce, and remembers
+ * `(state → { codeVerifier, userId, expiresAt })` for 10 minutes. The
+ * callback handler `consume(state)` returns the entry exactly once and
+ * deletes it (single-use, defeats CSRF + replay).
+ *
+ * In-memory is fine for v1: each session uses 1 entry, expiry is short,
+ * and a missed lookup just forces the user to re-click "Connect". Move
+ * to Postgres when we have multiple API pods.
+ */
+export interface OAuthStateEntry {
+  codeVerifier: string;
+  userId: string;
+  expiresAt: number;
+}
+
+export class OAuthStateStore {
+  private readonly store = new Map<string, OAuthStateEntry>();
+  constructor(
+    private readonly ttlMs = 10 * 60 * 1000,
+    private readonly clock: () => number = Date.now,
+  ) {}
+
+  start(userId: string): { state: string; codeVerifier: string; codeChallenge: string } {
+    const codeVerifier = base64url(randomBytes(64));
+    const codeChallenge = base64url(createHash('sha256').update(codeVerifier).digest());
+    const state = base64url(randomBytes(32));
+    this.gc();
+    this.store.set(state, {
+      codeVerifier,
+      userId,
+      expiresAt: this.clock() + this.ttlMs,
+    });
+    return { state, codeVerifier, codeChallenge };
+  }
+
+  consume(state: string): OAuthStateEntry | null {
+    const entry = this.store.get(state);
+    if (!entry) return null;
+    this.store.delete(state);
+    if (entry.expiresAt < this.clock()) return null;
+    return entry;
+  }
+
+  private gc(): void {
+    const now = this.clock();
+    for (const [k, v] of this.store) {
+      if (v.expiresAt < now) this.store.delete(k);
+    }
+  }
+}
+
+function base64url(b: Buffer): string {
+  return b.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+/**
+ * Build the Google OAuth consent URL. Scope is `drive.file` (per-file
+ * authorization) NOT `drive` (full account) — Phase 4 red-flag row 12,
+ * Phase 1 Q5. Test asserts the literal string.
+ */
+export function buildConsentUrl(args: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  codeChallenge: string;
+}): string {
+  const params = new URLSearchParams({
+    client_id: args.clientId,
+    redirect_uri: args.redirectUri,
+    response_type: 'code',
+    scope: 'https://www.googleapis.com/auth/drive.file',
+    access_type: 'offline',
+    prompt: 'consent',
+    state: args.state,
+    code_challenge: args.codeChallenge,
+    code_challenge_method: 'S256',
+  });
+  return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+}

--- a/cspell.json
+++ b/cspell.json
@@ -479,7 +479,15 @@
     "tombstones",
     "Tombstones",
     "tombstoned",
-    "Tombstoned"
+    "Tombstoned",
+    "gdrive",
+    "Gdrive",
+    "GDrive",
+    "GDRIVE",
+    "pkce",
+    "PKCE",
+    "bytea",
+    "wordprocessingml"
   ],
   "ignoreRegExpList": [
     "Base64",

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -1,0 +1,28 @@
+/**
+ * Feature flags shared across api + web. Default everything to `false` so
+ * a new flag is dark until explicitly turned on. Reads happen at request
+ * time (api) or render time (web) — flipping the const here + redeploying
+ * is the activation path. There is no runtime override store today.
+ */
+export const FEATURE_FLAGS: Record<string, boolean> = {
+  /**
+   * Google Drive integration (Phase 5 of the gdrive feature). Off until
+   * WT-A through WT-E all merge and the backend is verified end-to-end.
+   * When false:
+   *   - api: every `/integrations/gdrive/*` route 404s.
+   *   - web: source-selection cards + settings page hide the Drive surface.
+   */
+  gdriveIntegration: false,
+
+  /**
+   * Multi-account UI gate for the gdrive Settings page. Data model is
+   * already multi-account; this flag only controls the UI affordance.
+   */
+  gdriveMultiAccount: false,
+} as const;
+
+export type FeatureFlag = 'gdriveIntegration' | 'gdriveMultiAccount';
+
+export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  return FEATURE_FLAGS[flag] === true;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,6 @@
 export * from './signer';
+export { FEATURE_FLAGS, isFeatureEnabled } from './feature-flags';
+export type { FeatureFlag } from './feature-flags';
 export {
   ESIGN_DISCLOSURE_VERSION,
   ENVELOPE_RETENTION_YEARS_DEFAULT,


### PR DESCRIPTION
## Summary

WT-A-1 of the Google Drive integration: backend OAuth flow + KMS-wrapped
refresh tokens + per-user account persistence + migration. Files-proxy +
rate-limiter intentionally deferred to WT-A-2 (`feature/gdrive-files-proxy`)
per the Phase 5 corrected manager verdict in
`.claude/gdrive-feature/decisions.md`.

## What ships

- NestJS module `apps/api/src/integrations/gdrive/`:
  - `GET  /integrations/gdrive/oauth/url` (PKCE S256, scope=`drive.file`)
  - `GET  /integrations/gdrive/oauth/callback` (single-use 10-min state nonce)
  - `GET  /integrations/gdrive/accounts` (sanitized view, no token bytes)
  - `DELETE /integrations/gdrive/accounts/:id` (revoke + soft-delete)
  - `GET  /integrations/gdrive/files` -> 501 Not Implemented (`TODO(WT-A-2)`)
- KMS envelope (AES-256-GCM, fresh 32-byte DEK per row, 96-bit random IV)
  reusing the per-tenant CMK pattern from PR #12 (`memory/project_kms_signer.md`).
  Refresh tokens NEVER persisted in plaintext.
- Token issuer with single-flight per-account refresh + 30s skew guard +
  `AbortSignal` pass-through (Phase 4 watchpoint #3).
- Migration `0013_gdrive_accounts.sql` (up) + paired `_down.sql`
  (establishes the down-script convention for future migrations).
- 7 `GDRIVE_*` env vars added to `env.schema.ts` AND documented in
  `CLAUDE.md` (red-flag row 4 cleared).
- Shared feature flag `gdriveIntegration` (default off); routes return
  404 when off, indistinguishable from a misconfigured server.

## Why a 2-way split (manager-authorized LOC exception)

Total ~1075 LOC vs. the 600 LOC ceiling from `pr-plan.md`. The 2-way
split (WT-A-1 OAuth core + WT-A-2 files-proxy ~230 LOC) is the smallest
reviewable unit because OAuth state nonce + KMS envelope + persistence +
redirect handling are intrinsically coupled. Rate-limiter belongs with
its sole consumer (`GET /files`); shipping it here would be an orphan
provider (tripping `nestjs-best-practices`).

Further 3-way splits don't help — the OAuth callback handler + state
nonce + KMS encrypt + persistence + redirect path is irreducibly ~700
LOC when properly tested. Contacts module precedent (~790 LOC) confirms
this scale of security-critical PR is acceptable in this repo.

Authorization: Phase 5 corrected verdict in
`.claude/gdrive-feature/decisions.md` (see "Phase 5 — 2026-05-03 —
REVISE (CORRECTED — supersedes 15:07 block)").

## Test plan (from `pr-plan.md` WT-A entry)

- `gdrive.service.spec.ts` — unit:
  - refresh-token single-flight (concurrent `getAccessToken` calls
    collapse to one Google refresh request).
  - KMS envelope encrypt/decrypt round-trip via stubbed KMS client.
  - expired-token branch maps `invalid_grant` -> `TokenExpiredError`
    (`token-expired` code).
- `gdrive-kms.service.spec.ts` — unit:
  - AES-256-GCM round-trip with stubbed KMS data key.
  - Substring assertion: ciphertext output never contains the plaintext
    bytes (red-flag row 3 invariant).
- `gdrive.controller.spec.ts` — unit:
  - state-nonce mismatch rejected with 400.
  - consent URL contains `scope=...drive.file` AND negative regex
    rejecting broader `drive` / `drive.readonly`.
  - PKCE: URL contains `code_challenge_method=S256` and `access_type=offline`.
  - `oauth-declined` code surfaced when Google returns `error=access_denied`.
  - persisted account row's `refresh_token_ciphertext` does NOT contain
    plaintext.
  - `GET /accounts` view sanitized (no `refreshTokenCiphertext` /
    `refreshTokenKmsKeyArn` fields).
  - `DELETE /accounts/:id` soft-deletes (sets `deleted_at`, hides from
    `listForUser`).
  - feature-flag-off: every route throws `NotFoundException`.
  - `GET /files` returns 501 with `code: 'not-implemented'` (WT-A-2 stub
    contract — WT-A-2 will replace this assertion when wiring the proxy).

Local gates (run in this worktree):
- `pnpm -r typecheck` — OK
- `pnpm -r lint` — OK
- `pnpm --filter api test src/integrations/gdrive` — 3 suites / 17 tests
- `pnpm --filter api test` — 63 suites / 801 tests (full unit suite)

## Watchpoints honored

- KMS plaintext-token substring assertion test (ciphertext never
  contains the plaintext refresh token).
- OAuth scope hard-coded to `drive.file`; URL-encoded positive
  assertion AND negative regex rejecting broader scopes.
- Single-flight token refresh under concurrent load (Phase 4 watchpoint #3).
- Soft-delete + partial UNIQUE `WHERE deleted_at IS NULL` allows
  reconnect after disconnect while preserving forensic continuity.
- Per-tenant single CMK (Phase 4 watchpoint #5; per-user CMK NOT
  silently upgraded — manager-level scope change required).
- OAuth state store: in-process Map + 10-min TTL + single-use consume.
  Documented as v1; multi-instance migration would need Postgres-backed
  store (Phase 5 watchpoint #4).
- Backend-only PR: no `apps/web/**`, no `apps/api/src/sealing/**` touched.
- 7 `GDRIVE_*` env vars added to `env.schema.ts` AND documented in
  `CLAUDE.md` (red-flag row 4 cleared).
- Migration ships paired `_down.sql` (red-flag row 5 cleared;
  establishes convention for future migrations).

## nodejs-security skill verdict

Walked the staged diff against rules 1-18. No MUST-FIX items.

- Rule 16.4 (AEAD): AES-256-GCM only.
- Rule 16.6 (random): 96-bit random IV per encryption via
  `crypto.randomBytes(12)`; PKCE verifier + state nonce via
  `crypto.randomBytes`. No `Math.random` for security.
- Rule 16.1/16.2: no `eval`, no `vm`, no dynamic `require`.
- Rule 10.1/10.2: SQL via Kysely query builder, fully parameterized;
  no `$queryRawUnsafe`.
- Rule 4.1/4.3/4.5: identity from `@CurrentUser` (verified token), never
  from request body; per-user repo scoping on every read AND write
  (`findByIdForUser`, `softDelete(id, userId)`, `listForUser(userId)`).
- Rule 13.1/13.5: env vars zod-validated, no `|| 'fallback'` for
  secrets at boot; no secrets in logs.
- Rule 15.1: error scrubbing in `gdrive-kms.service.ts` (catch/re-throw
  with generic message — never echoes plaintext token).
- Rule 12.1 informational: outbound calls only to hardcoded
  `oauth2.googleapis.com` / `www.googleapis.com` / `googleapis.com`
  (no SSRF surface).

## Deferred

- **WT-A-2** — files-proxy + per-user rate-limiter + real `GET /files`
  implementation. Files held at
  `.claude/gdrive-feature/wt-a2-holding/` for pickup
  (`rate-limiter.ts`, `rate-limiter.spec.ts`).
  Branch from `main` AFTER this PR merges (no stacked PRs).
- **WT-A-3 (Phase 6 prod-prep window)** — e2e suite against LocalStack
  KMS for the gdrive OAuth round-trip, ~200 LOC. Reuses the harness
  PR #15 established for the sealing module.

## Refs

- `.claude/gdrive-feature/decisions.md` — Phase 5 corrected verdict
- `.claude/gdrive-feature/pr-plan.md` — WT-A scope + test plan
- `memory/project_kms_signer.md` — KMS envelope precedent (PR #12)