### PR TITLE
fix(gdrive): flip gdriveIntegration flag to true on prod

### DIFF
--- a/packages/shared/src/feature-flags.ts
+++ b/packages/shared/src/feature-flags.ts
@@ -6,13 +6,24 @@
  */
 export const FEATURE_FLAGS: Record<string, boolean> = {
   /**
-   * Google Drive integration (Phase 5 of the gdrive feature). Off until
-   * WT-A through WT-E all merge and the backend is verified end-to-end.
+   * Google Drive integration (Phase 5 of the gdrive feature). Activated
+   * 2026-05-03 after WT-A..WT-E shipped + Phase 6.A iter-2 a11y fixes
+   * merged (PR #127). Pre-activation the flag was `false`, which caused
+   * `GDriveController.requireFlag()` to 404 every `/integrations/gdrive/*`
+   * route on prod — the surface was reachable in the SPA but the API
+   * returned `404 not_found` for OAuth URL, accounts list, file picker.
    * When false:
    *   - api: every `/integrations/gdrive/*` route 404s.
    *   - web: source-selection cards + settings page hide the Drive surface.
+   * When true (current):
+   *   - api: routes serve. If `GDRIVE_OAUTH_CLIENT_ID` / `_CLIENT_SECRET`
+   *     are unset on the host the OAuth-URL endpoint returns 503
+   *     `gdrive_oauth_not_configured`; the SPA surfaces a dismissible
+   *     inline alert (PR #125 + #127 iter-2 Bug D path).
+   *   - web: source-selection cards + Settings → Integrations show the
+   *     Drive surface.
    */
-  gdriveIntegration: false,
+  gdriveIntegration: true,
 
   /**
    * Multi-account UI gate for the gdrive Settings page. Data model is


### PR DESCRIPTION
## Summary

Flip `gdriveIntegration` from `false` → `true` in `packages/shared/src/feature-flags.ts`.

## Why

During the Phase 6.A iter-2 prod walk-through after PR #127 merged, every `/integrations/gdrive/*` API call on prod returned `404 not_found`. Root cause traced to `GDriveController.requireFlag()` which throws `NotFoundException` when `isFeatureEnabled('gdriveIntegration')` is false. The flag was deliberately off "until WT-A through WT-E all merge and the backend is verified end-to-end" — that precondition is now met:

- WT-A..E all shipped (oauth backend, integrations page, picker, doc-to-pdf, flow integrations).
- Phase 6.A iter-2 a11y batch landed in PR #127 (DrivePicker focus, DisconnectModal Tab trap + inline error, 503-alert dismiss).
- PR #125 added the friendly 503 fallback so the SPA degrades gracefully if `GDRIVE_OAUTH_CLIENT_ID` / `_CLIENT_SECRET` are unset on the host.

## Behaviour after merge + deploy

- **API**: `/integrations/gdrive/*` routes serve. With env unset: `oauth/url` returns 503 `gdrive_oauth_not_configured` → SPA dismissible inline alert (Bug D path). With env set: full OAuth round-trip works.
- **Web**: Source-selection cards + Settings → Integrations show the live Drive surface instead of a frozen empty-state.

## Verification (local)

- [x] `pnpm --filter shared build`
- [x] `pnpm -r typecheck`
- [x] `pnpm -r lint`
- [x] `pnpm --filter api test` — 864/864 ✓
- [x] `pnpm --filter web test` — 1389/1389 ✓

## Test plan (post-deploy on prod)

- [ ] `curl -s -H "Authorization: Bearer <jwt>" https://api.seald.nromomentum.com/integrations/gdrive/accounts` returns `[]` (200, not 404).
- [ ] `curl -s -H "Authorization: Bearer <jwt>" https://api.seald.nromomentum.com/integrations/gdrive/oauth/url` returns either `{url:"…"}` (env configured) or 503 `gdrive_oauth_not_configured` (env missing → SPA shows dismissible alert per Bug D).
- [ ] Re-run Phase 6.A iter-2 prod walk for Bugs A/B/C live (requires connected Drive account).

🤖 Generated with [Claude Code](https://claude.com/claude-code)