### PR TITLE
fix(gdrive): fail loud (503) + UI alert when OAuth env vars missing

### DIFF
--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -147,6 +147,52 @@ describe('GDriveController', () => {
     expect(out.url).toContain('access_type=offline');
   });
 
+  it('GET /oauth/url throws 503 (not a broken URL) when GDRIVE_OAUTH_CLIENT_ID is unset', async () => {
+    // Phase 6.A iter-1 round-1 LOCAL bug: when GDRIVE_OAUTH_CLIENT_ID
+    // (and/or _CLIENT_SECRET) was unset, gdrive.module.ts fell back to
+    // an empty string and consentUrl happily returned a Google consent
+    // URL with `client_id=` (empty). The user clicked Connect Google
+    // Drive and Google's error page popped up with "Missing required
+    // parameter: client_id" — confusing UX that hid the real cause
+    // (server-side misconfig). Contract: when the OAuth client id or
+    // secret are empty/unset and the feature flag is ON, the API must
+    // throw 503 ServiceUnavailable so the SPA can render a friendly
+    // "Drive integration is not configured on this server" notice
+    // instead of silently bouncing the user to a broken Google URL.
+    // Mirrors the existing GDriveKmsService stubFail pattern from
+    // gdrive.module.ts (KMS already throws when ARN/region unset).
+    const repo = new FakeRepo();
+    const kms = new GDriveKmsService(
+      new StubKmsClient(),
+      'arn:aws:kms:us-east-1:000000000000:key/k',
+    );
+    const google = new StubGoogleClient();
+    const svc = new GDriveService(repo, kms, google);
+    const state = new OAuthStateStore();
+    const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000 });
+    const proxy: FilesProxy = async () => ({ files: [] });
+    const ctrlEmptyClient = new GDriveController(
+      svc,
+      state,
+      { ...CFG, clientId: '' },
+      limiter,
+      proxy,
+    );
+    const ctrlEmptySecret = new GDriveController(
+      svc,
+      state,
+      { ...CFG, clientSecret: '' },
+      limiter,
+      proxy,
+    );
+    await expect(ctrlEmptyClient.consentUrl(USER_1)).rejects.toMatchObject({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+    });
+    await expect(ctrlEmptySecret.consentUrl(USER_1)).rejects.toMatchObject({
+      status: HttpStatus.SERVICE_UNAVAILABLE,
+    });
+  });
+
   it('GET /oauth/callback rejects with 400 when state nonce is unknown', async () => {
     const { ctrl } = makeController();
     await expect(

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -83,9 +83,25 @@ export class GDriveController {
     }
   }
 
+  /**
+   * Fail loudly when the OAuth env vars are missing. The module factory
+   * falls back to empty strings so the api can boot dark (flag-off
+   * scenario), but once the flag is ON every OAuth route MUST have a
+   * real client id + secret. Without this check, `consentUrl` happily
+   * returned a Google URL with `client_id=` and the user got a confusing
+   * "Missing required parameter: client_id" error from Google. Mirrors
+   * the GDriveKmsService stubFail pattern in `gdrive.module.ts`.
+   */
+  private requireOAuthConfigured(): void {
+    if (!this.config.clientId || !this.config.clientSecret) {
+      throw new HttpException('gdrive_oauth_not_configured', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
   @Get('oauth/url')
   async consentUrl(@CurrentUser() user: AuthUser): Promise<{ url: string }> {
     this.requireFlag();
+    this.requireOAuthConfigured();
     const { state, codeChallenge } = this.stateStore.start(user.id);
     return {
       url: buildConsentUrl({
@@ -112,6 +128,7 @@ export class GDriveController {
     @Res({ passthrough: true }) res: { redirect(url: string): void },
   ): Promise<void> {
     this.requireFlag();
+    this.requireOAuthConfigured();
     if (error) {
       throw new HttpException(`oauth-declined: ${error}`, 400);
     }

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
@@ -15,7 +15,7 @@ vi.mock('../../../lib/api/apiClient', () => ({
 const openSpy = vi.fn();
 Object.defineProperty(window, 'open', { value: openSpy, writable: true });
 
-import { apiClient } from '../../../lib/api/apiClient';
+import { apiClient, type ApiError } from '../../../lib/api/apiClient';
 const mockedGet = apiClient.get as ReturnType<typeof vi.fn>;
 const mockedDelete = apiClient.delete as ReturnType<typeof vi.fn>;
 
@@ -96,6 +96,34 @@ describe('IntegrationsPage', () => {
     // The "Connected" status badge surfaces — query by exact text so the
     // sub-line ("Connected May 3, 2026 · Last used …") doesn't collide.
     expect(screen.getByText('Connected')).toBeInTheDocument();
+  });
+
+  it('shows a friendly inline alert and does NOT open Google when /oauth/url returns 503', async () => {
+    // Phase 6.A iter-1 round-1 LOCAL bug companion: when the API
+    // returns 503 `gdrive_oauth_not_configured` (server missing
+    // GDRIVE_OAUTH_CLIENT_ID / _CLIENT_SECRET), the page must surface a
+    // friendly alert ("Drive integration is not configured on this
+    // server") instead of bouncing the user to a broken Google URL.
+    // Pre-fix behaviour: window.open() was called with whatever the
+    // (now-throwing) call resolved to — the user saw Google's
+    // "Missing required parameter: client_id" error page.
+    mockedGet.mockImplementation((url: string) => {
+      if (url === '/integrations/gdrive/accounts') {
+        return Promise.resolve({ data: [], status: 200 });
+      }
+      if (url === '/integrations/gdrive/oauth/url') {
+        const err: ApiError = new Error('gdrive_oauth_not_configured');
+        err.status = 503;
+        return Promise.reject(err);
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+    renderPage();
+    const button = await screen.findByRole('button', { name: /connect google drive/i });
+    await userEvent.click(button);
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/not configured/i);
+    expect(openSpy).not.toHaveBeenCalled();
   });
 
   it('opens the Disconnect confirm modal when the user clicks Disconnect', async () => {

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
@@ -1,7 +1,16 @@
 import { useCallback, useState } from 'react';
-import { Link as LinkIcon, ChevronRight, Eye, Lock, XCircle, Cloud } from 'lucide-react';
+import {
+  Link as LinkIcon,
+  ChevronRight,
+  Eye,
+  Lock,
+  XCircle,
+  Cloud,
+  AlertTriangle,
+} from 'lucide-react';
 import styled from 'styled-components';
 import { isFeatureEnabled } from 'shared';
+import type { ApiError } from '@/lib/api/apiClient';
 import { Avatar } from '@/components/Avatar';
 import { Badge } from '@/components/Badge';
 import { Button } from '@/components/Button';
@@ -213,6 +222,41 @@ const ComingSoonHeader = styled.div`
   align-items: center;
   gap: ${({ theme }) => theme.space[3]};
   opacity: 0.65;
+`;
+
+const ConfigAlert = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 16px;
+  padding: 14px 16px;
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.color.bg.sunken};
+`;
+
+const ConfigAlertIconWrap = styled.span`
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  background: ${({ theme }) => theme.color.ink[100]};
+  color: ${({ theme }) => theme.color.fg[2]};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+`;
+
+const ConfigAlertCopy = styled.div`
+  font-size: 13px;
+  color: ${({ theme }) => theme.color.fg[2]};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
+`;
+
+const ConfigAlertTitle = styled.div`
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.fg[1]};
+  margin-bottom: 2px;
 `;
 
 const ComingSoonIconWrap = styled.div`
@@ -456,6 +500,22 @@ export function IntegrationsPage() {
           explicitly pick.
         </Subtitle>
       </Hero>
+
+      {(connect.error as ApiError | null)?.status === 503 ? (
+        <ConfigAlert role="alert">
+          <ConfigAlertIconWrap aria-hidden>
+            <Icon icon={AlertTriangle} size={16} />
+          </ConfigAlertIconWrap>
+          <ConfigAlertCopy>
+            <ConfigAlertTitle>Drive integration is not configured on this server</ConfigAlertTitle>
+            The server is missing its Google OAuth credentials. Ask your admin to set
+            <code style={{ margin: '0 4px' }}>GDRIVE_OAUTH_CLIENT_ID</code>
+            and
+            <code style={{ margin: '0 4px' }}>GDRIVE_OAUTH_CLIENT_SECRET</code>
+            before connecting an account.
+          </ConfigAlertCopy>
+        </ConfigAlert>
+      ) : null}
 
       <CardStack>
         <GDriveCard


### PR DESCRIPTION
## Summary
- API: throw `503 gdrive_oauth_not_configured` from `/oauth/url` and `/oauth/callback` when `GDRIVE_OAUTH_CLIENT_ID` or `GDRIVE_OAUTH_CLIENT_SECRET` is empty (mirrors the `GDriveKmsService.stubFail` pattern).
- Web: `IntegrationsPage` detects 503 from the React-Query mutation error and renders an inline `role=\"alert\"` panel asking the admin to set the env vars; `window.open` is **never** called in this branch.

## Why
Found in Phase 6.A iter-1 round-1 LOCAL: with the feature flag ON but env vars unset, clicking **Connect Google Drive** bounced the user to Google's *Missing required parameter: client_id* error page. Root cause was the empty-string fallback in `gdrive.module.ts:99-100` (kept so the api can boot dark when the flag is off). Once the flag is ON the OAuth routes must fail loudly.

## Test plan
- [x] api: `pnpm --filter api test` — 864/864 ✓ (new spec covers both empty-id and empty-secret branches)
- [x] web: `pnpm --filter web test` — 1372/1372 ✓ (new `IntegrationsPage` test asserts alert renders + `window.open` not called)
- [x] typecheck + lint ✓
- [x] Browser walkthrough at `localhost:5173/settings/integrations` — alert renders inline, no Google redirect (`local-iter1-bug3-postfix-503-alert.png`)
- [ ] CI: typecheck / lint / unit / web / e2e

## Notes
- Feature flag `gdriveIntegration` stays `false` on `main`; the dark-boot path is unaffected because `requireFlag()` 404s before `requireOAuthConfigured()` runs.
- Phase 6.A counter resets — bug found in iter-1 round-1 means the local-stage 5-clean counter restarts at 0 once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)