### PR TITLE
ci: aggregator jobs to unblock path-filtered backend-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,3 +447,27 @@ jobs:
 
       - name: Verify PAdES conformance
         run: pnpm --filter api exec ts-node scripts/verify-pades.ts ../../pdfs
+
+  # Aggregator job: succeeds if every upstream job is success or skipped.
+  # Branch protection points at this single job (instead of 9 individual
+  # jobs) so backend-only PRs whose web/playwright jobs are SKIPPED via
+  # paths-ignore can still satisfy the required-status-checks gate.
+  ci-success:
+    name: CI Success
+    runs-on: ubuntu-latest
+    needs: [install, lint, audit, unit, web, storybook, playwright-web, e2e, pades-verify]
+    if: always()
+    steps:
+      - name: Verify all required jobs passed (or were skipped)
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "Upstream results: $results"
+          if [[ "$results" == *failure* ]]; then
+            echo "::error::One or more upstream jobs failed"
+            exit 1
+          fi
+          if [[ "$results" == *cancelled* ]]; then
+            echo "::error::One or more upstream jobs were cancelled"
+            exit 1
+          fi
+          echo "All upstream jobs succeeded or were skipped — gate passes."

--- a/.github/workflows/lint-meta.yml
+++ b/.github/workflows/lint-meta.yml
@@ -146,3 +146,28 @@ jobs:
 
       - name: Run cspell
         run: pnpm lint:spelling
+
+  # Aggregator job: succeeds if every upstream lint job is success or
+  # skipped. Branch protection points at this single job so a PR that
+  # touches no .feature files (gherkin SKIPPED) or no workflow YAML
+  # (actionlint SKIPPED) can still satisfy the required-status-checks
+  # gate.
+  lint-meta-success:
+    name: Lint Meta Success
+    runs-on: ubuntu-latest
+    needs: [lint-workflows, lint-gherkin, lint-spelling]
+    if: always()
+    steps:
+      - name: Verify all required lint jobs passed (or were skipped)
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "Upstream results: $results"
+          if [[ "$results" == *failure* ]]; then
+            echo "::error::One or more upstream lint jobs failed"
+            exit 1
+          fi
+          if [[ "$results" == *cancelled* ]]; then
+            echo "::error::One or more upstream lint jobs were cancelled"
+            exit 1
+          fi
+          echo "All upstream lint jobs succeeded or were skipped — gate passes."

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -7,17 +7,20 @@ name: Playwright
 # regressions (CSS-in-JS hydration, react-router lazy boundaries, etc.).
 
 on:
+  # Always trigger on PRs + pushes to main (no workflow-level paths
+  # filter). Each individual job is guarded by a job-level `if` based
+  # on the `changes` filter below — this lets backend-only PRs report
+  # SKIPPED checks (which the `Playwright Success` aggregator passes
+  # as success-or-skip) instead of producing no checks at all.
   pull_request:
     branches: [main]
-    # Browser e2e exercises the SPA. Scope PR runs to web/shared
-    # changes; main pushes keep the broader paths-ignore so every
-    # merged HEAD is exercised in a real browser.
-    paths:
-      - 'apps/web/**'
-      - 'packages/shared/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.github/workflows/playwright.yml'
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'Design-Guide/**'
+      - 'LICENSE'
+      - '.gitignore'
+      - '.editorconfig'
   push:
     branches: [main]
     paths-ignore:
@@ -42,9 +45,33 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
 
 jobs:
+  # Path filter — both browser-e2e jobs only need to run when the SPA
+  # or shared package changes. Pushes to main bypass the filter so
+  # every merged HEAD is exercised in a real browser.
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/shared/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/playwright.yml'
+
   e2e-web:
     name: Web e2e (Playwright + Chromium)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.web == 'true'
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -87,6 +114,8 @@ jobs:
   bdd-e2e:
     name: BDD e2e (web)
     runs-on: ubuntu-latest
+    needs: changes
+    if: github.event_name == 'push' || needs.changes.outputs.web == 'true'
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
@@ -131,3 +160,27 @@ jobs:
           path: apps/web/playwright-report/
           if-no-files-found: ignore
           retention-days: 14
+
+  # Aggregator job: succeeds if every upstream playwright job is success
+  # or skipped. Branch protection points at this single job so backend-
+  # only PRs (where e2e-web + bdd-e2e are SKIPPED via the changes filter)
+  # can still satisfy the required-status-checks gate.
+  playwright-success:
+    name: Playwright Success
+    runs-on: ubuntu-latest
+    needs: [e2e-web, bdd-e2e]
+    if: always()
+    steps:
+      - name: Verify all required playwright jobs passed (or were skipped)
+        run: |
+          results='${{ join(needs.*.result, ',') }}'
+          echo "Upstream results: $results"
+          if [[ "$results" == *failure* ]]; then
+            echo "::error::One or more upstream playwright jobs failed"
+            exit 1
+          fi
+          if [[ "$results" == *cancelled* ]]; then
+            echo "::error::One or more upstream playwright jobs were cancelled"
+            exit 1
+          fi
+          echo "All upstream playwright jobs succeeded or were skipped — gate passes."


### PR DESCRIPTION
## Summary

- Add `CI Success` and `Lint Meta Success` aggregator jobs that pass when every upstream job is `success` or `skipped`.
- Lets backend-only PRs (whose web/storybook/playwright/gherkin jobs are SKIPPED via `paths-ignore`) satisfy branch protection without each conditional check needing to run.
- After this lands, branch protection will be repointed at the two aggregators (plus the always-running `Analyze (actions)` + `Analyze (javascript-typescript)`), shrinking the required-check list from 14 → 4.

## Why

PR #117 (WT-A-2, backend-only) was blocked by the current `Web unit tests` / `Storybook build` / `Playwright web` / `actionlint` / `gherkin-lint` required checks all reporting `skipped`. GitHub treats `skipped` ≠ `success` for required-status-checks, so a clean backend PR couldn't merge.

Aggregator jobs solve this by collapsing the gate into a single `success`-or-`failure` signal that respects the path filter semantics.

## Test plan

- [x] `actionlint` clean on both updated workflows
- [ ] CI green on this PR (sanity — both aggregators should report `success`)
- [ ] After merge, update branch protection required checks → `[CI Success, Lint Meta Success, Analyze (actions), Analyze (javascript-typescript)]`
- [ ] Re-attempt `gh pr merge 117 --squash --delete-branch` and confirm it succeeds without `--admin`

## Notes

This PR itself will hit the same trap (workflow-only change → most jobs SKIP → required checks unsatisfied), so it requires a one-time `--admin` merge. After that, every subsequent PR uses the aggregators normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)