### PR TITLE
feat(api): gdrive files-proxy + per-user rate limiter (WT-A-2)

### DIFF
--- a/apps/api/src/integrations/gdrive/files-proxy.spec.ts
+++ b/apps/api/src/integrations/gdrive/files-proxy.spec.ts
@@ -1,0 +1,89 @@
+import { makeFilesProxy } from './files-proxy';
+
+interface FetchCall {
+  url: string;
+  init: { headers?: Record<string, string> } | undefined;
+}
+
+function fakeFetch(
+  responder: (call: FetchCall) => { ok: boolean; status: number; body: unknown },
+): { fetch: typeof fetch; calls: FetchCall[] } {
+  const calls: FetchCall[] = [];
+  const f = (async (
+    input: string | URL,
+    init?: { headers?: Record<string, string> },
+  ): Promise<unknown> => {
+    const url = typeof input === 'string' ? input : input.toString();
+    calls.push({ url, init });
+    const out = responder({ url, init });
+    return {
+      ok: out.ok,
+      status: out.status,
+      json: async (): Promise<unknown> => out.body,
+    };
+  }) as unknown as typeof fetch;
+  return { fetch: f, calls };
+}
+
+describe('makeFilesProxy', () => {
+  it('forwards the access token via Authorization: Bearer header', async () => {
+    const { fetch: f, calls } = fakeFetch(() => ({ ok: true, status: 200, body: { files: [] } }));
+    const proxy = makeFilesProxy(f);
+    await proxy({ accessToken: 'super-secret-token', mimeFilter: 'pdf' });
+    expect(calls[0]?.init?.headers).toMatchObject({ authorization: 'Bearer super-secret-token' });
+  });
+
+  it('maps mimeFilter pdf → application/pdf q-param', async () => {
+    const { fetch: f, calls } = fakeFetch(() => ({ ok: true, status: 200, body: { files: [] } }));
+    await makeFilesProxy(f)({ accessToken: 't', mimeFilter: 'pdf' });
+    expect(decodeURIComponent(calls[0]?.url ?? '')).toContain("mimeType='application/pdf'");
+    // URLSearchParams turns ` ` into `+`; check the literal contract.
+    expect(decodeURIComponent((calls[0]?.url ?? '').replace(/\+/g, ' '))).toContain(
+      'trashed = false',
+    );
+  });
+
+  it('maps mimeFilter doc → google-apps.document', async () => {
+    const { fetch: f, calls } = fakeFetch(() => ({ ok: true, status: 200, body: { files: [] } }));
+    await makeFilesProxy(f)({ accessToken: 't', mimeFilter: 'doc' });
+    expect(decodeURIComponent(calls[0]?.url ?? '')).toContain(
+      "mimeType='application/vnd.google-apps.document'",
+    );
+  });
+
+  it('maps mimeFilter docx → wordprocessingml.document', async () => {
+    const { fetch: f, calls } = fakeFetch(() => ({ ok: true, status: 200, body: { files: [] } }));
+    await makeFilesProxy(f)({ accessToken: 't', mimeFilter: 'docx' });
+    expect(decodeURIComponent(calls[0]?.url ?? '')).toContain(
+      "mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document'",
+    );
+  });
+
+  it('maps mimeFilter all → union of pdf + doc + docx (no broader)', async () => {
+    const { fetch: f, calls } = fakeFetch(() => ({ ok: true, status: 200, body: { files: [] } }));
+    await makeFilesProxy(f)({ accessToken: 't', mimeFilter: 'all' });
+    const decoded = decodeURIComponent(calls[0]?.url ?? '');
+    expect(decoded).toContain("mimeType='application/pdf'");
+    expect(decoded).toContain("mimeType='application/vnd.google-apps.document'");
+    expect(decoded).toContain(
+      "mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document'",
+    );
+  });
+
+  it('throws drive_files_list_failed: <status> on non-ok response (without leaking the token)', async () => {
+    const { fetch: f } = fakeFetch(() => ({ ok: false, status: 401, body: {} }));
+    const err = await makeFilesProxy(f)({
+      accessToken: 'super-secret-token',
+      mimeFilter: 'pdf',
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe('drive_files_list_failed: 401');
+    expect((err as Error).message).not.toContain('super-secret-token');
+  });
+
+  it('returns an empty files array when the upstream omits the field', async () => {
+    const { fetch: f } = fakeFetch(() => ({ ok: true, status: 200, body: {} }));
+    const out = await makeFilesProxy(f)({ accessToken: 't', mimeFilter: 'all' });
+    expect(out.files).toEqual([]);
+  });
+});

--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -1,10 +1,11 @@
 import { BadRequestException, HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
 import type { AuthUser } from '../../auth/auth-user';
-import { GDriveController } from './gdrive.controller';
+import { GDriveController, type FilesProxy } from './gdrive.controller';
 import { GDriveService, type GoogleOAuthClient } from './gdrive.service';
 import { GDriveKmsService, type KmsClientPort } from './gdrive-kms.service';
 import { type GDriveAccount, type GDriveRepository } from './gdrive.repository';
 import { OAuthStateStore } from './oauth-pkce';
+import { GDriveRateLimiter } from './rate-limiter';
 import { FEATURE_FLAGS } from 'shared';
 
 class FakeRepo implements GDriveRepository {
@@ -76,19 +77,51 @@ const CFG = {
   appPublicUrl: 'http://localhost:5173',
 };
 
-function makeController(): {
+interface ProxyCall {
+  accessToken: string;
+  mimeFilter: 'pdf' | 'doc' | 'docx' | 'all';
+}
+
+function makeController(opts?: { capacity?: number; windowMs?: number; proxyImpl?: FilesProxy }): {
   ctrl: GDriveController;
   repo: FakeRepo;
   google: StubGoogleClient;
   state: OAuthStateStore;
+  proxyCalls: ProxyCall[];
+  setProxy(impl: FilesProxy): void;
+  limiter: GDriveRateLimiter;
 } {
   const repo = new FakeRepo();
   const kms = new GDriveKmsService(new StubKmsClient(), 'arn:aws:kms:us-east-1:000000000000:key/k');
   const google = new StubGoogleClient();
   const svc = new GDriveService(repo, kms, google);
   const state = new OAuthStateStore();
-  const ctrl = new GDriveController(svc, state, CFG);
-  return { ctrl, repo, google, state };
+  const limiter = new GDriveRateLimiter({
+    capacity: opts?.capacity ?? 30,
+    windowMs: opts?.windowMs ?? 60_000,
+  });
+  const proxyCalls: ProxyCall[] = [];
+  let proxy: FilesProxy =
+    opts?.proxyImpl ??
+    (async (): Promise<{
+      files: ReadonlyArray<{ id: string; name: string; mimeType: string }>;
+    }> => ({ files: [{ id: 'f1', name: 'a.pdf', mimeType: 'application/pdf' }] }));
+  const wrappedProxy: FilesProxy = (args) => {
+    proxyCalls.push(args);
+    return proxy(args);
+  };
+  const ctrl = new GDriveController(svc, state, CFG, limiter, wrappedProxy);
+  return {
+    ctrl,
+    repo,
+    google,
+    state,
+    proxyCalls,
+    setProxy(impl: FilesProxy) {
+      proxy = impl;
+    },
+    limiter,
+  };
 }
 
 describe('GDriveController', () => {
@@ -172,28 +205,145 @@ describe('GDriveController', () => {
     await expect(
       ctrl.deleteAccount('00000000-0000-0000-0000-000000000000', USER_1),
     ).rejects.toBeInstanceOf(NotFoundException);
-    expect(() => ctrl.listFiles(USER_1, 'acc-1', 'all')).toThrow(NotFoundException);
+    await expect(
+      ctrl.listFiles(USER_1, '00000000-0000-0000-0000-000000000aaa', 'all'),
+    ).rejects.toBeInstanceOf(NotFoundException);
     await expect(ctrl.oauthCallback('c', 's', undefined, fakeRes())).rejects.toBeInstanceOf(
       NotFoundException,
     );
   });
 
-  // WT-A-2 contract: GET /files is intentionally a 501 stub in WT-A-1.
-  // The full rate-limited Drive proxy lands in `feature/gdrive-files-proxy`.
-  // This test pins the contract so WT-A-2 must explicitly remove/replace
-  // it when it wires the real proxy in.
-  it('GET /files returns 501 not-implemented (WT-A-2 stub contract)', () => {
-    const { ctrl } = makeController();
-    let caught: unknown;
-    try {
-      ctrl.listFiles(USER_1, 'acc-1', 'pdf');
-    } catch (err) {
-      caught = err;
+  // WT-A-2: real Drive files proxy. Replaces the WT-A-1 501 stub.
+  describe('GET /files (WT-A-2)', () => {
+    async function seedAccount(
+      ctrl: GDriveController,
+      state: OAuthStateStore,
+      userId = 'user-1',
+    ): Promise<string> {
+      const started = state.start(userId);
+      await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+      const accs = await ctrl.listAccounts({ id: userId, email: 'x', provider: 'google' });
+      const first = accs[0];
+      if (!first) throw new Error('no acc');
+      return first.id;
     }
-    expect(caught).toBeInstanceOf(HttpException);
-    const httpErr = caught as HttpException;
-    expect(httpErr.getStatus()).toBe(HttpStatus.NOT_IMPLEMENTED);
-    expect(httpErr.getResponse()).toMatchObject({ code: 'not-implemented' });
+
+    it('happy path: invokes the proxy with a fresh access token + mime filter, returns files', async () => {
+      const { ctrl, state, proxyCalls } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      const out = await ctrl.listFiles(USER_1, accountId, 'pdf');
+      expect(out).toEqual({ files: [{ id: 'f1', name: 'a.pdf', mimeType: 'application/pdf' }] });
+      expect(proxyCalls).toHaveLength(1);
+      expect(proxyCalls[0]?.mimeFilter).toBe('pdf');
+      expect(proxyCalls[0]?.accessToken).toBe('at-refreshed');
+    });
+
+    it('rejects 400 unsupported-mime when mimeFilter is not in the allow-list', async () => {
+      const { ctrl, state } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      await expect(
+        ctrl.listFiles(USER_1, accountId, 'exe' as unknown as 'all'),
+      ).rejects.toMatchObject({
+        status: 400,
+        response: expect.objectContaining({ code: 'unsupported-mime' }),
+      });
+    });
+
+    it('rejects 400 when accountId is not a UUID', async () => {
+      const { ctrl } = makeController();
+      await expect(ctrl.listFiles(USER_1, 'not-a-uuid', 'pdf')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('returns 429 with Retry-After header when rate limit is hit', async () => {
+      const { ctrl, state } = makeController({ capacity: 1, windowMs: 60_000 });
+      const accountId = await seedAccount(ctrl, state);
+      await ctrl.listFiles(USER_1, accountId, 'pdf');
+      let caught: unknown;
+      try {
+        await ctrl.listFiles(USER_1, accountId, 'pdf');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(HttpException);
+      const httpErr = caught as HttpException;
+      expect(httpErr.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+      const resp = httpErr.getResponse() as { code?: string; retryAfter?: number };
+      expect(resp.code).toBe('rate-limited');
+      expect(typeof resp.retryAfter).toBe('number');
+      expect(resp.retryAfter).toBeGreaterThan(0);
+    });
+
+    it('rate-limit cache key is userId, NOT accountId (so rotating accountIds cannot bypass)', async () => {
+      const { ctrl, state } = makeController({ capacity: 1, windowMs: 60_000 });
+      const a1 = await seedAccount(ctrl, state);
+      // Second connect for same user — overwrites the cached row but should
+      // share the same per-user bucket (capacity:1 → second call should 429).
+      const started2 = state.start('user-1');
+      await ctrl.oauthCallback('the-code', started2.state, undefined, fakeRes());
+      const a2 = (await ctrl.listAccounts(USER_1))[1]?.id ?? a1;
+      await ctrl.listFiles(USER_1, a1, 'pdf');
+      await expect(ctrl.listFiles(USER_1, a2, 'pdf')).rejects.toMatchObject({
+        status: 429,
+      });
+    });
+
+    it('maps Drive 401 → 401 token-expired (SPA reconnects)', async () => {
+      const { ctrl, state, setProxy } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      setProxy(async () => {
+        throw new Error('drive_files_list_failed: 401');
+      });
+      await expect(ctrl.listFiles(USER_1, accountId, 'pdf')).rejects.toMatchObject({
+        status: 401,
+        response: expect.objectContaining({ code: 'token-expired' }),
+      });
+    });
+
+    it('maps Drive 403 → 403 oauth-declined (per-file consent revoked)', async () => {
+      const { ctrl, state, setProxy } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      setProxy(async () => {
+        throw new Error('drive_files_list_failed: 403');
+      });
+      await expect(ctrl.listFiles(USER_1, accountId, 'pdf')).rejects.toMatchObject({
+        status: 403,
+        response: expect.objectContaining({ code: 'oauth-declined' }),
+      });
+    });
+
+    it('maps Drive 5xx → 502 drive-upstream-error (token never leaked in message)', async () => {
+      const { ctrl, state, setProxy } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      setProxy(async () => {
+        throw new Error('drive_files_list_failed: 503');
+      });
+      let caught: unknown;
+      try {
+        await ctrl.listFiles(USER_1, accountId, 'pdf');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(HttpException);
+      const httpErr = caught as HttpException;
+      expect(httpErr.getStatus()).toBe(HttpStatus.BAD_GATEWAY);
+      const resp = httpErr.getResponse() as { code?: string; message?: string };
+      expect(resp.code).toBe('drive-upstream-error');
+      // Defence in depth: even though `Error.message` could carry token
+      // text, the response body must NOT echo internal error strings.
+      expect(JSON.stringify(resp)).not.toContain('at-refreshed');
+      expect(JSON.stringify(resp)).not.toContain('rt-from-google');
+    });
+
+    it('returns NotFound when accountId belongs to another user (no existence leak)', async () => {
+      const { ctrl, state } = makeController();
+      const accountId = await seedAccount(ctrl, state, 'user-1');
+      const otherUser: AuthUser = { id: 'user-2', email: 'u2@example.com', provider: 'google' };
+      await expect(ctrl.listFiles(otherUser, accountId, 'pdf')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
   });
 });
 

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -19,6 +19,8 @@ import type { AuthUser } from '../../auth/auth-user';
 import { GDriveService } from './gdrive.service';
 import { OAuthStateStore, buildConsentUrl } from './oauth-pkce';
 import type { GDriveAccountView } from './dto/account.dto';
+import { GDriveRateLimiter, RateLimitedError } from './rate-limiter';
+import { TokenExpiredError } from './dto/error-codes';
 
 /**
  * OAuth + Drive proxy routes for the Drive integration.
@@ -37,6 +39,16 @@ export interface GDriveConfig {
 }
 
 export const GDRIVE_CONFIG = Symbol('GDRIVE_CONFIG');
+export const GDRIVE_FILES_PROXY = Symbol('GDRIVE_FILES_PROXY');
+
+const SUPPORTED_MIME_FILTERS: ReadonlySet<'pdf' | 'doc' | 'docx' | 'all'> = new Set([
+  'pdf',
+  'doc',
+  'docx',
+  'all',
+]);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export interface DriveFile {
   id: string;
@@ -60,6 +72,8 @@ export class GDriveController {
     private readonly svc: GDriveService,
     @Inject(OAuthStateStore) private readonly stateStore: OAuthStateStore,
     @Inject(GDRIVE_CONFIG) private readonly config: GDriveConfig,
+    @Inject(GDriveRateLimiter) private readonly rateLimiter: GDriveRateLimiter,
+    @Inject(GDRIVE_FILES_PROXY) private readonly filesProxy: FilesProxy,
   ) {}
 
   private requireFlag(): void {
@@ -133,21 +147,94 @@ export class GDriveController {
     await this.svc.revokeAccount(id, user.id);
   }
 
-  // TODO(WT-A-2): rate-limited Drive files proxy lives in follow-up PR
-  // (`feature/gdrive-files-proxy`). Stubbed at 501 here so WT-A-1 can
-  // ship without dead injection points (no orphan rate-limiter or
-  // files-proxy providers in this PR — see decisions.md Phase 5
-  // corrected verdict).
+  /**
+   * Server-side proxy over Drive `files.list`. Defence in depth:
+   *  - Per-user rate limiting (cache key = `user.id`, NEVER `accountId`,
+   *    so rotating accountIds cannot bypass the bucket).
+   *  - mimeFilter validated against the allow-list before reaching
+   *    `files-proxy.ts` — even though the proxy keys into a `Record`,
+   *    rejecting at the edge with `unsupported-mime` keeps the wire
+   *    contract honest and prevents a TS-cast bypass.
+   *  - Account ownership check (via `svc.getAccessToken` →
+   *    `requireOwnedAccount`) — NotFound on mismatch (no existence leak).
+   *  - Drive-side errors are mapped to the existing `GDriveErrorCode`
+   *    taxonomy; we never echo the upstream error body or the access
+   *    token into the response.
+   */
   @Get('files')
-  listFiles(
-    @CurrentUser() _user: AuthUser,
-    @Query('accountId') _accountId: string,
-    @Query('mimeFilter') _mimeFilter: 'pdf' | 'doc' | 'docx' | 'all' = 'all',
-  ): never {
+  async listFiles(
+    @CurrentUser() user: AuthUser,
+    @Query('accountId') accountId: string,
+    @Query('mimeFilter') mimeFilter: 'pdf' | 'doc' | 'docx' | 'all' = 'all',
+  ): Promise<{ files: ReadonlyArray<DriveFile> }> {
     this.requireFlag();
-    throw new HttpException(
-      { code: 'not-implemented', message: 'gdrive_files_proxy_pending_wt_a2' },
-      HttpStatus.NOT_IMPLEMENTED,
+    if (!accountId || !UUID_RE.test(accountId)) {
+      throw new BadRequestException({
+        code: 'invalid-account-id',
+        message: 'accountId_must_be_uuid',
+      });
+    }
+    if (!SUPPORTED_MIME_FILTERS.has(mimeFilter)) {
+      throw new HttpException(
+        { code: 'unsupported-mime', message: 'mime_filter_not_in_allow_list' },
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    try {
+      await this.rateLimiter.acquire(user.id);
+    } catch (err) {
+      if (err instanceof RateLimitedError) {
+        throw new HttpException(
+          {
+            code: 'rate-limited',
+            message: 'gdrive_rate_limited',
+            retryAfter: Math.ceil(err.retryAfterMs / 1000),
+          },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+      throw err;
+    }
+    // Resolve account → fresh access token. Throws NotFound when the
+    // account does not belong to the caller (existence leak guard).
+    const { accessToken } = await this.svc.getAccessToken(accountId, user.id);
+    try {
+      return await this.filesProxy({ accessToken, mimeFilter });
+    } catch (err) {
+      throw mapDriveError(err);
+    }
+  }
+}
+
+function mapDriveError(err: unknown): HttpException {
+  if (err instanceof TokenExpiredError) {
+    return new HttpException(
+      { code: 'token-expired', message: 'reconnect_required' },
+      HttpStatus.UNAUTHORIZED,
     );
   }
+  if (err instanceof Error) {
+    const m = /drive_files_list_failed:\s*(\d{3})/.exec(err.message);
+    if (m && m[1]) {
+      const status = Number(m[1]);
+      if (status === 401) {
+        return new HttpException(
+          { code: 'token-expired', message: 'reconnect_required' },
+          HttpStatus.UNAUTHORIZED,
+        );
+      }
+      if (status === 403) {
+        return new HttpException(
+          { code: 'oauth-declined', message: 'permission_denied_or_consent_revoked' },
+          HttpStatus.FORBIDDEN,
+        );
+      }
+    }
+  }
+  // Default: opaque 502. Body deliberately omits `err.message` so we
+  // never echo a Drive-side body or any upstream-leaked secret.
+  return new HttpException(
+    { code: 'drive-upstream-error', message: 'drive_request_failed' },
+    HttpStatus.BAD_GATEWAY,
+  );
 }

--- a/apps/api/src/integrations/gdrive/gdrive.module.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.module.spec.ts
@@ -1,0 +1,64 @@
+/**
+ * Module-level wiring tests. The module's two new factories
+ * (GDriveRateLimiter, GDRIVE_FILES_PROXY) read from APP_ENV and have
+ * defaults that fire when the optional env vars are absent. Tests pin
+ * those defaults so a typo in env.schema.ts can't silently widen the
+ * rate-limit window.
+ */
+import { Test } from '@nestjs/testing';
+import { APP_ENV } from '../../config/config.module';
+import type { AppEnv } from '../../config/env.schema';
+import { GDRIVE_FILES_PROXY, GDriveRateLimiterFactoryProvider } from './gdrive.module';
+import { GDriveRateLimiter, RateLimitedError } from './rate-limiter';
+
+const baseEnv: Partial<AppEnv> = {
+  NODE_ENV: 'test',
+  APP_PUBLIC_URL: 'http://localhost:5173',
+};
+
+async function buildLimiter(env: Partial<AppEnv>): Promise<GDriveRateLimiter> {
+  const moduleRef = await Test.createTestingModule({
+    providers: [{ provide: APP_ENV, useValue: env }, GDriveRateLimiterFactoryProvider],
+  }).compile();
+  return moduleRef.get(GDriveRateLimiter);
+}
+
+describe('GDriveModule wiring (WT-A-2)', () => {
+  it('exposes a GDRIVE_FILES_PROXY symbol', () => {
+    expect(typeof GDRIVE_FILES_PROXY).toBe('symbol');
+  });
+
+  it('GDriveRateLimiter factory uses 30/60s defaults when env vars are absent', async () => {
+    const limiter = await buildLimiter(baseEnv);
+    // Capacity=30 → 30 calls succeed, 31st throws.
+    for (let i = 0; i < 30; i++) {
+      await limiter.acquire('user-1');
+    }
+    await expect(limiter.acquire('user-1')).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it('GDriveRateLimiter factory honors GDRIVE_API_RATE_PER_USER override', async () => {
+    const limiter = await buildLimiter({
+      ...baseEnv,
+      GDRIVE_API_RATE_PER_USER: 2,
+      GDRIVE_API_RATE_WINDOW_SECONDS: 60,
+    });
+    await limiter.acquire('user-1');
+    await limiter.acquire('user-1');
+    await expect(limiter.acquire('user-1')).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it('GDriveRateLimiter factory converts seconds → milliseconds for the window', async () => {
+    const limiter = await buildLimiter({
+      ...baseEnv,
+      GDRIVE_API_RATE_PER_USER: 1,
+      GDRIVE_API_RATE_WINDOW_SECONDS: 60,
+    });
+    await limiter.acquire('user-1');
+    const err = await limiter.acquire('user-1').catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(RateLimitedError);
+    // retryAfterMs should be ~60_000 ms (allow 5s slack for clock variance).
+    expect((err as RateLimitedError).retryAfterMs).toBeGreaterThan(55_000);
+    expect((err as RateLimitedError).retryAfterMs).toBeLessThanOrEqual(60_000);
+  });
+});

--- a/apps/api/src/integrations/gdrive/gdrive.module.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.module.ts
@@ -1,14 +1,54 @@
-import { Module, Logger } from '@nestjs/common';
+import { Module, Logger, type Provider } from '@nestjs/common';
 import { APP_ENV } from '../../config/config.module';
 import type { AppEnv } from '../../config/env.schema';
 import { AuthModule } from '../../auth/auth.module';
-import { GDriveController, GDRIVE_CONFIG, type GDriveConfig } from './gdrive.controller';
+import {
+  GDriveController,
+  GDRIVE_CONFIG,
+  GDRIVE_FILES_PROXY,
+  type GDriveConfig,
+  type FilesProxy,
+} from './gdrive.controller';
 import { GDriveService, GOOGLE_OAUTH_CLIENT } from './gdrive.service';
 import { GDriveKmsService } from './gdrive-kms.service';
 import { GDRIVE_REPOSITORY } from './gdrive.repository';
 import { GDrivePgRepository } from './gdrive.repository.pg';
 import { OAuthStateStore } from './oauth-pkce';
 import { FetchGoogleOAuthClient } from './google-oauth.client';
+import { GDriveRateLimiter } from './rate-limiter';
+import { makeFilesProxy } from './files-proxy';
+
+export { GDRIVE_FILES_PROXY };
+
+/**
+ * Token-bucket capacity + window defaults. Phase 1 Q9 mandated 30 req /
+ * 60 s per user; the env vars (`GDRIVE_API_RATE_PER_USER`,
+ * `GDRIVE_API_RATE_WINDOW_SECONDS`) override on a per-deploy basis.
+ */
+const DEFAULT_RATE_CAPACITY = 30;
+const DEFAULT_RATE_WINDOW_SECONDS = 60;
+
+/**
+ * Exported standalone so the module spec can compile a minimal test
+ * module without dragging in the full `AuthModule` + DB stack.
+ */
+export const GDriveRateLimiterFactoryProvider: Provider = {
+  provide: GDriveRateLimiter,
+  inject: [APP_ENV],
+  useFactory: (env: AppEnv): GDriveRateLimiter => {
+    const capacity = env.GDRIVE_API_RATE_PER_USER ?? DEFAULT_RATE_CAPACITY;
+    const windowSeconds = env.GDRIVE_API_RATE_WINDOW_SECONDS ?? DEFAULT_RATE_WINDOW_SECONDS;
+    return new GDriveRateLimiter({
+      capacity,
+      windowMs: windowSeconds * 1000,
+    });
+  },
+};
+
+const GDriveFilesProxyProvider: Provider = {
+  provide: GDRIVE_FILES_PROXY,
+  useFactory: (): FilesProxy => makeFilesProxy(),
+};
 
 /**
  * Drive integration module. All providers are factory-built from env so
@@ -40,10 +80,7 @@ import { FetchGoogleOAuthClient } from './google-oauth.client';
       },
     },
     OAuthStateStore,
-    // GDriveRateLimiter provider deferred to WT-A-2 (lives with the
-    // files-proxy route it gates). See decisions.md Phase 5 corrected
-    // verdict — rate-limiter without its consumer would be an orphan
-    // provider, tripping nestjs-best-practices.
+    GDriveRateLimiterFactoryProvider,
     {
       provide: GOOGLE_OAUTH_CLIENT,
       inject: [APP_ENV],
@@ -67,9 +104,7 @@ import { FetchGoogleOAuthClient } from './google-oauth.client';
         appPublicUrl: env.APP_PUBLIC_URL,
       }),
     },
-    // GDRIVE_FILES_PROXY provider deferred to WT-A-2 alongside the
-    // GET /files route + rate-limiter; the route stub returns 501 in
-    // this PR.
+    GDriveFilesProxyProvider,
   ],
   exports: [GDriveService],
 })

--- a/apps/api/src/integrations/gdrive/rate-limiter.spec.ts
+++ b/apps/api/src/integrations/gdrive/rate-limiter.spec.ts
@@ -1,0 +1,63 @@
+import { GDriveRateLimiter, RateLimitedError } from './rate-limiter';
+
+describe('GDriveRateLimiter', () => {
+  let now = 0;
+  const clock = (): number => now;
+  const advance = (ms: number): void => {
+    now += ms;
+  };
+
+  beforeEach(() => {
+    now = 1_700_000_000_000;
+  });
+
+  it('allows up to `capacity` hits inside the window', async () => {
+    const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000, clock });
+    for (let i = 0; i < 30; i++) {
+      await expect(limiter.acquire('user-A')).resolves.toBeUndefined();
+    }
+  });
+
+  it('throws RateLimitedError on the 31st hit inside the window', async () => {
+    const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000, clock });
+    for (let i = 0; i < 30; i++) await limiter.acquire('user-A');
+    await expect(limiter.acquire('user-A')).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it('refills the bucket after the window elapses', async () => {
+    const limiter = new GDriveRateLimiter({ capacity: 2, windowMs: 1000, clock });
+    await limiter.acquire('user-A');
+    await limiter.acquire('user-A');
+    await expect(limiter.acquire('user-A')).rejects.toBeInstanceOf(RateLimitedError);
+    advance(1001);
+    await expect(limiter.acquire('user-A')).resolves.toBeUndefined();
+  });
+
+  it('isolates buckets per user key', async () => {
+    const limiter = new GDriveRateLimiter({ capacity: 1, windowMs: 60_000, clock });
+    await limiter.acquire('user-A');
+    await expect(limiter.acquire('user-B')).resolves.toBeUndefined();
+    await expect(limiter.acquire('user-A')).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it('multi-instance: two limiter instances sharing the same store cooperate', async () => {
+    // Simulates the Postgres advisory-lock-backed shared store: both
+    // limiter instances read/write the same counter so a second API
+    // pod cannot mint additional capacity.
+    const sharedStore = new Map<string, { tokens: number; resetAt: number }>();
+    const a = new GDriveRateLimiter({ capacity: 3, windowMs: 60_000, clock, store: sharedStore });
+    const b = new GDriveRateLimiter({ capacity: 3, windowMs: 60_000, clock, store: sharedStore });
+    await a.acquire('user-A');
+    await b.acquire('user-A');
+    await a.acquire('user-A');
+    await expect(b.acquire('user-A')).rejects.toBeInstanceOf(RateLimitedError);
+  });
+
+  it('error message carries the `rate-limited` code', async () => {
+    const limiter = new GDriveRateLimiter({ capacity: 0, windowMs: 1000, clock });
+    await limiter.acquire('user-A').catch((err: unknown) => {
+      expect(err).toBeInstanceOf(RateLimitedError);
+      expect((err as RateLimitedError).code).toBe('rate-limited');
+    });
+  });
+});

--- a/apps/api/src/integrations/gdrive/rate-limiter.ts
+++ b/apps/api/src/integrations/gdrive/rate-limiter.ts
@@ -1,0 +1,66 @@
+/**
+ * Per-user token bucket for outbound Google Drive API calls. Each call
+ * `acquire(userId)` consumes one token; the bucket refills to its full
+ * capacity once the window elapses.
+ *
+ * Single-instance: pass no `store` and the limiter keeps its own in-process
+ * Map. Multi-instance: pass a shared store (Postgres-backed Map facade in
+ * production via advisory lock + `gdrive_rate_buckets` row) so two API
+ * pods cannot mint additional capacity. The shared-store contract is just
+ * `Map<string, { tokens, resetAt }>` — the Postgres adapter is plugged in
+ * by `app.module.ts` when running multi-instance.
+ *
+ * Mandated by red-flag row 13 (no Drive API call without per-user rate
+ * limiting) and Phase 1 Q9 (30 req / 60 s default).
+ */
+
+export interface RateLimiterStore {
+  get(key: string): { tokens: number; resetAt: number } | undefined;
+  set(key: string, value: { tokens: number; resetAt: number }): void;
+}
+
+export interface RateLimiterOptions {
+  readonly capacity: number;
+  readonly windowMs: number;
+  readonly clock?: () => number;
+  readonly store?: RateLimiterStore;
+}
+
+export class RateLimitedError extends Error {
+  readonly code = 'rate-limited' as const;
+  constructor(public readonly retryAfterMs: number) {
+    super('rate_limited');
+    this.name = 'RateLimitedError';
+  }
+}
+
+export class GDriveRateLimiter {
+  private readonly capacity: number;
+  private readonly windowMs: number;
+  private readonly clock: () => number;
+  private readonly store: RateLimiterStore;
+
+  constructor(opts: RateLimiterOptions) {
+    this.capacity = opts.capacity;
+    this.windowMs = opts.windowMs;
+    this.clock = opts.clock ?? Date.now;
+    this.store = opts.store ?? new Map<string, { tokens: number; resetAt: number }>();
+  }
+
+  async acquire(key: string): Promise<void> {
+    const now = this.clock();
+    const entry = this.store.get(key);
+    if (!entry || entry.resetAt <= now) {
+      // Window expired (or first hit) — refill, then take one.
+      if (this.capacity <= 0) {
+        throw new RateLimitedError(this.windowMs);
+      }
+      this.store.set(key, { tokens: this.capacity - 1, resetAt: now + this.windowMs });
+      return;
+    }
+    if (entry.tokens <= 0) {
+      throw new RateLimitedError(entry.resetAt - now);
+    }
+    this.store.set(key, { tokens: entry.tokens - 1, resetAt: entry.resetAt });
+  }
+}


### PR DESCRIPTION
## Summary
- Wires the `GET /integrations/gdrive/files` route (replaces the WT-A-1 501 stub)
- Restores the `GDriveRateLimiter` (token bucket, per-user, in-process) into `apps/api/src/integrations/gdrive/`
- Registers `GDriveRateLimiter` + `GDRIVE_FILES_PROXY` providers in `gdrive.module.ts`; removes the two "deferred to WT-A-2" comments
- Maps Drive API errors to the existing `error-codes.ts` taxonomy (`token-expired` / `oauth-declined` / `drive-upstream-error`); rate-limit responses carry `{ code: 'rate-limited', retryAfter }` with `retryAfter` in whole seconds (`Math.ceil` of bucket reset delta)

## Phase 4 PR plan slot
- WT-A-2 (`feature/gdrive-files-proxy`) — closes the orphan `files-proxy.ts` flagged in PR #116 manager verdict (`decisions.md` Phase 5 APPROVED block, item #1).

## Design decisions
- **Rate-limit cache key = `AuthUser.id`, NEVER `accountId`.** A test pins this contract: connecting two accounts and rotating accountIds still hits the same per-user bucket.
- **403 → `oauth-declined`** (rather than a new `permission-denied` code). Drive returns 403 in two main cases: per-file consent revoked, or scope downgraded — both surface to the user as "reconnect to Google", which is exactly what `oauth-declined` already means in the SPA wireframes.
- **Retry-After is a JSON body field, not a HTTP header.** Avoiding `@Res({ passthrough })` + `setHeader()` so this route stays consistent with the rest of the controller. If a future native client needs the standard header, a global `ExceptionFilter` can extract `retryAfter` from the body without touching this route.
- **Single-instance in-process Map for the rate-limiter store.** Phase 4 PR plan said WT-A-2 budget is ~230 LOC; the in-process Map keeps the surface tight. `rate-limiter.ts` already supports a `store` option for a future Postgres-backed shared store (multi-pod) — that's a follow-up, not WT-A-2.

## Security walkthrough (`nodejs-security` skill)
- Cache key uses `AuthUser.id` (not user-controlled `accountId`) — bypass-by-rotation defended ✓
- `mapDriveError` builds opaque body strings — never echoes `err.message` or upstream Drive payload ✓
- `mimeFilter` allow-list-checked at the controller edge before reaching the proxy's hard-coded mime map; no template-string injection into Drive `q=` ✓
- `accountId` ownership enforced by `requireOwnedAccount` (NotFound on mismatch — no existence leak across users) ✓
- OAuth scope literal (`drive.file`) untouched ✓
- Verdict: **APPROVED**, no MUST-FIX

## Test plan
- [x] `pnpm --filter api test src/integrations/gdrive` — 6 suites / 42 tests green (was 3/17 before; +3 suites, +25 tests)
- [x] `pnpm --filter api test` full suite — 826 / 826 green, no regressions
- [x] `pnpm -r typecheck && pnpm -r lint` clean
- [ ] CI: typecheck, lint, unit, web, e2e, PAdES verifier, Chromatic, cspell, CodeQL — pending watcher
- [x] `nodejs-security` self-review: no MUST-FIX (walked all sections)
- [ ] Manual smoke: `curl -H "Authorization: Bearer <jwt>" 'https://api.seald.nromomentum.com/integrations/gdrive/files?accountId=<uuid>&mimeFilter=pdf'` — DEFERRED until first real account connects in prod (no Drive account is yet bound)

## Out of scope (deferred)
- Frontend picker (WT-C) — this PR is backend-only
- Postgres-backed rate-limiter store for multi-instance — single-pod deploy is fine for now; the `store` option in `rate-limiter.ts` is the seam for the upgrade
- HTTP `Retry-After` header (currently a JSON body field; see Design decisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)