### PR TITLE
fix(web): replace disabled+title Drive CTA with navigable Connect-in-Settings

### DIFF
--- a/apps/web/e2e/features/gdrive/disabled-cta.feature
+++ b/apps/web/e2e/features/gdrive/disabled-cta.feature
@@ -1,0 +1,44 @@
+Feature: Drive picker CTA — accessible path to Settings when no account is connected
+  # Phase 6.A iter-1 round-1 LOCAL bug. Found 2026-05-03 walking the
+  # gdrive feature surface end-to-end on localhost.
+  #
+  # Pre-fix: When `feature.gdriveIntegration` is ON but the user has not
+  # connected a Google account, both Drive entry points (the
+  # `/document/new` source card AND the `/templates/:id/use` Step 1
+  # "Upload a new one" panel) render a `<button disabled title="Connect
+  # Google Drive in Settings to use this.">`. Three a11y failures:
+  #   1. The native `title` attribute is not announced by NVDA / VoiceOver
+  #      on disabled buttons.
+  #   2. Disabled buttons aren't focusable, so keyboard users get no
+  #      affordance at all.
+  #   3. Touch users never see a hover tooltip.
+  # Net effect: a dead-end CTA. The user is told "go to Settings" only
+  # if they have a desktop pointer device AND they happen to hover for
+  # ~1s. There is no clickable path from these surfaces to
+  # `/settings/integrations`.
+  #
+  # Post-fix: when `connected=false`, the surface MUST render an
+  # enabled, focusable affordance whose visible label and accessible
+  # name include "Connect" and which navigates to
+  # `/settings/integrations` on activation. No reliance on `title`.
+
+  Background:
+    Given the gdriveIntegration feature flag is on
+    And no Google Drive account is connected for the signed-in user
+
+  @gdrive @a11y @smoke
+  Scenario: /document/new exposes an enabled "Connect Drive in Settings" CTA
+    When the sender visits "/document/new"
+    Then the Drive source card renders a button with accessible name matching /connect.*settings/i
+    And that button is not disabled
+    And activating that button navigates to "/settings/integrations"
+    And no element on the page relies on the native `title` attribute to convey the connect-in-settings hint
+
+  @gdrive @a11y @smoke
+  Scenario: /templates/:id/use Upload-new step exposes an enabled "Connect Drive in Settings" CTA
+    Given a template with id "475e2154-b1f8-45ee-877a-be8a0ef1eb67" exists
+    When the sender visits "/templates/475e2154-b1f8-45ee-877a-be8a0ef1eb67/use"
+    And the sender selects the "Upload a new one" document source
+    Then the Drive replace button renders with accessible name matching /connect.*settings/i
+    And that button is not disabled
+    And activating that button navigates to "/settings/integrations"

--- a/apps/web/e2e/steps/gdrive.steps.ts
+++ b/apps/web/e2e/steps/gdrive.steps.ts
@@ -1,0 +1,157 @@
+import { expect } from '@playwright/test';
+import { createBdd } from 'playwright-bdd';
+import { test } from '../fixtures/test';
+
+const { Given, When, Then } = createBdd(test);
+
+/**
+ * Steps for `features/gdrive/disabled-cta.feature`. Covers the Phase 6.A
+ * iter-1 LOCAL bug: pre-fix the Drive CTA on `/document/new` and on the
+ * `/templates/:id/use` Step 1 "Upload a new one" panel was a
+ * `<button disabled title="…">` (an a11y dead-end — native `title` is
+ * not announced on disabled buttons, the button isn't focusable, touch
+ * users see no tooltip). Post-fix it's an enabled, focusable
+ * "Connect Drive in Settings" button that navigates to
+ * `/settings/integrations`.
+ *
+ * Two harness contortions worth flagging:
+ *
+ *  1. **Feature-flag override.** The static `FEATURE_FLAGS` constant in
+ *     `packages/shared/src/feature-flags.ts` is `false` for
+ *     `gdriveIntegration` on `main`; the override-host
+ *     `__SEALD_FEATURE_OVERRIDES__` is read by `isFeatureEnabled` at
+ *     call time so we can flip the flag from this Given without
+ *     touching the constant. Production never sets this global.
+ *
+ *  2. **Templates store hydration.** `UseTemplatePage` reads from the
+ *     module-scoped templates store and does NOT fetch on its own.
+ *     Deep-linking via `page.goto('/templates/<id>/use')` would boot a
+ *     fresh bundle with an empty store and render the NotFoundCard.
+ *     The "When the sender visits …" step detects this pattern and
+ *     hydrates by navigating to `/templates` first (the list page DOES
+ *     fetch /api/templates on mount), then SPA-navigates to the wizard
+ *     URL via history.pushState + popstate so module state survives.
+ */
+
+const FLAG_OVERRIDE_INIT_SCRIPT = `(function () {
+  const host = globalThis;
+  host.__SEALD_FEATURE_OVERRIDES__ = Object.assign(
+    {},
+    host.__SEALD_FEATURE_OVERRIDES__,
+    { gdriveIntegration: true },
+  );
+})();`;
+
+Given('the gdriveIntegration feature flag is on', async ({ page }) => {
+  await page.addInitScript(FLAG_OVERRIDE_INIT_SCRIPT);
+});
+
+Given(
+  'no Google Drive account is connected for the signed-in user',
+  async ({ seededUser, mockedApi }) => {
+    await seededUser.signInAs();
+    // useGDriveAccounts hits /api/integrations/gdrive/accounts. An empty
+    // array is the "connected=false" branch — drives the "Connect Drive
+    // in Settings" button rendering on both /document/new and
+    // /templates/:id/use.
+    mockedApi.on('GET', /\/api\/integrations\/gdrive\/accounts(\?|$)/, { json: [] });
+    // The settings/integrations destination renders cleanly with the
+    // same empty-list response — the "navigates to" assertion just
+    // waits for the URL to change, but we still want the page to mount
+    // without bubbling an unmocked-route 404 into the React tree.
+  },
+);
+
+When('the sender visits {string}', async ({ page }, url: string) => {
+  if (/^\/templates\/[^/]+\/use(\?|$)/.test(url)) {
+    // UseTemplatePage doesn't auto-fetch templates — it reads from the
+    // module-scoped store populated by /templates, /document/new, and
+    // the editor route. Hard-navigating directly to the wizard URL on
+    // a fresh page boot leaves the store empty → NotFoundCard. Hydrate
+    // via /templates first (TemplatesListPage calls listTemplates() on
+    // mount), then SPA-navigate so the store survives.
+    await page.goto('/templates');
+    // Wait for the list to render at least one template card so we
+    // know /api/templates resolved and the store is hydrated.
+    await expect(page.getByRole('heading', { name: /templates/i }).first()).toBeVisible();
+    await page.evaluate((target) => {
+      window.history.pushState({}, '', target);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+    }, url);
+    await page.waitForURL((u) => u.pathname + u.search === url || u.pathname === url);
+    return;
+  }
+  await page.goto(url);
+});
+
+When('the sender selects the {string} document source', async ({ page }, label: string) => {
+  await page.getByRole('radio', { name: new RegExp(`^${label}$`, 'i') }).click();
+});
+
+Given('a template with id {string} exists', async ({ mockedApi }, id: string) => {
+  // Mirrors the Nest TemplatesController's ApiTemplate wire shape. The
+  // hydrating list page (TemplatesListPage) maps `title` → summary.name.
+  mockedApi.on('GET', /\/api\/templates(\?|$)/, {
+    json: [
+      {
+        id,
+        owner_id: '00000000-0000-4000-8000-000000000a11',
+        title: 'Sample template for gdrive disabled-cta scenario',
+        description: '',
+        cover_color: '#EEF2FF',
+        field_layout: [],
+        tags: [],
+        last_signers: [],
+        has_example_pdf: false,
+        uses_count: 0,
+        last_used_at: null,
+        created_at: '2026-04-01T10:00:00Z',
+        updated_at: '2026-05-01T10:00:00Z',
+      },
+    ],
+  });
+});
+
+Then(
+  /^the Drive source card renders a button with accessible name matching \/([^/]+)\/([gimsuy]*)$/,
+  async ({ page }, body: string, flags: string) => {
+    await expect(page.getByRole('button', { name: new RegExp(body, flags) })).toBeVisible();
+  },
+);
+
+Then(
+  /^the Drive replace button renders with accessible name matching \/([^/]+)\/([gimsuy]*)$/,
+  async ({ page }, body: string, flags: string) => {
+    await expect(page.getByRole('button', { name: new RegExp(body, flags) })).toBeVisible();
+  },
+);
+
+Then('that button is not disabled', async ({ page }) => {
+  // The two scenarios both target the "Connect Drive in Settings" CTA.
+  // Querying by accessible name keeps this step generic across both
+  // surfaces (rule 4.6 — query by role/name, not test id).
+  const cta = page.getByRole('button', { name: /connect.*settings/i });
+  await expect(cta).toBeEnabled();
+  await expect(cta).not.toHaveAttribute('disabled', /.*/);
+});
+
+Then('activating that button navigates to {string}', async ({ page }, url: string) => {
+  const cta = page.getByRole('button', { name: /connect.*settings/i });
+  await cta.click();
+  await page.waitForURL(new RegExp(url.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '(\\?|$)'));
+});
+
+Then(
+  'no element on the page relies on the native `title` attribute to convey the connect-in-settings hint',
+  async ({ page }) => {
+    // Pre-fix the surface rendered <button disabled title="Connect
+    // Google Drive in Settings to use this.">. Post-fix no element
+    // should carry that hint via `title`. Match common phrasings
+    // tied to the Drive CTA so a regression that re-introduces the
+    // tooltip — even with slightly different copy — still trips this.
+    const titled = page.locator(
+      '[title*="Connect Google Drive" i], [title*="Settings to use this" i], [title*="Drive in Settings" i]',
+    );
+    await expect(titled).toHaveCount(0);
+  },
+);

--- a/apps/web/src/features/gdriveImport/DriveSourceCard.test.tsx
+++ b/apps/web/src/features/gdriveImport/DriveSourceCard.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { seald } from '@/styles/theme';
+import { DriveSourceCard } from './DriveSourceCard';
+
+/**
+ * RED gate for the Phase 6.A iter-1 round-1 LOCAL bug:
+ *
+ *   When the gdrive feature flag is on but no Drive account is
+ *   connected, `DriveSourceCard` rendered a `<button disabled
+ *   title="Connect Google Drive in Settings to use this." />`. The
+ *   `title` attribute is invisible to screen readers on a disabled
+ *   button, the button isn't focusable, and there's no clickable path
+ *   to `/settings/integrations` — a dead-end CTA.
+ *
+ * Post-fix: the not-connected branch renders an enabled, navigable
+ * affordance whose accessible name says "Connect" and which routes to
+ * `/settings/integrations` on activation. See Gherkin spec at
+ * `apps/web/e2e/features/gdrive/disabled-cta.feature`.
+ */
+
+function renderCard(props: Partial<React.ComponentProps<typeof DriveSourceCard>> = {}) {
+  return render(
+    <ThemeProvider theme={seald}>
+      <MemoryRouter initialEntries={['/document/new']}>
+        <Routes>
+          <Route
+            path="/document/new"
+            element={
+              <DriveSourceCard
+                connected={props.connected ?? false}
+                onPickDrive={props.onPickDrive ?? vi.fn()}
+              />
+            }
+          />
+          <Route path="/settings/integrations" element={<div>integrations-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('DriveSourceCard', () => {
+  describe('when connected=false', () => {
+    it('renders an enabled button with "Connect" in its accessible name (no disabled+title dead-end)', () => {
+      renderCard({ connected: false });
+      const cta = screen.getByRole('button', { name: /connect.*settings/i });
+      expect(cta).toBeInTheDocument();
+      expect(cta).toBeEnabled();
+    });
+
+    it('does NOT rely on the native `title` attribute for the connect-in-settings hint', () => {
+      renderCard({ connected: false });
+      const cta = screen.getByRole('button', { name: /connect.*settings/i });
+      // The fix replaces the title-tooltip pattern with a visible label.
+      expect(cta.getAttribute('title')).toBeNull();
+    });
+
+    it('navigates to /settings/integrations when activated', async () => {
+      renderCard({ connected: false });
+      const cta = screen.getByRole('button', { name: /connect.*settings/i });
+      await userEvent.click(cta);
+      expect(await screen.findByText('integrations-page')).toBeInTheDocument();
+    });
+
+    it('does NOT call onPickDrive when the user activates the connect CTA', async () => {
+      const onPickDrive = vi.fn();
+      renderCard({ connected: false, onPickDrive });
+      await userEvent.click(screen.getByRole('button', { name: /connect.*settings/i }));
+      expect(onPickDrive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when connected=true', () => {
+    it('renders the Pick from Google Drive button enabled', () => {
+      renderCard({ connected: true });
+      const pick = screen.getByRole('button', { name: /pick from google drive/i });
+      expect(pick).toBeEnabled();
+    });
+
+    it('calls onPickDrive when clicked', async () => {
+      const onPickDrive = vi.fn();
+      renderCard({ connected: true, onPickDrive });
+      await userEvent.click(screen.getByRole('button', { name: /pick from google drive/i }));
+      expect(onPickDrive).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/features/gdriveImport/DriveSourceCard.tsx
+++ b/apps/web/src/features/gdriveImport/DriveSourceCard.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/Button';
 import { GDriveLogo } from './GDriveLogo';
 
@@ -8,13 +9,21 @@ import { GDriveLogo } from './GDriveLogo';
  *
  * The card is feature-flag gated at the call site — when
  * `feature.gdriveIntegration` is OFF, the route does not render this
- * component at all. When it IS on but no account is connected, the CTA
- * is disabled with a tooltip pointing the sender to Settings.
+ * component at all. When it IS on but no account is connected, the
+ * Pick CTA is replaced with an enabled "Connect Drive in Settings"
+ * button that navigates to `/settings/integrations`. Pre-fix the CTA
+ * was a `<button disabled title="…">` — the native `title` attribute
+ * isn't announced by screen readers on a disabled button, the button
+ * isn't focusable, and touch users get no tooltip at all (a dead-end
+ * surface). See `DriveSourceCard.test.tsx` + the Gherkin spec at
+ * `apps/web/e2e/features/gdrive/disabled-cta.feature`.
  */
 export interface DriveSourceCardProps {
   readonly connected: boolean;
   readonly onPickDrive: () => void;
 }
+
+const SETTINGS_INTEGRATIONS_PATH = '/settings/integrations';
 
 const Card = styled.div`
   background: ${({ theme }) => theme.color.bg.surface};
@@ -56,9 +65,8 @@ const Description = styled.p`
   line-height: ${({ theme }) => theme.font.lineHeight.normal};
 `;
 
-const DISABLED_TOOLTIP = 'Connect Google Drive in Settings to use this.';
-
 export function DriveSourceCard({ connected, onPickDrive }: DriveSourceCardProps) {
+  const navigate = useNavigate();
   return (
     <Card>
       <IconBox aria-hidden>
@@ -70,14 +78,15 @@ export function DriveSourceCard({ connected, onPickDrive }: DriveSourceCardProps
           Pick a PDF, Google Doc, or Word document from your Drive. Per-file access only.
         </Description>
       </Body>
-      <Button
-        variant={connected ? 'primary' : 'secondary'}
-        onClick={onPickDrive}
-        disabled={!connected}
-        {...(connected ? {} : { title: DISABLED_TOOLTIP })}
-      >
-        Pick from Google Drive
-      </Button>
+      {connected ? (
+        <Button variant="primary" onClick={onPickDrive}>
+          Pick from Google Drive
+        </Button>
+      ) : (
+        <Button variant="secondary" onClick={() => navigate(SETTINGS_INTEGRATIONS_PATH)}>
+          Connect Drive in Settings
+        </Button>
+      )}
     </Card>
   );
 }

--- a/apps/web/src/features/gdriveImport/DriveTemplateReplaceButton.test.tsx
+++ b/apps/web/src/features/gdriveImport/DriveTemplateReplaceButton.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { seald } from '@/styles/theme';
+import { DriveTemplateReplaceButton } from './DriveTemplateReplaceButton';
+
+/**
+ * RED gate for the same Phase 6.A iter-1 LOCAL bug as
+ * `DriveSourceCard.test.tsx`, but for the `/templates/:id/use`
+ * Step 1 "Upload a new one" surface. Same a11y failure pattern, same
+ * post-fix contract (visible "Connect Drive in Settings" label that
+ * navigates to `/settings/integrations`). See Gherkin spec at
+ * `apps/web/e2e/features/gdrive/disabled-cta.feature`.
+ */
+
+function renderButton(
+  props: Partial<React.ComponentProps<typeof DriveTemplateReplaceButton>> = {},
+) {
+  return render(
+    <ThemeProvider theme={seald}>
+      <MemoryRouter initialEntries={['/templates/x/use']}>
+        <Routes>
+          <Route
+            path="/templates/x/use"
+            element={
+              <DriveTemplateReplaceButton
+                connected={props.connected ?? false}
+                onPickDrive={props.onPickDrive ?? vi.fn()}
+              />
+            }
+          />
+          <Route path="/settings/integrations" element={<div>integrations-page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('DriveTemplateReplaceButton', () => {
+  describe('when connected=false', () => {
+    it('renders an enabled button with "Connect" in its accessible name', () => {
+      renderButton({ connected: false });
+      const cta = screen.getByRole('button', { name: /connect.*settings/i });
+      expect(cta).toBeInTheDocument();
+      expect(cta).toBeEnabled();
+    });
+
+    it('does NOT rely on the native `title` attribute for the connect-in-settings hint', () => {
+      renderButton({ connected: false });
+      const cta = screen.getByRole('button', { name: /connect.*settings/i });
+      expect(cta.getAttribute('title')).toBeNull();
+    });
+
+    it('navigates to /settings/integrations when activated', async () => {
+      renderButton({ connected: false });
+      await userEvent.click(screen.getByRole('button', { name: /connect.*settings/i }));
+      expect(await screen.findByText('integrations-page')).toBeInTheDocument();
+    });
+
+    it('does NOT call onPickDrive when the user activates the connect CTA', async () => {
+      const onPickDrive = vi.fn();
+      renderButton({ connected: false, onPickDrive });
+      await userEvent.click(screen.getByRole('button', { name: /connect.*settings/i }));
+      expect(onPickDrive).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when connected=true', () => {
+    it('renders the Pick from Google Drive button enabled', () => {
+      renderButton({ connected: true });
+      const pick = screen.getByRole('button', { name: /pick from google drive/i });
+      expect(pick).toBeEnabled();
+    });
+
+    it('calls onPickDrive when clicked', async () => {
+      const onPickDrive = vi.fn();
+      renderButton({ connected: true, onPickDrive });
+      await userEvent.click(screen.getByRole('button', { name: /pick from google drive/i }));
+      expect(onPickDrive).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/features/gdriveImport/DriveTemplateReplaceButton.tsx
+++ b/apps/web/src/features/gdriveImport/DriveTemplateReplaceButton.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/Button';
 import { GDriveLogo } from './GDriveLogo';
 
@@ -7,30 +8,32 @@ import { GDriveLogo } from './GDriveLogo';
  * "Upload a PDF" button and inherits the same `secondary` variant so
  * the two affordances read as peers.
  *
- * Disabled-with-tooltip when no Drive account is connected — same
- * contract as `DriveSourceCard` on the New Document surface.
+ * When no Drive account is connected the button is replaced with a
+ * "Connect Drive in Settings" CTA that navigates to
+ * `/settings/integrations`. Same accessibility contract + rationale as
+ * `DriveSourceCard` (see that component's header comment + the Gherkin
+ * spec at `apps/web/e2e/features/gdrive/disabled-cta.feature`).
  */
 export interface DriveTemplateReplaceButtonProps {
   readonly connected: boolean;
   readonly onPickDrive: () => void;
 }
 
-const DISABLED_TOOLTIP = 'Connect Google Drive in Settings to use this.';
+const SETTINGS_INTEGRATIONS_PATH = '/settings/integrations';
 
 export function DriveTemplateReplaceButton({
   connected,
   onPickDrive,
 }: DriveTemplateReplaceButtonProps) {
+  const navigate = useNavigate();
   return (
     <Button
       variant="secondary"
-      onClick={onPickDrive}
-      disabled={!connected}
-      {...(connected ? {} : { title: DISABLED_TOOLTIP })}
+      onClick={connected ? onPickDrive : () => navigate(SETTINGS_INTEGRATIONS_PATH)}
     >
       <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
         <GDriveLogo size={16} />
-        Pick from Google Drive
+        {connected ? 'Pick from Google Drive' : 'Connect Drive in Settings'}
       </span>
     </Button>
   );

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.gdrive.test.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.gdrive.test.tsx
@@ -97,13 +97,21 @@ describe('UseTemplatePage Drive integration (WT-E)', () => {
     expect(cta).toBeEnabled();
   });
 
-  it('shows the Drive button disabled with tooltip when no account is connected', () => {
+  it('shows an enabled "Connect Drive in Settings" button when no account is connected', () => {
+    // Phase 6.A iter-1 LOCAL bug companion (see DriveSourceCard
+    // post-fix rationale + the Gherkin spec at
+    // `apps/web/e2e/features/gdrive/disabled-cta.feature`). Pre-fix
+    // this surface rendered a disabled button with a `title` tooltip
+    // — invisible to screen readers, non-focusable, and unreachable
+    // on touch. Post-fix it's an enabled button whose label includes
+    // "Connect" and which navigates to /settings/integrations.
     isFeatureEnabledSpy.mockReturnValue(true);
     mockAccounts(false);
     gotoStep1Upload();
-    const cta = screen.getByRole('button', { name: /pick from google drive/i });
-    expect(cta).toBeDisabled();
-    expect(cta).toHaveAttribute('title', 'Connect Google Drive in Settings to use this.');
+    const cta = screen.getByRole('button', { name: /connect.*settings/i });
+    expect(cta).toBeEnabled();
+    expect(cta.getAttribute('title')).toBeNull();
+    expect(screen.queryByRole('button', { name: /pick from google drive/i })).toBeNull();
   });
 
   it('opens the picker when the active CTA is clicked', () => {

--- a/apps/web/src/routes/UploadRoute.gdrive.test.tsx
+++ b/apps/web/src/routes/UploadRoute.gdrive.test.tsx
@@ -103,13 +103,25 @@ describe('UploadRoute Drive integration (WT-E)', () => {
     expect(cta).toBeEnabled();
   });
 
-  it('shows the Drive card with disabled CTA + tooltip when flag is on but no account', () => {
+  it('shows an enabled "Connect Drive in Settings" CTA when flag is on but no account', () => {
+    // Phase 6.A iter-1 LOCAL bug: pre-fix this surface rendered a
+    // `<button disabled title="…">` — an a11y dead-end (native title
+    // not announced for disabled buttons; not focusable; touch users
+    // see nothing). Post-fix the not-connected branch renders an
+    // enabled button whose visible label + accessible name include
+    // "Connect" and that navigates to /settings/integrations on
+    // activation. See `DriveSourceCard.test.tsx` and the Gherkin spec
+    // at `apps/web/e2e/features/gdrive/disabled-cta.feature`.
     isFeatureEnabledSpy.mockReturnValue(true);
     mockAccounts(false);
     renderRoute();
-    const cta = screen.getByRole('button', { name: /pick from google drive/i });
-    expect(cta).toBeDisabled();
-    expect(cta).toHaveAttribute('title', 'Connect Google Drive in Settings to use this.');
+    const cta = screen.getByRole('button', { name: /connect.*settings/i });
+    expect(cta).toBeEnabled();
+    expect(cta.getAttribute('title')).toBeNull();
+    // The legacy "Pick from Google Drive" label must be gone in the
+    // not-connected state — otherwise the user is misled into
+    // expecting the picker to open.
+    expect(screen.queryByRole('button', { name: /pick from google drive/i })).toBeNull();
   });
 
   it('opens the picker when the active CTA is clicked', () => {

--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -23,6 +23,25 @@ export const FEATURE_FLAGS: Record<string, boolean> = {
 
 export type FeatureFlag = 'gdriveIntegration' | 'gdriveMultiAccount';
 
+/**
+ * Runtime override hook for tests / local walkthroughs. Production never
+ * sets this global, so this branch is dead code in shipped builds. The
+ * Playwright BDD harness uses `addInitScript` to inject a flag override
+ * before the SPA boots so an e2e scenario tagged "feature flag is on"
+ * can render the gated surface without flipping the static constant.
+ */
+interface FeatureOverrideHost {
+  readonly __SEALD_FEATURE_OVERRIDES__?: Partial<Record<FeatureFlag, boolean>>;
+}
+
+function readOverride(flag: FeatureFlag): boolean | undefined {
+  if (typeof globalThis === 'undefined') return undefined;
+  const overrides = (globalThis as unknown as FeatureOverrideHost).__SEALD_FEATURE_OVERRIDES__;
+  return overrides ? overrides[flag] : undefined;
+}
+
 export function isFeatureEnabled(flag: FeatureFlag): boolean {
+  const override = readOverride(flag);
+  if (override !== undefined) return override;
   return FEATURE_FLAGS[flag] === true;
 }


### PR DESCRIPTION
## Summary

Phase 6.A iter-1 round-1 LOCAL bug, batched-BDD workflow.

When the gdrive feature flag is on but the user has no connected Google account, both Drive entry points (`/document/new` source card AND `/templates/:id/use` Step 1 Upload-new) rendered a `<button disabled title=\"Connect Google Drive in Settings to use this.\">`. Three a11y failures:

1. The native \`title\` attribute is **not announced** by NVDA / VoiceOver on a disabled button.
2. Disabled buttons aren't focusable, so keyboard users get no affordance.
3. Touch users never see a hover tooltip.

Net effect: a dead-end CTA. The user is told \"go to Settings\" only if they have a desktop pointer device AND happen to hover for ~1s. There is no clickable path from these surfaces to \`/settings/integrations\`.

**Post-fix:** the not-connected branch renders an enabled, focusable button whose visible label and accessible name include \"Connect\" and that navigates to \`/settings/integrations\` on activation. No reliance on \`title\`.

## Changes

- \`DriveSourceCard.tsx\` + \`DriveTemplateReplaceButton.tsx\`: \`useNavigate\` branch on \`connected\`; \"Pick from Google Drive\" only when connected.
- \`DriveSourceCard.test.tsx\` + \`DriveTemplateReplaceButton.test.tsx\` (new): RED-then-GREEN unit suites covering both branches (a11y + nav).
- \`UploadRoute.gdrive.test.tsx\` + \`UseTemplatePage.gdrive.test.tsx\`: rewrote the \"disabled + tooltip\" assertions to the new contract.
- \`apps/web/e2e/features/gdrive/disabled-cta.feature\` (new): Gherkin spec acting as the explicit acceptance criterion for the BDD-first batch (per \`feedback_batched_local_bdd_first.md\`).

## Test plan

- [x] Scoped vitest 12/12 for the two new test files
- [x] Full vitest 1384/1384 (including the rewritten consumer tests)
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm lint\` clean
- [ ] CI green (lint-meta, chromatic, playwright, ci) — watcher dispatched
- [ ] Manual local verify: feature flag on → \`/document/new\` shows enabled \"Connect Drive in Settings\" → click navigates to \`/settings/integrations\`

## Batch context

This is the only bug found while walking the gdrive feature surface end-to-end on localhost (other queued candidates either invalidated, e.g. Drive picker is correctly absent from \`Use saved document\` template path, or out-of-scope, e.g. unrelated TemplateCard \`onDuplicate\` console warning). Per the batched-BDD rule, ship what you have when the full surface walk yields < 3 bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)