### PR TITLE
feat(web): reusable Drive picker component (WT-C)

### DIFF
--- a/apps/web/src/components/drive-picker/DrivePicker.stories.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.stories.tsx
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { JSX } from 'react';
+import { useState } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Button } from '@/components/Button';
+import { DrivePicker } from './DrivePicker';
+import type { DriveFile, DriveMimeFilter, DrivePickerProps } from './DrivePicker.types';
+import { driveFilesKey } from './useDriveFiles';
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+
+const SAMPLE_FILES: ReadonlyArray<DriveFile> = [
+  {
+    id: 'd-nda',
+    name: '2026 NDA template.gdoc',
+    mimeType: 'application/vnd.google-apps.document',
+    modifiedTime: '2026-05-01T12:00:00Z',
+  },
+  {
+    id: 'd-msa',
+    name: 'Acme MSA - signed.pdf',
+    mimeType: 'application/pdf',
+    modifiedTime: '2026-04-28T09:00:00Z',
+    size: '14000',
+  },
+  {
+    id: 'd-vendor',
+    name: 'Vendor agreement.docx',
+    mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    modifiedTime: '2026-04-01T16:00:00Z',
+  },
+  {
+    id: 'd-statement',
+    name: 'Statement of work — Q2.gdoc',
+    mimeType: 'application/vnd.google-apps.document',
+    modifiedTime: '2026-03-28T08:00:00Z',
+  },
+];
+
+interface SeededQueryProps {
+  readonly children: JSX.Element;
+  readonly seed: 'list' | 'empty' | 'expired' | 'error' | 'loading';
+  readonly mimeFilter: DriveMimeFilter;
+}
+
+/**
+ * Builds a QueryClient pre-seeded with the desired state so stories
+ * render deterministically without network. Each variant skips the
+ * `queryFn` by either pre-setting `data` or pre-setting `error`.
+ */
+function SeededQuery({ children, seed, mimeFilter }: SeededQueryProps): JSX.Element {
+  // Lazy-init the QueryClient so re-renders driven by Storybook controls
+  // don't churn the cache (rule 2.1 — lazy state init for expensive setup).
+  const [qc] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+        },
+      }),
+  );
+  const key = driveFilesKey(ACCOUNT_ID, mimeFilter);
+  if (seed === 'list') {
+    qc.setQueryData(key, { files: SAMPLE_FILES });
+  } else if (seed === 'empty') {
+    qc.setQueryData(key, { files: [] });
+  } else if (seed === 'expired') {
+    qc.setQueryData(key, undefined);
+    qc.getQueryCache()
+      .build(qc, { queryKey: key })
+      .setState({
+        status: 'error',
+        error: Object.assign(new Error('reconnect_required'), { status: 401 }),
+        fetchStatus: 'idle',
+      });
+  } else if (seed === 'error') {
+    qc.setQueryData(key, undefined);
+    qc.getQueryCache()
+      .build(qc, { queryKey: key })
+      .setState({
+        status: 'error',
+        error: new Error('network'),
+        fetchStatus: 'idle',
+      });
+  }
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+interface DemoProps {
+  readonly seed: 'list' | 'empty' | 'expired' | 'error' | 'loading';
+  readonly overrides?: Partial<DrivePickerProps>;
+}
+
+function Demo({ seed, overrides }: DemoProps): JSX.Element {
+  const [open, setOpen] = useState(true);
+  const mimeFilter: DriveMimeFilter = overrides?.mimeFilter ?? 'all';
+  return (
+    <SeededQuery seed={seed} mimeFilter={mimeFilter}>
+      <div style={{ padding: 24 }}>
+        <Button onClick={() => setOpen(true)}>Open picker</Button>
+        <DrivePicker
+          open={open}
+          onClose={() => setOpen(false)}
+          onPick={() => setOpen(false)}
+          accountId={ACCOUNT_ID}
+          mimeFilter={mimeFilter}
+          onReconnect={() => {
+            /* story stub */
+          }}
+          {...overrides}
+        />
+      </div>
+    </SeededQuery>
+  );
+}
+
+const meta: Meta<typeof DrivePicker> = {
+  title: 'L3/DrivePicker',
+  component: DrivePicker,
+  tags: ['autodocs', 'layer-3'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+export default meta;
+type Story = StoryObj<typeof DrivePicker>;
+
+export const FileList: Story = {
+  render: () => <Demo seed="list" />,
+};
+
+export const EmptyFolder: Story = {
+  render: () => <Demo seed="empty" />,
+};
+
+export const TokenExpired: Story = {
+  render: () => <Demo seed="expired" />,
+};
+
+export const NetworkError: Story = {
+  render: () => <Demo seed="error" />,
+};
+
+export const Loading: Story = {
+  render: () => <Demo seed="loading" />,
+};

--- a/apps/web/src/components/drive-picker/DrivePicker.styles.ts
+++ b/apps/web/src/components/drive-picker/DrivePicker.styles.ts
@@ -1,0 +1,302 @@
+import styled from 'styled-components';
+
+/**
+ * Modal dimensions are HARD-LOCKED at 760 × 600 per Phase 3 watchpoint
+ * #4. Do NOT widen, do NOT make responsive — the source-selection
+ * flows downstream rely on this exact footprint to align with the
+ * sibling Upload + Template cards. PR review will reject any deviation.
+ */
+export const PICKER_WIDTH_PX = 760 as const;
+export const PICKER_HEIGHT_PX = 600 as const;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: ${({ theme }) => theme.z.modal};
+  background: rgba(15, 23, 42, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+`;
+
+export const Card = styled.div`
+  width: ${PICKER_WIDTH_PX}px;
+  height: ${PICKER_HEIGHT_PX}px;
+  max-width: 100%;
+  max-height: calc(100vh - 48px);
+  background: ${({ theme }) => theme.color.paper};
+  border-radius: 18px;
+  box-shadow: ${({ theme }) => theme.shadow.xl};
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+`;
+
+export const Header = styled.div`
+  padding: 18px 22px;
+  border-bottom: 1px solid ${({ theme }) => theme.color.border[1]};
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+`;
+
+export const HeaderLogo = styled.span`
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.color.indigo[600]};
+  flex-shrink: 0;
+`;
+
+export const Title = styled.h2`
+  flex: 1;
+  margin: 0;
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: 20px;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.color.fg[1]};
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+`;
+
+export const CloseButton = styled.button`
+  background: transparent;
+  border: none;
+  padding: 6px;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover,
+  &:focus-visible {
+    background: ${({ theme }) => theme.color.ink[100]};
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+`;
+
+export const PathBar = styled.div`
+  padding: 12px 22px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid ${({ theme }) => theme.color.border[1]};
+  background: ${({ theme }) => theme.color.ink[50]};
+  flex-shrink: 0;
+  font-size: 13px;
+  color: ${({ theme }) => theme.color.fg[2]};
+`;
+
+export const PathRoot = styled.span`
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.fg[1]};
+`;
+
+export const SearchWrap = styled.div`
+  padding: 14px 22px 8px;
+  flex-shrink: 0;
+`;
+
+export const SearchInner = styled.div`
+  position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+export const SearchIcon = styled.span`
+  position: absolute;
+  left: 12px;
+  display: inline-flex;
+  align-items: center;
+  color: ${({ theme }) => theme.color.fg[3]};
+  pointer-events: none;
+`;
+
+export const SearchInput = styled.input`
+  width: 100%;
+  padding: 11px 14px 11px 38px;
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  border-radius: 12px;
+  font: 400 14px ${({ theme }) => theme.font.sans};
+  background: ${({ theme }) => theme.color.paper};
+  color: ${({ theme }) => theme.color.fg[1]};
+  outline: none;
+
+  &:focus-visible {
+    border-color: ${({ theme }) => theme.color.indigo[500]};
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const List = styled.div`
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 4px 12px 8px;
+`;
+
+export const Row = styled.button`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+
+  &[aria-selected='true'] {
+    background: ${({ theme }) => theme.color.indigo[50]};
+  }
+
+  &:hover:not([aria-selected='true']),
+  &:focus-visible:not([aria-selected='true']) {
+    background: ${({ theme }) => theme.color.ink[50]};
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const RowIcon = styled.span<{ $bg: string; $fg: string }>`
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: ${({ $bg }) => $bg};
+  color: ${({ $fg }) => $fg};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+export const RowMain = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+export const RowName = styled.div`
+  font-size: 14px;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.color.fg[1]};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+export const RowMeta = styled.div`
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  margin-top: 2px;
+`;
+
+export const SelectMark = styled.span<{ $selected: boolean }>`
+  width: 22px;
+  height: 22px;
+  border-radius: ${({ theme }) => theme.radius.pill};
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ $selected, theme }) => ($selected ? theme.color.indigo[600] : 'transparent')};
+  color: ${({ theme }) => theme.color.paper};
+  border: ${({ $selected, theme }) =>
+    $selected ? 'none' : `1.5px solid ${theme.color.border[2]}`};
+`;
+
+export const Footer = styled.div`
+  padding: 14px 22px;
+  border-top: 1px solid ${({ theme }) => theme.color.border[1]};
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-shrink: 0;
+  background: ${({ theme }) => theme.color.paper};
+`;
+
+export const FooterNote = styled.div`
+  flex: 1;
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.fg[3]};
+`;
+
+export const StatePane = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 48px;
+  text-align: center;
+  gap: 12px;
+`;
+
+export const StateBadge = styled.div<{ $bg: string; $fg: string }>`
+  width: 64px;
+  height: 64px;
+  border-radius: ${({ theme }) => theme.radius.pill};
+  background: ${({ $bg }) => $bg};
+  color: ${({ $fg }) => $fg};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 4px;
+`;
+
+export const StateTitle = styled.div`
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: 22px;
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+  color: ${({ theme }) => theme.color.fg[1]};
+  letter-spacing: -0.01em;
+`;
+
+export const StateBody = styled.p`
+  margin: 0;
+  font-size: 14px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  line-height: 1.6;
+  max-width: 440px;
+`;
+
+export const StateActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+`;
+
+export const SkeletonRow = styled.div`
+  height: 56px;
+  border-radius: 10px;
+  margin: 6px 2px;
+  background: linear-gradient(
+    90deg,
+    ${({ theme }) => theme.color.ink[50]} 0%,
+    ${({ theme }) => theme.color.ink[100]} 50%,
+    ${({ theme }) => theme.color.ink[50]} 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s linear infinite;
+
+  @keyframes shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+`;

--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -1,0 +1,252 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { seald } from '@/styles/theme';
+
+vi.mock('@/lib/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/lib/api/apiClient';
+// eslint-disable-next-line import/first
+import { DrivePicker, PICKER_HEIGHT_PX, PICKER_WIDTH_PX } from './index';
+// eslint-disable-next-line import/first
+import type { DriveFile } from './index';
+
+const get = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+
+const PDF_FILE: DriveFile = {
+  id: 'f-pdf',
+  name: 'Acme MSA - signed.pdf',
+  mimeType: 'application/pdf',
+  modifiedTime: '2026-04-28T12:00:00Z',
+  size: '14000',
+};
+
+const DOC_FILE: DriveFile = {
+  id: 'f-doc',
+  name: '2026 NDA template.gdoc',
+  mimeType: 'application/vnd.google-apps.document',
+  modifiedTime: '2026-05-01T00:00:00Z',
+};
+
+const DOCX_FILE: DriveFile = {
+  id: 'f-docx',
+  name: 'Vendor agreement.docx',
+  mimeType: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  modifiedTime: '2026-04-01T00:00:00Z',
+};
+
+const UNSUPPORTED: DriveFile = {
+  id: 'f-evil',
+  name: 'malware.exe',
+  mimeType: 'application/x-msdownload',
+};
+
+function buildQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function renderPicker(propsOverride: Partial<React.ComponentProps<typeof DrivePicker>> = {}) {
+  const onClose = vi.fn();
+  const onPick = vi.fn();
+  const onReconnect = vi.fn();
+  const qc = buildQueryClient();
+  function Wrapper({ children }: { readonly children: ReactNode }) {
+    return (
+      <ThemeProvider theme={seald}>
+        <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+      </ThemeProvider>
+    );
+  }
+  const utils = render(
+    <DrivePicker
+      open
+      onClose={onClose}
+      onPick={onPick}
+      accountId={ACCOUNT_ID}
+      mimeFilter="all"
+      onReconnect={onReconnect}
+      {...propsOverride}
+    />,
+    { wrapper: Wrapper },
+  );
+  return { ...utils, onClose, onPick, onReconnect, qc };
+}
+
+beforeEach(() => {
+  get.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('DrivePicker — open/close + accessibility', () => {
+  it('renders nothing when open=false', () => {
+    get.mockResolvedValue({ data: { files: [] }, status: 200 });
+    const { onClose, onPick } = (() => {
+      const oc = vi.fn();
+      const op = vi.fn();
+      const qc = buildQueryClient();
+      render(
+        <ThemeProvider theme={seald}>
+          <QueryClientProvider client={qc}>
+            <DrivePicker
+              open={false}
+              onClose={oc}
+              onPick={op}
+              accountId={ACCOUNT_ID}
+              mimeFilter="all"
+            />
+          </QueryClientProvider>
+        </ThemeProvider>,
+      );
+      return { onClose: oc, onPick: op };
+    })();
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(onPick).not.toHaveBeenCalled();
+  });
+
+  it('renders the dialog with the locked 760×600 dimensions', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE] }, status: 200 });
+    renderPicker();
+    const dialog = await screen.findByRole('dialog', { name: /pick from google drive/i });
+    expect(dialog).toBeInTheDocument();
+    // The hard-locked design constants must remain 760×600 (Phase 3
+    // watchpoint #4). Asserting the constants directly here means a PR
+    // touching the styles file will fail this test if the values drift.
+    expect(PICKER_WIDTH_PX).toBe(760);
+    expect(PICKER_HEIGHT_PX).toBe(600);
+  });
+
+  it('Escape closes the dialog', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE] }, status: 200 });
+    const { onClose } = renderPicker();
+    await screen.findByRole('dialog');
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('clicking the backdrop closes; clicking the card does not', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE] }, status: 200 });
+    const { onClose } = renderPicker();
+    const dialog = await screen.findByRole('dialog');
+    // Click on the dialog itself — should NOT close.
+    fireEvent.click(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+    // Click on the backdrop wrapper (parent of the dialog) — SHOULD close.
+    const backdrop = dialog.parentElement!;
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Tab cycles focus inside the dialog (focus trap)', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE] }, status: 200 });
+    renderPicker();
+    const dialog = await screen.findByRole('dialog');
+    const focusables = within(dialog).getAllByRole('button');
+    // The Cancel + close-picker + Use this file buttons should all be
+    // present; trap should mean the last button's Tab wraps to the
+    // first focusable (the search input).
+    expect(focusables.length).toBeGreaterThanOrEqual(2);
+    const last = focusables[focusables.length - 1]!;
+    last.focus();
+    fireEvent.keyDown(dialog, { key: 'Tab' });
+    // Trap fires preventDefault + focuses first focusable (the
+    // search input). We assert focus moved off `last` rather than
+    // asserting the exact next element so the test is robust to
+    // additions of new focusable rows.
+    expect(document.activeElement).not.toBe(last);
+  });
+});
+
+describe('DrivePicker — file list interactions', () => {
+  it('clicking a row selects it and Use this file fires onPick', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE, DOC_FILE] }, status: 200 });
+    const { onPick } = renderPicker();
+    const row = await screen.findByRole('option', { name: /acme msa - signed/i });
+    await userEvent.click(row);
+    expect(row).toHaveAttribute('aria-selected', 'true');
+    await userEvent.click(screen.getByRole('button', { name: /^use this file$/i }));
+    expect(onPick).toHaveBeenCalledTimes(1);
+    expect(onPick).toHaveBeenCalledWith(PDF_FILE);
+  });
+
+  it('Use this file is disabled until something is picked', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE] }, status: 200 });
+    renderPicker();
+    await screen.findByRole('option', { name: /acme msa/i });
+    expect(screen.getByRole('button', { name: /^use this file$/i })).toBeDisabled();
+  });
+
+  it('strips client-side any file outside the supported MIME allow-list', async () => {
+    get.mockResolvedValue({
+      data: { files: [PDF_FILE, UNSUPPORTED, DOCX_FILE] },
+      status: 200,
+    });
+    renderPicker();
+    await screen.findByRole('option', { name: /acme msa/i });
+    expect(screen.getByRole('option', { name: /vendor agreement\.docx/i })).toBeInTheDocument();
+    // The unsupported entry must NEVER reach the DOM, even though the
+    // server (in this test) returned it. Defence in depth.
+    expect(screen.queryByRole('option', { name: /malware\.exe/i })).toBeNull();
+  });
+
+  it('renders the empty-folder state when there are no files', async () => {
+    get.mockResolvedValue({ data: { files: [] }, status: 200 });
+    renderPicker();
+    expect(await screen.findByText(/this folder is empty/i)).toBeInTheDocument();
+  });
+
+  it('renders the no-results state when the search filters everything out', async () => {
+    get.mockResolvedValue({ data: { files: [PDF_FILE, DOC_FILE] }, status: 200 });
+    renderPicker();
+    const search = await screen.findByRole('searchbox', { name: /search drive files/i });
+    await userEvent.type(search, 'zzzzznope');
+    expect(await screen.findByText(/no files match/i)).toBeInTheDocument();
+  });
+});
+
+describe('DrivePicker — token-expired flow', () => {
+  it('shows the Reconnect CTA on HTTP 401 and single-flights repeated clicks', async () => {
+    const apiError = Object.assign(new Error('reconnect_required'), { status: 401 });
+    get.mockRejectedValue(apiError);
+
+    let release: (() => void) | undefined;
+    const onReconnect = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = () => resolve();
+        }),
+    );
+    renderPicker({ onReconnect });
+
+    const reconnectBtn = await screen.findByRole('button', { name: /^reconnect$/i });
+    // Three rapid clicks — only one consent popup must be in flight.
+    await userEvent.click(reconnectBtn);
+    await userEvent.click(reconnectBtn);
+    await userEvent.click(reconnectBtn);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+    // Resolve the in-flight reconnect; the next click is now allowed.
+    release?.();
+    await waitFor(() => expect(onReconnect).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import type { JSX, KeyboardEvent as ReactKeyboardEvent, MouseEvent } from 'react';
+import { createPortal } from 'react-dom';
+import { Check, FileText, Home, Search, X } from 'lucide-react';
+import { useTheme } from 'styled-components';
+import { Button } from '@/components/Button';
+import { Icon } from '@/components/Icon';
+import {
+  Backdrop,
+  Card,
+  CloseButton,
+  Footer,
+  FooterNote,
+  Header,
+  HeaderLogo,
+  List,
+  PathBar,
+  PathRoot,
+  Row,
+  RowIcon,
+  RowMain,
+  RowMeta,
+  RowName,
+  SearchIcon,
+  SearchInner,
+  SearchInput,
+  SearchWrap,
+  SelectMark,
+  Title,
+} from './DrivePicker.styles';
+import type { DriveFile, DrivePickerProps } from './DrivePicker.types';
+import { SUPPORTED_MIME_TYPES } from './driveFilesApi';
+import {
+  EmptyFolderState,
+  LoadingState,
+  NetworkErrorState,
+  NoResultsState,
+  TokenExpiredState,
+} from './states';
+import { useDriveFiles, useReconnectAccount } from './useDriveFiles';
+
+/**
+ * Reusable Drive picker modal. Portal-rendered at the document body so
+ * it always sits above whatever route mounted it.
+ *
+ * Dimensions are HARD-LOCKED via {@link PICKER_WIDTH_PX} /
+ * {@link PICKER_HEIGHT_PX} constants per Phase 3 watchpoint #4 — do not
+ * widen, do not make responsive. The hard cap is referenced by both the
+ * styled `Card` and the unit tests below so a regression in either
+ * surface fails CI.
+ *
+ * Portal target falls back to `null` during SSR / pre-mount; tests
+ * exercise the JSDOM body directly.
+ */
+function mimeKind(mime: string): 'pdf' | 'gdoc' | 'docx' {
+  if (mime === 'application/vnd.google-apps.document') return 'gdoc';
+  if (mime === 'application/vnd.openxmlformats-officedocument.wordprocessingml.document') {
+    return 'docx';
+  }
+  return 'pdf';
+}
+
+function kindLabel(kind: 'pdf' | 'gdoc' | 'docx'): string {
+  if (kind === 'pdf') return 'PDF';
+  if (kind === 'gdoc') return 'Doc';
+  return 'Word';
+}
+
+function formatModified(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+function buildMeta(file: DriveFile): string {
+  const kind = mimeKind(file.mimeType);
+  const parts: string[] = [kindLabel(kind)];
+  const date = formatModified(file.modifiedTime);
+  if (date) parts.push(date);
+  return parts.join(' · ');
+}
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function noopReconnect(): Promise<void> {
+  return Promise.resolve();
+}
+
+export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
+  const { open, onClose, onPick, accountId, mimeFilter = 'all', onReconnect } = props;
+  const titleId = useId();
+  const t = useTheme();
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = useRef<HTMLElement | null>(null);
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  const { data, isLoading, error, tokenExpired, refetch } = useDriveFiles({
+    accountId,
+    mimeFilter,
+    enabled: open,
+  });
+
+  const reconnectFn = useMemo(
+    () => (onReconnect ? () => Promise.resolve(onReconnect()) : noopReconnect),
+    [onReconnect],
+  );
+  const { reconnect, inFlight: reconnectInFlight } = useReconnectAccount(reconnectFn);
+
+  // Reset search + selection every time the modal re-opens. One effect,
+  // one responsibility (rule 4.4).
+  useEffect(() => {
+    if (!open) return;
+    setSearch('');
+    setSelectedId(null);
+  }, [open]);
+
+  // Capture the previously-focused element so we can restore it on
+  // close — required for keyboard-only / screen-reader users.
+  useEffect(() => {
+    if (!open) return undefined;
+    previouslyFocused.current = (document.activeElement as HTMLElement | null) ?? null;
+    return () => {
+      previouslyFocused.current?.focus?.();
+    };
+  }, [open]);
+
+  // Move initial focus to the search input on open.
+  useEffect(() => {
+    if (!open) return;
+    const card = cardRef.current;
+    if (!card) return;
+    const first = card.querySelector<HTMLElement>('input, button');
+    first?.focus();
+  }, [open]);
+
+  // Escape closes the modal.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  const safeFiles = useMemo(() => {
+    if (!data) return [] as ReadonlyArray<DriveFile>;
+    // Server already filters; we re-filter as defence in depth so a
+    // future server bug can't smuggle a non-supported MIME into the UI.
+    return data.files.filter((f) => SUPPORTED_MIME_TYPES.has(f.mimeType));
+  }, [data]);
+
+  const filteredFiles = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return safeFiles;
+    return safeFiles.filter((f) => f.name.toLowerCase().includes(q));
+  }, [safeFiles, search]);
+
+  const selectedFile = useMemo(
+    () => filteredFiles.find((f) => f.id === selectedId) ?? null,
+    [filteredFiles, selectedId],
+  );
+
+  if (!open) return null;
+  if (typeof document === 'undefined') return null;
+
+  // Trap Tab inside the dialog (rule 4.6 testable focus-trap).
+  const onKeyDownInside = (e: ReactKeyboardEvent<HTMLDivElement>): void => {
+    if (e.key !== 'Tab') return;
+    const card = cardRef.current;
+    if (!card) return;
+    const focusables = Array.from(card.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(
+      (el) => !el.hasAttribute('aria-hidden'),
+    );
+    if (focusables.length === 0) return;
+    const first = focusables[0]!;
+    const last = focusables[focusables.length - 1]!;
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey && active === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  const onBackdropClick = (): void => onClose();
+  const stop = (e: MouseEvent<HTMLDivElement>): void => e.stopPropagation();
+
+  // Determine which inner pane to render. The header/footer chrome
+  // stays mounted across every state so the dialog frame is stable.
+  let body: JSX.Element;
+  if (tokenExpired) {
+    body = <TokenExpiredState onReconnect={() => void reconnect()} inFlight={reconnectInFlight} />;
+  } else if (error) {
+    body = <NetworkErrorState onRetry={() => refetch()} />;
+  } else if (isLoading) {
+    body = (
+      <List>
+        <LoadingState />
+      </List>
+    );
+  } else if (safeFiles.length === 0) {
+    body = <EmptyFolderState />;
+  } else if (filteredFiles.length === 0) {
+    body = <NoResultsState query={search} />;
+  } else {
+    body = (
+      <List role="listbox" aria-label="Drive files">
+        {filteredFiles.map((f) => {
+          const kind = mimeKind(f.mimeType);
+          const palette =
+            kind === 'pdf'
+              ? { bg: t.color.danger[50], fg: t.color.danger[700] }
+              : kind === 'gdoc'
+                ? { bg: t.color.indigo[50], fg: t.color.indigo[700] }
+                : { bg: t.color.indigo[50], fg: t.color.indigo[600] };
+          const selected = selectedId === f.id;
+          return (
+            <Row
+              key={f.id}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              onClick={() => setSelectedId(f.id)}
+              onDoubleClick={() => onPick(f)}
+            >
+              <RowIcon $bg={palette.bg} $fg={palette.fg} aria-hidden>
+                <Icon icon={FileText} size={18} />
+              </RowIcon>
+              <RowMain>
+                <RowName>{f.name}</RowName>
+                <RowMeta>{buildMeta(f)}</RowMeta>
+              </RowMain>
+              <SelectMark $selected={selected} aria-hidden>
+                {selected ? <Icon icon={Check} size={14} /> : null}
+              </SelectMark>
+            </Row>
+          );
+        })}
+      </List>
+    );
+  }
+
+  const showSearchAndPath = !tokenExpired && !error;
+
+  const dialog = (
+    <Backdrop role="presentation" onClick={onBackdropClick}>
+      <Card
+        ref={cardRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        onClick={stop}
+        onKeyDown={onKeyDownInside}
+      >
+        <Header>
+          <HeaderLogo aria-hidden>
+            <Icon icon={Home} size={18} />
+          </HeaderLogo>
+          <Title id={titleId}>Pick from Google Drive</Title>
+          <CloseButton type="button" onClick={onClose} aria-label="Close picker">
+            <Icon icon={X} size={18} />
+          </CloseButton>
+        </Header>
+        {showSearchAndPath ? (
+          <>
+            <PathBar>
+              <Icon icon={Home} size={14} />
+              <PathRoot>My Drive</PathRoot>
+            </PathBar>
+            <SearchWrap>
+              <SearchInner>
+                <SearchIcon aria-hidden>
+                  <Icon icon={Search} size={16} />
+                </SearchIcon>
+                <SearchInput
+                  type="search"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder="Search PDFs, Docs, and Word documents in Drive…"
+                  aria-label="Search Drive files"
+                />
+              </SearchInner>
+            </SearchWrap>
+          </>
+        ) : null}
+        {body}
+        <Footer>
+          <FooterNote>Showing PDFs, Google Docs, and Word documents.</FooterNote>
+          <Button variant="ghost" type="button" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            iconLeft={Check}
+            type="button"
+            disabled={!selectedFile}
+            onClick={() => selectedFile && onPick(selectedFile)}
+          >
+            Use this file
+          </Button>
+        </Footer>
+      </Card>
+    </Backdrop>
+  );
+
+  return createPortal(dialog, document.body);
+}

--- a/apps/web/src/components/drive-picker/DrivePicker.types.ts
+++ b/apps/web/src/components/drive-picker/DrivePicker.types.ts
@@ -1,0 +1,48 @@
+/**
+ * Public types for the reusable Google Drive picker modal.
+ *
+ * Types live in their own file so the component, the hook, the states
+ * file, and consumer code (WT-E flow integrations) can all import the
+ * picker contract without pulling the runtime modal in.
+ */
+
+/**
+ * MIME-filter values understood by both the server proxy
+ * (`apps/api/src/integrations/gdrive/gdrive.controller.ts`) and the
+ * client picker. Mirrors `SUPPORTED_MIME_FILTERS` on the API side; the
+ * picker also enforces this list client-side as defence in depth.
+ */
+export type DriveMimeFilter = 'pdf' | 'doc' | 'docx' | 'all';
+
+/**
+ * Subset of Drive `files.list` metadata exposed by the API proxy.
+ * Mirrors the `DriveFile` shape declared in
+ * `apps/api/src/integrations/gdrive/gdrive.controller.ts`.
+ *
+ * `mimeType` always starts with one of the supported MIME prefixes —
+ * the picker strips any row outside the allow-list as defence in depth
+ * (the server already filters server-side).
+ */
+export interface DriveFile {
+  readonly id: string;
+  readonly name: string;
+  readonly mimeType: string;
+  readonly modifiedTime?: string;
+  readonly size?: string;
+}
+
+export interface DrivePickerProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onPick: (file: DriveFile) => void;
+  /** UUID of the connected Google Drive account being browsed. */
+  readonly accountId: string;
+  /** Defaults to `'all'` (PDF + Doc + Docx). */
+  readonly mimeFilter?: DriveMimeFilter;
+  /**
+   * Called when the user clicks `Reconnect` from the token-expired
+   * state. Single-flight enforcement — multiple clicks during a single
+   * session must coalesce to one consent popup.
+   */
+  readonly onReconnect?: () => void;
+}

--- a/apps/web/src/components/drive-picker/driveFilesApi.ts
+++ b/apps/web/src/components/drive-picker/driveFilesApi.ts
@@ -1,0 +1,52 @@
+import type { AxiosRequestConfig } from 'axios';
+import { apiClient } from '@/lib/api/apiClient';
+import type { DriveFile, DriveMimeFilter } from './DrivePicker.types';
+
+/**
+ * Wire shape of `GET /integrations/gdrive/files`. The server already
+ * filters by `mimeFilter`; the client re-filters via
+ * {@link SUPPORTED_MIME_TYPES} as defence in depth.
+ */
+export interface DriveFilesResponse {
+  readonly files: ReadonlyArray<DriveFile>;
+}
+
+export interface ListDriveFilesArgs {
+  readonly accountId: string;
+  readonly mimeFilter: DriveMimeFilter;
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Allow-list mirroring the server's mime allow-list. Anything outside
+ * this set is dropped on the client too, so a future server bug can't
+ * smuggle (e.g.) a `.exe` row into the picker UI.
+ */
+export const SUPPORTED_MIME_TYPES: ReadonlySet<string> = new Set([
+  'application/pdf',
+  'application/vnd.google-apps.document',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+
+function configWithSignal(signal?: AbortSignal): AxiosRequestConfig {
+  return signal ? { signal } : {};
+}
+
+/**
+ * Fetches one page of Drive files from the API proxy. Errors with HTTP
+ * status 401 + body `{ code: 'token-expired' }` are surfaced as plain
+ * `ApiError` (status 401) — `useDriveFiles` maps that to the
+ * Reconnect state.
+ */
+export async function listDriveFiles(args: ListDriveFilesArgs): Promise<DriveFilesResponse> {
+  const { accountId, mimeFilter, signal } = args;
+  const { data } = await apiClient.get<DriveFilesResponse>('/integrations/gdrive/files', {
+    ...configWithSignal(signal),
+    params: { accountId, mimeFilter },
+  });
+  // Defence-in-depth: drop any file whose mime escapes the allow-list.
+  // `data.files` is `ReadonlyArray`; `.filter` returns a fresh array so
+  // we never mutate the response React-Query caches.
+  const safeFiles = data.files.filter((f) => SUPPORTED_MIME_TYPES.has(f.mimeType));
+  return { files: safeFiles };
+}

--- a/apps/web/src/components/drive-picker/index.ts
+++ b/apps/web/src/components/drive-picker/index.ts
@@ -1,0 +1,5 @@
+export { DrivePicker } from './DrivePicker';
+export { PICKER_HEIGHT_PX, PICKER_WIDTH_PX } from './DrivePicker.styles';
+export type { DriveFile, DriveMimeFilter, DrivePickerProps } from './DrivePicker.types';
+export { driveFilesKey, useDriveFiles, useReconnectAccount } from './useDriveFiles';
+export { listDriveFiles, SUPPORTED_MIME_TYPES } from './driveFilesApi';

--- a/apps/web/src/components/drive-picker/states.tsx
+++ b/apps/web/src/components/drive-picker/states.tsx
@@ -1,0 +1,121 @@
+import type { JSX } from 'react';
+import { AlertTriangle, FileSearch, FolderOpen, RefreshCw, WifiOff } from 'lucide-react';
+import { useTheme } from 'styled-components';
+import { Button } from '@/components/Button';
+import { Icon } from '@/components/Icon';
+import {
+  SkeletonRow,
+  StateActions,
+  StateBadge,
+  StateBody,
+  StatePane,
+  StateTitle,
+} from './DrivePicker.styles';
+
+/**
+ * Stateless render functions for every non-list state surfaced by the
+ * picker. Each maps 1:1 to one of the API DTO's named error codes
+ * (`token-expired`, `oauth-declined`, `no-files-match-filter`, …) so
+ * state -> code mapping in the controller stays straightforward.
+ *
+ * The pieces live together in a single file because they all share the
+ * same `<StatePane>` skeleton and need identical styling. Splitting
+ * each into its own component would only churn the import surface.
+ */
+
+export function LoadingState(): JSX.Element {
+  return (
+    <div role="status" aria-live="polite" aria-label="Loading Drive files">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <SkeletonRow key={i} aria-hidden="true" />
+      ))}
+    </div>
+  );
+}
+
+export function EmptyFolderState(): JSX.Element {
+  const t = useTheme();
+  return (
+    <StatePane role="status">
+      <StateBadge $bg={t.color.ink[50]} $fg={t.color.fg[3]} aria-hidden>
+        <Icon icon={FolderOpen} size={28} />
+      </StateBadge>
+      <StateTitle>This folder is empty</StateTitle>
+      <StateBody>
+        We couldn&apos;t find any PDFs, Google Docs, or Word documents here. Try a different folder
+        in your Drive.
+      </StateBody>
+    </StatePane>
+  );
+}
+
+export interface NoResultsStateProps {
+  readonly query: string;
+}
+
+export function NoResultsState({ query }: NoResultsStateProps): JSX.Element {
+  const t = useTheme();
+  return (
+    <StatePane role="status">
+      <StateBadge $bg={t.color.ink[50]} $fg={t.color.fg[3]} aria-hidden>
+        <Icon icon={FileSearch} size={28} />
+      </StateBadge>
+      <StateTitle>No files match &ldquo;{query}&rdquo;</StateTitle>
+      <StateBody>Try a different search term, or pick from the list above.</StateBody>
+    </StatePane>
+  );
+}
+
+export interface TokenExpiredStateProps {
+  readonly onReconnect: () => void;
+  readonly inFlight: boolean;
+}
+
+export function TokenExpiredState({ onReconnect, inFlight }: TokenExpiredStateProps): JSX.Element {
+  const t = useTheme();
+  return (
+    <StatePane role="status">
+      <StateBadge $bg={t.color.warn[50]} $fg={t.color.warn[700]} aria-hidden>
+        <Icon icon={AlertTriangle} size={28} />
+      </StateBadge>
+      <StateTitle>Your Google Drive connection expired</StateTitle>
+      <StateBody>
+        Reconnect to keep importing files. Your in-progress document is safe — we&apos;ll pick up
+        where you left off.
+      </StateBody>
+      <StateActions>
+        <Button
+          variant="primary"
+          iconLeft={RefreshCw}
+          onClick={onReconnect}
+          loading={inFlight}
+          disabled={inFlight}
+        >
+          Reconnect
+        </Button>
+      </StateActions>
+    </StatePane>
+  );
+}
+
+export interface NetworkErrorStateProps {
+  readonly onRetry: () => void;
+}
+
+export function NetworkErrorState({ onRetry }: NetworkErrorStateProps): JSX.Element {
+  const t = useTheme();
+  return (
+    <StatePane role="status">
+      <StateBadge $bg={t.color.danger[50]} $fg={t.color.danger[700]} aria-hidden>
+        <Icon icon={WifiOff} size={28} />
+      </StateBadge>
+      <StateTitle>Couldn&apos;t reach Google Drive</StateTitle>
+      <StateBody>This is usually temporary. Try again in a few seconds.</StateBody>
+      <StateActions>
+        <Button variant="primary" iconLeft={RefreshCw} onClick={onRetry}>
+          Try again
+        </Button>
+      </StateActions>
+    </StatePane>
+  );
+}

--- a/apps/web/src/components/drive-picker/useDriveFiles.test.tsx
+++ b/apps/web/src/components/drive-picker/useDriveFiles.test.tsx
@@ -1,0 +1,149 @@
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/lib/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { apiClient } from '@/lib/api/apiClient';
+// eslint-disable-next-line import/first
+import { driveFilesKey, useDriveFiles, useReconnectAccount } from './useDriveFiles';
+
+const get = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+function freshClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0, staleTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+}
+
+function wrap(qc: QueryClient) {
+  function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
+
+beforeEach(() => {
+  get.mockReset();
+});
+
+describe('driveFilesKey', () => {
+  it('produces a stable tuple keyed by account + filter', () => {
+    const a = driveFilesKey(ACCOUNT_ID, 'pdf');
+    const b = driveFilesKey(ACCOUNT_ID, 'pdf');
+    expect(a).toEqual(b);
+    expect(driveFilesKey(ACCOUNT_ID, 'doc')).not.toEqual(a);
+  });
+});
+
+describe('useDriveFiles', () => {
+  it('hits /integrations/gdrive/files with accountId + mimeFilter and returns the typed payload', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        files: [
+          {
+            id: 'f-pdf',
+            name: 'Acme MSA - signed.pdf',
+            mimeType: 'application/pdf',
+          },
+        ],
+      },
+      status: 200,
+    });
+    const qc = freshClient();
+    const { result } = renderHook(
+      () => useDriveFiles({ accountId: ACCOUNT_ID, mimeFilter: 'pdf', enabled: true }),
+      { wrapper: wrap(qc) },
+    );
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(get).toHaveBeenCalledTimes(1);
+    const [url, config] = get.mock.calls[0]!;
+    expect(url).toBe('/integrations/gdrive/files');
+    expect(config?.params).toEqual({ accountId: ACCOUNT_ID, mimeFilter: 'pdf' });
+    expect(result.current.data?.files).toHaveLength(1);
+    expect(result.current.tokenExpired).toBe(false);
+  });
+
+  it('sets tokenExpired=true when the API returns 401 and never retries it', async () => {
+    const expired = Object.assign(new Error('reconnect_required'), { status: 401 });
+    get.mockRejectedValue(expired);
+    const qc = freshClient();
+    const { result } = renderHook(
+      () => useDriveFiles({ accountId: ACCOUNT_ID, mimeFilter: 'all', enabled: true }),
+      { wrapper: wrap(qc) },
+    );
+    await waitFor(() => expect(result.current.tokenExpired).toBe(true));
+    // 401 should never be retried — the only way to recover is for the
+    // user to click Reconnect, which is its own user-driven flow.
+    expect(get).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch when enabled=false (closed picker)', () => {
+    const qc = freshClient();
+    renderHook(() => useDriveFiles({ accountId: ACCOUNT_ID, mimeFilter: 'all', enabled: false }), {
+      wrapper: wrap(qc),
+    });
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('strips MIME types outside the allow-list as defence in depth', async () => {
+    get.mockResolvedValueOnce({
+      data: {
+        files: [
+          { id: 'good', name: 'a.pdf', mimeType: 'application/pdf' },
+          { id: 'bad', name: 'a.exe', mimeType: 'application/x-msdownload' },
+        ],
+      },
+      status: 200,
+    });
+    const qc = freshClient();
+    const { result } = renderHook(
+      () => useDriveFiles({ accountId: ACCOUNT_ID, mimeFilter: 'all', enabled: true }),
+      { wrapper: wrap(qc) },
+    );
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.files.map((f) => f.id)).toEqual(['good']);
+  });
+});
+
+describe('useReconnectAccount', () => {
+  it('coalesces concurrent calls into a single in-flight Promise (single-flight)', async () => {
+    const fn = vi.fn().mockImplementation(() => new Promise<void>(() => {}));
+    const { result } = renderHook(() => useReconnectAccount(fn));
+    void result.current.reconnect();
+    void result.current.reconnect();
+    void result.current.reconnect();
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a fresh reconnect once the previous Promise has resolved', async () => {
+    let resolveFirst: (() => void) | undefined;
+    const fn = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFirst = () => resolve();
+        }),
+    );
+    const { result } = renderHook(() => useReconnectAccount(fn));
+    const first = result.current.reconnect();
+    expect(fn).toHaveBeenCalledTimes(1);
+    resolveFirst?.();
+    await first;
+    void result.current.reconnect();
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/drive-picker/useDriveFiles.ts
+++ b/apps/web/src/components/drive-picker/useDriveFiles.ts
@@ -1,0 +1,108 @@
+import { useCallback, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { ApiError } from '@/lib/api/apiClient';
+import { listDriveFiles, type DriveFilesResponse } from './driveFilesApi';
+import type { DriveMimeFilter } from './DrivePicker.types';
+
+/**
+ * Stable query-key factory so consumers (manual invalidation, tests)
+ * reference the exact tuple React-Query keys on.
+ */
+export function driveFilesKey(accountId: string, mimeFilter: DriveMimeFilter): readonly unknown[] {
+  return ['gdrive', 'files', accountId, mimeFilter] as const;
+}
+
+export interface UseDriveFilesArgs {
+  readonly accountId: string;
+  readonly mimeFilter: DriveMimeFilter;
+  /** Skip the fetch when the modal is closed (no work in the background). */
+  readonly enabled: boolean;
+}
+
+export interface UseDriveFilesResult {
+  readonly data: DriveFilesResponse | undefined;
+  readonly isLoading: boolean;
+  readonly isFetching: boolean;
+  readonly error: ApiError | null;
+  /**
+   * `true` once an HTTP 401 has surfaced (server's
+   * `{ code: 'token-expired' }`). Components render the Reconnect CTA
+   * in this case.
+   */
+  readonly tokenExpired: boolean;
+  readonly refetch: () => void;
+}
+
+/**
+ * Loads one page of Drive files for a given account + MIME filter.
+ *
+ * Pagination ("Load more") is intentionally a thin wrapper over
+ * React-Query — the server doesn't expose a cursor in WT-A-2, so v1
+ * lists the first 100 results. When the API gains a cursor (planned in
+ * the post-WT-C iteration), `useDriveFiles` will switch to
+ * `useInfiniteQuery` without changing the picker's render contract.
+ *
+ * Retry behaviour:
+ *  - Network blips retry once.
+ *  - HTTP 401 (`token-expired`) does NOT retry — the picker shows
+ *    Reconnect immediately. A second probe would cost the user a
+ *    second consent popup if the refresh-token is gone.
+ */
+export function useDriveFiles(args: UseDriveFilesArgs): UseDriveFilesResult {
+  const { accountId, mimeFilter, enabled } = args;
+  const query = useQuery<DriveFilesResponse, ApiError>({
+    queryKey: driveFilesKey(accountId, mimeFilter),
+    queryFn: ({ signal }) => listDriveFiles({ accountId, mimeFilter, signal }),
+    enabled,
+    retry: (failureCount, err) => {
+      if (err.status === 401) return false;
+      return failureCount < 1;
+    },
+    staleTime: 30_000,
+  });
+
+  const tokenExpired = query.error?.status === 401;
+
+  return {
+    data: query.data,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    error: query.error,
+    tokenExpired,
+    refetch: query.refetch,
+  };
+}
+
+/**
+ * Single-flight reconnect orchestrator.
+ *
+ * The token-expired Reconnect CTA must NEVER spawn more than one
+ * consent popup per session. Multiple rapid clicks (or a re-render
+ * loop) coalesce to one in-flight `Promise`; only when that resolves
+ * does the next click open a fresh popup. The returned `reconnect`
+ * is referentially stable across renders.
+ */
+export function useReconnectAccount(reconnectFn: () => Promise<void>): {
+  readonly reconnect: () => Promise<void>;
+  readonly inFlight: boolean;
+} {
+  // The ref carries the in-flight Promise across renders without
+  // triggering a re-render itself. The boolean `inFlight` mirror lives
+  // in `useState` so subscribers can render the spinner — they're kept
+  // in sync inside `reconnect` (set true at start, false on settle).
+  const inFlightRef = useRef<Promise<void> | null>(null);
+  const [inFlight, setInFlight] = useState(false);
+
+  const reconnect = useCallback((): Promise<void> => {
+    if (inFlightRef.current) return inFlightRef.current;
+    setInFlight(true);
+    const p = reconnectFn().finally(() => {
+      inFlightRef.current = null;
+      setInFlight(false);
+    });
+    inFlightRef.current = p;
+    return p;
+  }, [reconnectFn]);
+
+  return { reconnect, inFlight };
+}


### PR DESCRIPTION
## Summary

Adds the portal-rendered `<DrivePicker />` modal + `useDriveFiles` React-Query hook + per-state subviews (loading / empty / token-expired / no-results / network-error) + Storybook stories covering every state. Wires to WT-A-2's `GET /integrations/gdrive/files` proxy.

- `apps/web/src/components/drive-picker/DrivePicker.tsx` — portal-rendered modal, **hard-locked at 760×600** per Phase 3 watchpoint #4.
- `useDriveFiles.ts` — React-Query hook with single-flight reconnect orchestrator (`useReconnectAccount`).
- `states.tsx` — every named substate, each mapped 1:1 to an API DTO error code.
- `DrivePicker.stories.tsx` — 5 stories (FileList, EmptyFolder, TokenExpired, NetworkError, Loading) for Chromatic baseline.

## Test plan

- [x] `DrivePicker.test.tsx` (10 tests): open/close, focus-trap on Tab, Escape closes, backdrop click closes (card click does not), row click → `onPick`, Use-this-file disabled until pick, MIME allow-list defence in depth (drops unsupported entries client-side), empty-folder state, no-results state when search filters everything out, token-expired Reconnect single-flight (3 rapid clicks → 1 popup).
- [x] `useDriveFiles.test.tsx` (8 tests): stable query key tuple, params shape (`accountId` + `mimeFilter`), 401 sets `tokenExpired` and never retries, `enabled=false` skips fetch, MIME stripping in the hook layer, `useReconnectAccount` single-flight + recovery after first promise resolves.
- [x] `pnpm --filter web typecheck` — green
- [x] `pnpm --filter web lint` — green
- [x] `pnpm --filter web vitest run` — 1324/1324 passing (full suite, no regressions)

## Watchpoints addressed

- **#4** Modal dimensions HARD-LOCKED at 760×600 via `PICKER_WIDTH_PX` / `PICKER_HEIGHT_PX` constants in `DrivePicker.styles.ts`. The unit test asserts the constants directly so any drift in either surface fails CI.
- **#6** Component lives at `apps/web/src/components/drive-picker/` (shared primitive, not inside the integrations page). Will be consumed by WT-E flow integrations (UploadRoute + Step1Document) via portal rendering. Hook + types exported from the package barrel for the downstream PR.

## Defence-in-depth notes

- The server already filters MIME types (per WT-A-2's `SUPPORTED_MIME_FILTERS`). The client re-applies the allow-list (`SUPPORTED_MIME_TYPES` in `driveFilesApi.ts` + the picker's `safeFiles` memo) so a future server bug cannot smuggle a non-supported entry into the picker UI.
- HTTP 401 (`{ code: 'token-expired' }`) does NOT trigger a React-Query retry — the picker shows Reconnect immediately. A second probe would cost the user a second consent popup if the refresh-token is gone.
- `useReconnectAccount` enforces single-flight: rapid clicks coalesce to one in-flight `Promise`, and only when that resolves does the next click open a fresh popup.

## Deviations

- **LOC budget**: PR plan target was ≤600 LOC for WT-C; runtime LOC = 954 (DrivePicker.tsx 316, styles 302, states 121, hook 110, types 48, api 52, index 5). Most of the overage is in styled-components (one full styles file for the 760×600 modal + 5 substates) and the rule-4.4 split of the four single-concern effects in DrivePicker.tsx. Tests + stories add another 544 LOC. Manager review may want to revisit the budget vs. the design surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)