### PR TITLE
fix(api): mark gdrive oauth/callback @Public() so Google redirect bypasses AuthGuard

### DIFF
--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -1,5 +1,6 @@
 import { BadRequestException, HttpException, HttpStatus, NotFoundException } from '@nestjs/common';
 import type { AuthUser } from '../../auth/auth-user';
+import { IS_PUBLIC_KEY } from '../../auth/public.decorator';
 import { GDriveController, type FilesProxy } from './gdrive.controller';
 import { GDriveService, type GoogleOAuthClient } from './gdrive.service';
 import { GDriveKmsService, type KmsClientPort } from './gdrive-kms.service';
@@ -195,6 +196,22 @@ describe('GDriveController', () => {
     // The row remains but `deleted_at` is set; listForUser filters it out.
     expect(repo.rows.get(acc.id)?.deletedAt).toBeTruthy();
     expect(await repo.listForUser('user-1')).toHaveLength(0);
+  });
+
+  // Regression for Phase 6 prod-bug-loop finding (2026-05-03):
+  // /oauth/callback is reached by Google's top-level browser redirect,
+  // which carries no Supabase JWT. Without @Public(), the global
+  // APP_GUARD AuthGuard rejects the redirect with 401 missing_token
+  // before the controller's requireFlag() runs — every Drive
+  // connection attempt would 401 in production. The unit tests below
+  // call the controller method directly and bypass the guard, so this
+  // metadata assertion is the only place that catches the omission.
+  it('GET /oauth/callback is marked @Public() so Google redirects bypass the global AuthGuard', () => {
+    const meta: unknown = Reflect.getMetadata(
+      IS_PUBLIC_KEY,
+      GDriveController.prototype.oauthCallback,
+    );
+    expect(meta).toBe(true);
   });
 
   it('feature flag off → every route 404s', async () => {

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -15,6 +15,7 @@ import {
 } from '@nestjs/common';
 import { isFeatureEnabled } from 'shared';
 import { CurrentUser } from '../../auth/current-user.decorator';
+import { Public } from '../../auth/public.decorator';
 import type { AuthUser } from '../../auth/auth-user';
 import { GDriveService } from './gdrive.service';
 import { OAuthStateStore, buildConsentUrl } from './oauth-pkce';
@@ -97,9 +98,13 @@ export class GDriveController {
   }
 
   @Get('oauth/callback')
+  @Public()
   // The callback is reached via Google's redirect — the user's browser, not
   // an authed JSON caller. We rely on the `state` nonce (single-use, 10
-  // min TTL) for CSRF + identity binding.
+  // min TTL) for CSRF + identity binding. @Public() opts the route out of
+  // the global APP_GUARD AuthGuard, which would otherwise 401 the redirect
+  // before requireFlag() even runs (no Supabase JWT on a top-level browser
+  // redirect from accounts.google.com).
   async oauthCallback(
     @Query('code') code: string,
     @Query('state') state: string,


### PR DESCRIPTION
## Summary

Phase 6 prod-bug-loop verification on https://api.seald.nromomentum.com caught a P0 bug: `GET /integrations/gdrive/oauth/callback` returns `401 {"error":"missing_token"}` instead of being processed.

The route is reached by Google's top-level browser redirect, which carries no Supabase JWT. The global `APP_GUARD` `AuthGuard` (registered in `auth.module.ts`) rejects the request **before** the controller's `requireFlag()` runs. With the feature flag flipped on, every "Connect Google Drive" attempt would fail at the callback step.

The unit tests in `gdrive.controller.spec.ts` bypass the global guard (they call `ctrl.oauthCallback(...)` directly), which is why Phase 5 review didn't catch this.

## Fix

- Add `@Public()` decorator to `oauthCallback()` in `gdrive.controller.ts`. CSRF + identity binding still come from the single-use, 10-min-TTL `state` nonce — security posture unchanged, just no longer requires an unobtainable JWT.
- Add regression test asserting `IS_PUBLIC_KEY` metadata is `true` on `GDriveController.prototype.oauthCallback`. RED before fix, GREEN after.

## Test plan

- [x] Failing test reproduces the bug (`expect(meta).toBe(true)` returns `undefined`)
- [x] Apply `@Public()`, test passes
- [x] Full `gdrive.controller.spec.ts` suite: 17/17 passing
- [x] `pnpm --filter api test`: 861/861 passing
- [x] `pnpm --filter api typecheck`: clean
- [x] `pnpm --filter api lint`: clean
- [ ] After merge: re-verify on prod that `/integrations/gdrive/oauth/callback?code=test&state=test` returns 404 (flag-off path) instead of 401

## Why this slipped through

Phase 5 review for WT-A-1 (PR #116) tested the controller method directly — the global `AuthGuard` was never wired into the test harness. The bug only manifests in a real HTTP request with no Authorization header. This is exactly the failure mode `seald-prod-bug-loop` Phase 6 is designed to catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)