### PR TITLE
fix(gdrive): use drive/v3/about for identity under drive.file scope

### DIFF
--- a/apps/api/src/integrations/gdrive/google-oauth.client.spec.ts
+++ b/apps/api/src/integrations/gdrive/google-oauth.client.spec.ts
@@ -1,0 +1,139 @@
+import { FetchGoogleOAuthClient } from './google-oauth.client';
+
+/**
+ * Regression tests for FetchGoogleOAuthClient.exchangeCode.
+ *
+ * Pre-fix (2026-05-04 prod incident, "Bug E" in
+ * .claude/gdrive-feature/phase6a-iter2-prod-qa.md): the client called
+ * https://www.googleapis.com/oauth2/v3/userinfo to fetch the consenting
+ * user's `sub` + `email`. That endpoint requires `openid email` scopes;
+ * our requested scope is `https://www.googleapis.com/auth/drive.file`
+ * only (per the CLAUDE.md scope-minimization contract). Live Google
+ * therefore returned 403 on userinfo and the OAuth callback threw
+ * `google_oauth_userinfo_failed` → 500 → SPA never saw a connected
+ * account row. The bug never tripped CI because every existing spec
+ * mocked the OAuthClient interface and never exercised the real fetch
+ * path.
+ *
+ * Fix: switch to https://www.googleapis.com/drive/v3/about?fields=user
+ * which is reachable under `drive.file` and returns the same
+ * `permissionId` (sub) + `emailAddress`. These tests pin both the
+ * URL the client hits and the field-mapping on the response.
+ */
+describe('FetchGoogleOAuthClient.exchangeCode', () => {
+  const tokenJson = {
+    access_token: 'access-tok',
+    refresh_token: 'refresh-tok',
+    expires_in: 3600,
+    scope: 'https://www.googleapis.com/auth/drive.file',
+  };
+
+  const aboutJson = {
+    user: {
+      permissionId: 'google-permission-id-123',
+      emailAddress: 'eliran@example.com',
+      displayName: 'Eliran Azulay',
+    },
+  };
+
+  function mockFetchSequence(responses: Array<{ ok: boolean; status?: number; body: unknown }>): {
+    fetchImpl: typeof fetch;
+    calls: Array<{ url: string; init?: RequestInit }>;
+  } {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    let i = 0;
+    const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+      const r = responses[i++];
+      if (!r) throw new Error(`unexpected fetch call #${i} to ${String(url)}`);
+      calls.push({ url: String(url), ...(init !== undefined ? { init } : {}) });
+      return {
+        ok: r.ok,
+        status: r.status ?? (r.ok ? 200 : 400),
+        json: async () => r.body,
+        text: async () => JSON.stringify(r.body),
+      } as unknown as Response;
+    }) as unknown as typeof fetch;
+    return { fetchImpl, calls };
+  }
+
+  it('uses drive/v3/about?fields=user (NOT oauth2/v3/userinfo) to identify the consenting user', async () => {
+    const { fetchImpl, calls } = mockFetchSequence([
+      { ok: true, body: tokenJson },
+      { ok: true, body: aboutJson },
+    ]);
+    const client = new FetchGoogleOAuthClient(
+      'cid',
+      'csecret',
+      'https://api.example/cb',
+      fetchImpl,
+    );
+
+    await client.exchangeCode('code-abc', 'verifier-xyz');
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.url).toBe('https://oauth2.googleapis.com/token');
+    expect(calls[1]!.url).toBe('https://www.googleapis.com/drive/v3/about?fields=user');
+    // Hard guard: the legacy userinfo URL must NEVER reappear under the
+    // drive.file scope. CLAUDE.md "OAuth scope is hard-coded to
+    // drive.file (per-file consent only). Do not broaden" forbids the
+    // openid/email scopes that userinfo needs.
+    expect(calls.map((c) => c.url)).not.toContain('https://www.googleapis.com/oauth2/v3/userinfo');
+  });
+
+  it('maps drive about.user.{permissionId,emailAddress} to {googleUserId,googleEmail}', async () => {
+    const { fetchImpl } = mockFetchSequence([
+      { ok: true, body: tokenJson },
+      { ok: true, body: aboutJson },
+    ]);
+    const client = new FetchGoogleOAuthClient(
+      'cid',
+      'csecret',
+      'https://api.example/cb',
+      fetchImpl,
+    );
+
+    const result = await client.exchangeCode('code-abc', 'verifier-xyz');
+
+    expect(result.googleUserId).toBe('google-permission-id-123');
+    expect(result.googleEmail).toBe('eliran@example.com');
+    expect(result.refreshToken).toBe('refresh-tok');
+    expect(result.accessToken).toBe('access-tok');
+    expect(result.scope).toBe('https://www.googleapis.com/auth/drive.file');
+  });
+
+  it('passes the access token as a Bearer credential when calling drive about', async () => {
+    const { fetchImpl, calls } = mockFetchSequence([
+      { ok: true, body: tokenJson },
+      { ok: true, body: aboutJson },
+    ]);
+    const client = new FetchGoogleOAuthClient(
+      'cid',
+      'csecret',
+      'https://api.example/cb',
+      fetchImpl,
+    );
+
+    await client.exchangeCode('code-abc', 'verifier-xyz');
+
+    const aboutCall = calls[1]!;
+    const headers = (aboutCall.init?.headers ?? {}) as Record<string, string>;
+    expect(headers.authorization).toBe(`Bearer ${tokenJson.access_token}`);
+  });
+
+  it('throws google_oauth_about_failed when drive/v3/about responds non-2xx', async () => {
+    const { fetchImpl } = mockFetchSequence([
+      { ok: true, body: tokenJson },
+      { ok: false, status: 401, body: { error: { code: 401, message: 'unauthorized' } } },
+    ]);
+    const client = new FetchGoogleOAuthClient(
+      'cid',
+      'csecret',
+      'https://api.example/cb',
+      fetchImpl,
+    );
+
+    await expect(client.exchangeCode('code-abc', 'verifier-xyz')).rejects.toThrow(
+      'google_oauth_about_failed',
+    );
+  });
+});

--- a/apps/api/src/integrations/gdrive/google-oauth.client.ts
+++ b/apps/api/src/integrations/gdrive/google-oauth.client.ts
@@ -3,9 +3,27 @@ import type { GoogleOAuthClient } from './gdrive.service';
 /**
  * Minimal `fetch`-based Google OAuth client. Skips the `googleapis` SDK
  * (~250 KB) so the API bundle stays small. The three endpoints we need:
- *   - POST https://oauth2.googleapis.com/token   (code exchange + refresh)
- *   - GET  https://www.googleapis.com/oauth2/v3/userinfo (email + sub)
- *   - POST https://oauth2.googleapis.com/revoke  (revoke at Google)
+ *   - POST https://oauth2.googleapis.com/token            (code exchange + refresh)
+ *   - GET  https://www.googleapis.com/drive/v3/about?fields=user
+ *                                                          (email + permissionId)
+ *   - POST https://oauth2.googleapis.com/revoke           (revoke at Google)
+ *
+ * Identity-source note: we deliberately do NOT call
+ * https://www.googleapis.com/oauth2/v3/userinfo here. That endpoint
+ * requires the `openid email` scopes, which would broaden our consent
+ * beyond `https://www.googleapis.com/auth/drive.file` (the
+ * scope-minimization contract codified in CLAUDE.md). The Drive API
+ * `about.get?fields=user` endpoint is reachable under `drive.file`
+ * alone and returns the same identifying fields:
+ *   - `user.permissionId`   → stable per-user id (= what userinfo's
+ *                              `sub` claim provides; persisted as
+ *                              gdrive_accounts.google_user_id)
+ *   - `user.emailAddress`   → consenting-account email (gdrive_accounts.google_email)
+ *   - `user.displayName`    → unused today, available if the UI ever
+ *                              wants a friendlier label
+ * This change was forced by the 2026-05-04 prod incident where the
+ * userinfo call returned 403 under drive.file scope and the OAuth
+ * callback threw `google_oauth_userinfo_failed` → 500.
  *
  * `invalid_grant` from the refresh endpoint is the "user revoked access"
  * signal — surfaced upward so the service maps it to TokenExpiredError.
@@ -55,17 +73,21 @@ export class FetchGoogleOAuthClient implements GoogleOAuthClient {
     if (!tokenJson.refresh_token) {
       throw new Error('google_oauth_no_refresh_token: prompt=consent missing?');
     }
-    const userRes = await this.fetchImpl('https://www.googleapis.com/oauth2/v3/userinfo', {
+    // Identity lookup under drive.file scope (see header comment for why
+    // this is `about.get` and NOT `oauth2/v3/userinfo`).
+    const aboutRes = await this.fetchImpl('https://www.googleapis.com/drive/v3/about?fields=user', {
       headers: { authorization: `Bearer ${tokenJson.access_token}` },
     });
-    if (!userRes.ok) throw new Error('google_oauth_userinfo_failed');
-    const user = (await userRes.json()) as { sub: string; email: string };
+    if (!aboutRes.ok) throw new Error('google_oauth_about_failed');
+    const aboutJson = (await aboutRes.json()) as {
+      user: { permissionId: string; emailAddress: string };
+    };
     return {
       refreshToken: tokenJson.refresh_token,
       accessToken: tokenJson.access_token,
       expiresAt: Date.now() + tokenJson.expires_in * 1000,
-      googleUserId: user.sub,
-      googleEmail: user.email,
+      googleUserId: aboutJson.user.permissionId,
+      googleEmail: aboutJson.user.emailAddress,
       scope: tokenJson.scope,
     };
   }

--- a/cspell.json
+++ b/cspell.json
@@ -490,7 +490,9 @@
     "wordprocessingml",
     "Gotenberg",
     "gotenberg",
-    "unwired"
+    "unwired",
+    "KARN",
+    "KREG"
   ],
   "ignoreRegExpList": [
     "Base64",


### PR DESCRIPTION
## Summary

- Live prod incident 2026-05-04: clicking **Connect Google Drive** on `/settings/integrations` returned `{"error":"internal_error"}` (HTTP 500)
- Root cause: `FetchGoogleOAuthClient.exchangeCode` called `https://www.googleapis.com/oauth2/v3/userinfo`, which requires `openid email` scopes — we only request `drive.file` per CLAUDE.md scope-minimization contract → Google returned 403 → `google_oauth_userinfo_failed` thrown → 500
- Fix: switch identity lookup to `https://www.googleapis.com/drive/v3/about?fields=user` (reachable under `drive.file` alone, returns `permissionId` + `emailAddress`)
- Adds first real-fetch regression suite (`google-oauth.client.spec.ts`) — the bug never tripped CI because every existing spec mocked the OAuthClient interface

## Why this fix (not broaden scope)

CLAUDE.md gdrive section pins `drive.file` and forbids broadening. `drive/v3/about?fields=user` returns the identifying fields we persist:
- `user.permissionId` → `gdrive_accounts.google_user_id` (= what userinfo's `sub` provided)
- `user.emailAddress` → `gdrive_accounts.google_email`

## Test plan

- [x] 4 new tests in `google-oauth.client.spec.ts` (RED → GREEN):
  1. URL pin: hits `drive/v3/about?fields=user`, asserts `userinfo` URL never appears (catches future scope-broaden slips)
  2. Field mapping: `about.user.{permissionId,emailAddress}` → `{googleUserId,googleEmail}`
  3. Bearer auth on the about call
  4. Throws `google_oauth_about_failed` on non-2xx
- [x] `pnpm --filter api test` — 868/868 pass (no regression in gdrive.service or callback handler)
- [x] `pnpm -r typecheck` clean
- [x] `pnpm -r lint` clean
- [ ] Post-deploy: re-click Connect on prod → verify `gdrive_accounts` row appears + integrations page renders connected state

🤖 Generated with [Claude Code](https://claude.com/claude-code)