### PR TITLE
fix(gdrive): close OAuth popup + refresh parent on consent (Bug F)

### DIFF
--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
@@ -31,6 +31,13 @@ describe('IntegrationsPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     openSpy.mockReset();
+    // Reset OAuth-popup-bridge mocks between tests so a popup-mode case
+    // doesn't leak into the next render.
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
   });
 
   it('renders the breadcrumb + page title (no SettingsLayout / left rail)', async () => {
@@ -209,6 +216,144 @@ describe('IntegrationsPage', () => {
     // Both buttons usable for retry/back-out.
     expect(within(dialog).getByRole('button', { name: /^disconnect$/i })).not.toBeDisabled();
     expect(within(dialog).getByRole('button', { name: /cancel/i })).not.toBeDisabled();
+  });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Bug F (Phase 6.A iter-2 PROD, 2026-05-04). After the userinfo→about
+  // fix shipped (PR #132), the OAuth round-trip succeeds at the API but
+  // the popup never closes and the parent tab never refreshes — the
+  // user has to manually close the popup and reload /settings/integrations
+  // to see the connected row. The fix is a postMessage handshake:
+  //   - popup lands on /settings/integrations?connected=1, posts
+  //     { type: 'gdrive-oauth-complete' } to window.opener (same-origin
+  //     SPA), then window.close()
+  //   - parent listens for that message + invalidates the accounts query
+  //   - same-tab fallback (no opener — popup blocker collapsed it into
+  //     the parent tab) strips ?connected=1 + invalidates inline
+  // ────────────────────────────────────────────────────────────────────
+
+  it('popup mode: posts gdrive-oauth-complete to opener and closes the window', async () => {
+    const postMessageSpy = vi.fn();
+    const closeSpy = vi.fn();
+    const fakeOpener = { postMessage: postMessageSpy, closed: false } as unknown as Window;
+    Object.defineProperty(window, 'opener', {
+      value: fakeOpener,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'close', {
+      value: closeSpy,
+      writable: true,
+      configurable: true,
+    });
+    mockedGet.mockResolvedValue({ data: [], status: 200 });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/settings/integrations?connected=1']}>
+        <IntegrationsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: 'gdrive-oauth-complete' },
+        window.location.origin,
+      );
+    });
+    await waitFor(() => expect(closeSpy).toHaveBeenCalled());
+  });
+
+  it('same-tab fallback (no opener + ?connected=1): refetches accounts so the row appears', async () => {
+    let getCallCount = 0;
+    mockedGet.mockImplementation((url: string) => {
+      if (url === '/integrations/gdrive/accounts') {
+        getCallCount += 1;
+        if (getCallCount === 1) {
+          return Promise.resolve({ data: [], status: 200 });
+        }
+        return Promise.resolve({
+          data: [
+            {
+              id: 'acc-1',
+              email: 'eliran@example.com',
+              connectedAt: '2026-05-04T10:00:00Z',
+              lastUsedAt: null,
+            },
+          ],
+          status: 200,
+        });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/settings/integrations?connected=1']}>
+        <IntegrationsPage />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('eliran@example.com')).toBeInTheDocument();
+    expect(getCallCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('parent: same-origin gdrive-oauth-complete message invalidates the accounts query', async () => {
+    let getCallCount = 0;
+    mockedGet.mockImplementation((url: string) => {
+      if (url === '/integrations/gdrive/accounts') {
+        getCallCount += 1;
+        if (getCallCount === 1) {
+          return Promise.resolve({ data: [], status: 200 });
+        }
+        return Promise.resolve({
+          data: [
+            {
+              id: 'acc-1',
+              email: 'eliran@example.com',
+              connectedAt: '2026-05-04T10:00:00Z',
+              lastUsedAt: null,
+            },
+          ],
+          status: 200,
+        });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+    renderPage();
+    await screen.findByRole('button', { name: /connect google drive/i });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'gdrive-oauth-complete' },
+        origin: window.location.origin,
+      }),
+    );
+
+    expect(await screen.findByText('eliran@example.com')).toBeInTheDocument();
+  });
+
+  it('parent: ignores oauth-complete messages from a foreign origin (CSRF defence)', async () => {
+    let getCallCount = 0;
+    mockedGet.mockImplementation((url: string) => {
+      if (url === '/integrations/gdrive/accounts') {
+        getCallCount += 1;
+        return Promise.resolve({ data: [], status: 200 });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+    renderPage();
+    await screen.findByRole('button', { name: /connect google drive/i });
+    const initialCount = getCallCount;
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'gdrive-oauth-complete' },
+        origin: 'https://evil.example.com',
+      }),
+    );
+
+    // Wait one tick so any handler would have fired.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(getCallCount).toBe(initialCount);
   });
 
   it('confirming Disconnect calls the delete mutation with the account id', async () => {

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   Link as LinkIcon,
   ChevronRight,
@@ -21,6 +22,8 @@ import {
   useGDriveAccounts,
   useConnectGDrive,
   useDisconnectGDrive,
+  useGDriveOAuthCallbackBridge,
+  useGDriveOAuthMessageListener,
   type GDriveAccount,
 } from './useGDriveAccounts';
 import { DisconnectModal } from './DisconnectModal';
@@ -483,6 +486,17 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
  * page still renders cleanly in dev when the flag is off.
  */
 export function IntegrationsPage() {
+  const [searchParams] = useSearchParams();
+  const isCallbackReturn = searchParams.has('connected');
+
+  // Bug F (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback popup
+  // lands here with `?connected=1`. Bridge it back to the opener +
+  // close the popup; in same-tab fallback (popup blocker), refresh
+  // accounts inline. The companion listener wires the parent tab so
+  // the connected row appears the moment the popup posts back.
+  const isOAuthPopupBridge = useGDriveOAuthCallbackBridge(isCallbackReturn);
+  useGDriveOAuthMessageListener();
+
   const accountsQuery = useGDriveAccounts();
   const connect = useConnectGDrive();
   const disconnect = useDisconnectGDrive();
@@ -533,6 +547,17 @@ export function IntegrationsPage() {
   const disconnectErrorMessage = disconnect.error
     ? "We couldn't disconnect that account. Please try again."
     : null;
+
+  // Popup-bridge mode: don't render the integrations UI — the bridge
+  // effect is firing window.close() this tick. Show a tiny ack so the
+  // popup doesn't briefly flash the empty state before closing.
+  if (isOAuthPopupBridge) {
+    return (
+      <Page aria-live="polite">
+        <Subtitle>Connection successful — closing this window.</Subtitle>
+      </Page>
+    );
+  }
 
   return (
     <Page>

--- a/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
+++ b/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
@@ -1,5 +1,23 @@
+import { useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient, type ApiError } from '@/lib/api/apiClient';
+
+/**
+ * Postmessage envelope sent by the OAuth-callback popup back to its
+ * opener (the SPA tab that triggered the connect click). Same-origin
+ * only — the listener cross-checks `event.origin` against the SPA's
+ * own origin so a foreign tab cannot poke the parent into refetching.
+ */
+export const GDRIVE_OAUTH_COMPLETE_MESSAGE = 'gdrive-oauth-complete' as const;
+type GdriveOAuthCompleteMessage = { readonly type: typeof GDRIVE_OAUTH_COMPLETE_MESSAGE };
+
+function isOAuthCompleteMessage(data: unknown): data is GdriveOAuthCompleteMessage {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    (data as { type?: unknown }).type === GDRIVE_OAUTH_COMPLETE_MESSAGE
+  );
+}
 
 /**
  * View model for a connected Google Drive account, mirroring the API
@@ -62,6 +80,76 @@ export function useConnectGDrive() {
       window.open(res.data.url, 'gdrive-oauth', POPUP_FEATURES);
     },
   });
+}
+
+/**
+ * Bridge effect for the OAuth-callback popup landing page. The API
+ * redirects the popup to `/settings/integrations?connected=1` after a
+ * successful token exchange. This hook detects that landing and either:
+ *   - Popup mode: postMessage `gdrive-oauth-complete` back to the
+ *     opener (same-origin SPA tab) so the parent invalidates its
+ *     accounts query, then `window.close()` the popup.
+ *   - Same-tab fallback (no opener — popup-blocker collapsed it into
+ *     the parent tab): invalidate the accounts query inline.
+ *
+ * Returns a flag the page can use to render a tiny "Closing…" surface
+ * so the popup doesn't briefly flash the full integrations UI before
+ * dying. Bug F (Phase 6.A iter-2 PROD, 2026-05-04).
+ */
+export function useGDriveOAuthCallbackBridge(isCallbackReturn: boolean): boolean {
+  const qc = useQueryClient();
+  const opener = typeof window !== 'undefined' ? window.opener : null;
+  const isPopupBridge = isCallbackReturn && Boolean(opener) && opener !== window;
+  useEffect(() => {
+    if (!isCallbackReturn) return;
+    if (opener && opener !== window) {
+      try {
+        (opener as Window).postMessage(
+          { type: GDRIVE_OAUTH_COMPLETE_MESSAGE },
+          window.location.origin,
+        );
+      } catch {
+        // postMessage on a same-origin opener should not throw, but if
+        // the parent has navigated away the call is a no-op — fall
+        // through to window.close() so the popup still goes away.
+      }
+      window.close();
+      return;
+    }
+    // Same-tab fallback: popup blocker collapsed the popup into the
+    // parent tab, so we land on /settings/integrations?connected=1
+    // inline. We can't rely on window.postMessage-to-self in every
+    // environment (jsdom test runner drops the origin), so invalidate
+    // the accounts query directly. Defer with a macrotask
+    // (setTimeout 0) so the initial fetch from useGDriveAccounts has
+    // settled before the invalidate fires — invalidate during an
+    // in-flight fetch is deduped, leaving the empty list visible.
+    const timer = setTimeout(() => {
+      void qc.invalidateQueries({ queryKey: GDRIVE_ACCOUNTS_KEY });
+    }, 0);
+    return () => clearTimeout(timer);
+  }, [isCallbackReturn, opener, qc]);
+  return isPopupBridge;
+}
+
+/**
+ * Companion listener for the parent SPA tab. Subscribes to `message`
+ * events and, when a same-origin `gdrive-oauth-complete` arrives,
+ * invalidates the accounts query so the connected row appears without
+ * a reload. Pairs with `useGDriveOAuthCallbackBridge` running inside
+ * the popup.
+ */
+export function useGDriveOAuthMessageListener(): void {
+  const qc = useQueryClient();
+  useEffect(() => {
+    function handler(event: MessageEvent): void {
+      if (event.origin !== window.location.origin) return;
+      if (!isOAuthCompleteMessage(event.data)) return;
+      void qc.invalidateQueries({ queryKey: GDRIVE_ACCOUNTS_KEY });
+    }
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [qc]);
 }
 
 /**


### PR DESCRIPTION
## Summary

After Bug E shipped (PR #132), the OAuth round-trip works at the API
level — but the UX hit a follow-on bug in production: the consent
popup stayed open after redirect, and the parent SPA tab never
refetched the accounts query, so the user had to manually close the
popup and reload to see the connected row.

This PR adds a postMessage handshake between the popup and its
opener, plus a same-tab fallback for popup-blocker scenarios.

## Changes

**`useGDriveAccounts.ts`** — two new hooks:
- `useGDriveOAuthCallbackBridge(isCallbackReturn)` — runs inside the
  popup. Posts `gdrive-oauth-complete` to the same-origin opener,
  then `window.close()`. Same-tab fallback (no opener) defers an
  `invalidateQueries` via `setTimeout(0)` so the initial fetch
  settles before the refetch fires.
- `useGDriveOAuthMessageListener()` — runs in the parent tab.
  Origin-pinned to `window.location.origin` (CSRF defence).

**`IntegrationsPage.tsx`** — wires both hooks at top level (rule 2.2)
and renders a tiny "Connection successful — closing this window."
surface when in popup-bridge mode so the popup doesn't briefly flash
the empty integrations UI before `window.close()` fires.

## Test plan

- [x] vitest scoped: `IntegrationsPage.test.tsx` 13/13 pass (4 new RED → GREEN cases for Bug F)
- [x] vitest full: `apps/web` 1393/1393 pass
- [x] typecheck ✓ / lint ✓
- [x] React PR review skill: APPROVED — no MUST-FIX, no SHOULD-FIX
- [ ] Live walk on prod: connect Google account → popup auto-closes → connected row appears in parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)