### PR TITLE
fix(web,api): mount Drive OAuth bridge OUTSIDE AppShell to bypass /m/send redirect (Bug G)

### DIFF
--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -207,12 +207,16 @@ describe('GDriveController', () => {
     ).rejects.toMatchObject({ message: expect.stringContaining('oauth-declined') });
   });
 
-  it('GET /oauth/callback persists an account row and redirects to /settings/integrations', async () => {
+  it('GET /oauth/callback persists an account row and redirects to the popup-bridge route', async () => {
+    // Bug G (Phase 6.A iter-2 PROD, 2026-05-04): redirect target is the
+    // dedicated `/oauth/gdrive/callback` bridge (mounted OUTSIDE
+    // <AppShell />) so the popup is not mobile-redirected to /m/send
+    // before its postMessage + window.close() effect can run.
     const { ctrl, state, repo } = makeController();
     const started = state.start('user-1');
     const res = fakeRes();
     await ctrl.oauthCallback('the-code', started.state, undefined, res);
-    expect(res.redirectedTo).toMatch(/\/settings\/integrations/);
+    expect(res.redirectedTo).toMatch(/\/oauth\/gdrive\/callback\?connected=1/);
     const accounts = await repo.listForUser('user-1');
     expect(accounts).toHaveLength(1);
     expect(accounts[0]?.googleEmail).toBe('user@example.com');

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -142,7 +142,14 @@ export class GDriveController {
       code,
       codeVerifier: entry.codeVerifier,
     });
-    res.redirect(`${this.config.appPublicUrl}/settings/integrations?connected=1`);
+    // Bug G (2026-05-04): redirect to the dedicated OAuth callback
+    // route mounted OUTSIDE <AppShell />. Landing on
+    // /settings/integrations directly tripped AppShell's mobile-redirect
+    // rule (≤ 640 px → /m/send) on the 480 × 720 popup, so the popup
+    // never closed. The new bridge page handles popup mode (postMessage
+    // back to the opener + window.close()) and same-tab fallback
+    // (redirects back to /settings/integrations?connected=1).
+    res.redirect(`${this.config.appPublicUrl}/oauth/gdrive/callback?connected=1`);
   }
 
   @Get('accounts')

--- a/apps/landing/_worker.js
+++ b/apps/landing/_worker.js
@@ -28,6 +28,10 @@ const SPA_EXACT = new Set([
 // 2026-05-02 outage where missing prefixes silently served the landing
 // HTML instead of rewriting to the SPA shell. Pinned by
 // `apps/web/src/routes/settings/integrations/_worker-spa-routing.test.ts`.
+// `/oauth/` was added 2026-05-04 with Bug G (Drive OAuth popup-bridge
+// route mounted outside AppShell to bypass the mobile-redirect rule).
+// Pinned by
+// `apps/web/src/pages/GDriveOAuthCallbackPage/_worker-spa-routing.test.ts`.
 const SPA_PREFIXES = [
   '/auth/',
   '/debug/',
@@ -37,6 +41,7 @@ const SPA_PREFIXES = [
   '/templates/',
   '/m/',
   '/settings/',
+  '/oauth/',
 ];
 
 function isSpaRoute(pathname) {

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -17,6 +17,7 @@ import { SignUpPage } from './pages/SignUpPage';
 import { ForgotPasswordPage } from './pages/ForgotPasswordPage';
 import { CheckEmailPage } from './pages/CheckEmailPage';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
+import { GDriveOAuthCallbackPage } from './pages/GDriveOAuthCallbackPage';
 import { RequireSignerSession } from './features/signing/RequireSignerSession';
 import { SigningErrorBoundary } from './features/signing/SigningErrorBoundary';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -120,6 +121,13 @@ export function AppRoutes() {
 
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
       <Route path="/debug/auth" element={<DebugAuthPage />} />
+
+      {/* Drive OAuth popup-bridge — MUST live OUTSIDE <AppShell /> so the
+          mobile-redirect rule (≤ 640 px → /m/send) does NOT fire on the
+          480 × 720 popup before the postMessage + close effect can run.
+          Bug G (Phase 6.A iter-2 PROD, 2026-05-04). Pinned by
+          apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx. */}
+      <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
 
       {/* Public verify surface. Anyone with a 13-char short_code can pull
           the envelope's metadata + audit timeline. No auth gate. */}

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import type * as AuthProviderModule from '../../providers/AuthProvider';
+
+// Bug G (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback popup
+// is opened at 480 × 720 px. Mounting `/oauth/gdrive/callback` INSIDE
+// AppShell would re-trigger the mobile-redirect (≤ 640 px → /m/send)
+// and the popup would never close. This test pins the routing contract:
+// at a mobile viewport, hitting `/oauth/gdrive/callback` MUST render
+// the GDriveOAuthCallbackPage (no /m/send redirect).
+
+vi.mock('../../routes/settings/integrations/IntegrationsPage', () => ({
+  IntegrationsPage: () => <h1>integrations stub</h1>,
+}));
+
+let mobileViewport = true;
+vi.mock('../../hooks/useIsMobileViewport', () => ({
+  useIsMobileViewport: () => mobileViewport,
+  readIsMobileViewport: () => mobileViewport,
+  MOBILE_VIEWPORT_QUERY: '(max-width: 640px)',
+}));
+
+vi.mock('../../providers/AuthProvider', async () => {
+  const actual = await vi.importActual<typeof AuthProviderModule>('../../providers/AuthProvider');
+  return {
+    ...actual,
+    useAuth: () => ({
+      session: { access_token: 'x' },
+      user: { id: 'u1', email: 'e@example.com', name: 'E' },
+      guest: false,
+      loading: false,
+      signInWithPassword: vi.fn(),
+      signUpWithPassword: vi.fn(),
+      signInWithGoogle: vi.fn(),
+      resetPassword: vi.fn(),
+      signOut: vi.fn(),
+      enterGuestMode: vi.fn(),
+      exitGuestMode: vi.fn(),
+    }),
+  };
+});
+
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { AppRoutes } from '../../AppRoutes';
+
+describe('AppRoutes /oauth/gdrive/callback (Bug G — bypass mobile redirect)', () => {
+  beforeEach(() => {
+    mobileViewport = true;
+    // Popup mode: opener is set, so the bridge renders the "Connecting
+    // Drive…" surface (and would postMessage + close — both no-ops on
+    // window mocks below). The "Connecting Drive…" marker is the proof
+    // we did NOT mobile-redirect to /m/send.
+    Object.defineProperty(window, 'opener', {
+      value: { postMessage: vi.fn() } as unknown as Window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(window, 'close', {
+      value: vi.fn(),
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('renders the bridge page at mobile viewport (route is OUTSIDE AppShell)', async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <AppRoutes />
+      </MemoryRouter>,
+    );
+    // Pin: the bridge surface renders. If the route were inside AppShell,
+    // the mobile-viewport guard would have replaced this with the
+    // MobileSendPage at /m/send and the marker text below would be absent.
+    expect(await screen.findByText(/connecting drive/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { GDriveOAuthCallbackPage } from './GDriveOAuthCallbackPage';
+
+// Bug G (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback popup
+// is opened at 480 × 720 px. Landing on `/settings/integrations?connected=1`
+// triggered AppShell's mobile-redirect rule (≤ 640 px → /m/send) before
+// the popup-bridge effect could fire, so the popup ended up at /m/send
+// and never closed. Fix: dedicated `/oauth/gdrive/callback` route mounted
+// OUTSIDE AppShell. This file pins the component contract; the routing
+// pin lives in AppRoutes.gdrive-oauth-callback.test.tsx.
+
+describe('GDriveOAuthCallbackPage (Bug G)', () => {
+  let originalOpener: Window | null;
+  let postMessageSpy: ReturnType<typeof vi.fn>;
+  let closeSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    originalOpener = window.opener;
+    postMessageSpy = vi.fn();
+    closeSpy = vi.fn();
+    Object.defineProperty(window, 'close', {
+      value: closeSpy,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'opener', {
+      value: originalOpener,
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  it('popup mode: posts gdrive-oauth-complete to opener and closes the window', async () => {
+    const fakeOpener = { postMessage: postMessageSpy } as unknown as Window;
+    Object.defineProperty(window, 'opener', {
+      value: fakeOpener,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        { type: 'gdrive-oauth-complete' },
+        window.location.origin,
+      );
+    });
+    await waitFor(() => expect(closeSpy).toHaveBeenCalled());
+  });
+
+  it('popup mode: shows a small "Connecting Drive…" surface so the popup does not flash blank', async () => {
+    const fakeOpener = { postMessage: postMessageSpy } as unknown as Window;
+    Object.defineProperty(window, 'opener', {
+      value: fakeOpener,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/connecting drive/i)).toBeInTheDocument();
+  });
+
+  it('same-tab fallback (no opener): redirects to /settings/integrations?connected=1', async () => {
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+          <Route path="/settings/integrations" element={<h1>integrations stub</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: /integrations stub/i })).toBeInTheDocument();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
@@ -1,0 +1,65 @@
+import { useEffect, type ReactElement } from 'react';
+import { Navigate, useSearchParams } from 'react-router-dom';
+import { GDRIVE_OAUTH_COMPLETE_MESSAGE } from '@/routes/settings/integrations/useGDriveAccounts';
+
+/**
+ * Dedicated OAuth-callback bridge for the Google Drive popup. Mounted
+ * at `/oauth/gdrive/callback` OUTSIDE `<AppShell />` so the AppShell
+ * mobile-redirect rule (≤ 640 px → /m/send) does NOT fire — the popup
+ * is opened at 480 × 720 px and was getting redirected before the
+ * postMessage + close effect could run. Bug G (Phase 6.A iter-2 PROD,
+ * 2026-05-04). The canonical OAuth-popup pattern: dedicated callback
+ * route, postMessage to opener (same-origin), then window.close().
+ *
+ * Same-tab fallback (popup blocker collapsed the popup into the parent
+ * tab → no opener): redirect to /settings/integrations?connected=1 so
+ * the integrations page picks up the connected query param and
+ * invalidates the accounts query (handled by the existing bridge in
+ * useGDriveAccounts.ts).
+ */
+export function GDriveOAuthCallbackPage(): ReactElement {
+  const [params] = useSearchParams();
+  const opener = typeof window !== 'undefined' ? window.opener : null;
+  const isPopup = Boolean(opener) && opener !== window;
+
+  useEffect(() => {
+    if (!isPopup) return;
+    try {
+      (opener as Window).postMessage(
+        { type: GDRIVE_OAUTH_COMPLETE_MESSAGE },
+        window.location.origin,
+      );
+    } catch {
+      // Same-origin postMessage shouldn't throw; if the parent
+      // navigated away the call is a no-op. Either way, fall through
+      // to window.close() so the popup goes away.
+    }
+    window.close();
+  }, [isPopup, opener]);
+
+  if (!isPopup) {
+    const connected = params.get('connected');
+    const target = connected
+      ? `/settings/integrations?connected=${encodeURIComponent(connected)}`
+      : '/settings/integrations';
+    return <Navigate to={target} replace />;
+  }
+
+  // Tiny surface so the popup doesn't flash blank between landing and
+  // window.close(). Inline styles to avoid pulling in the styled
+  // components weight for a sub-second render.
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        minHeight: '100vh',
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        color: '#1f2937',
+      }}
+    >
+      <p>Connecting Drive…</p>
+    </div>
+  );
+}

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/_worker-spa-routing.test.ts
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/_worker-spa-routing.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// Bug G (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback popup
+// lands at `/oauth/gdrive/callback?connected=1`. If `/oauth/` is missing
+// from `apps/landing/_worker.js` SPA_PREFIXES, CF Pages serves the
+// landing shell instead of rewriting to /app — same outage class as
+// 2026-05-02 (`/m/`, `/templates`). This pin prevents that regression.
+
+const WORKER_PATH = resolve(__dirname, '../../../../landing/_worker.js');
+
+describe('apps/landing/_worker.js — /oauth/ SPA prefix coverage (Bug G)', () => {
+  const source = readFileSync(WORKER_PATH, 'utf8');
+
+  it('includes /oauth/ in SPA_PREFIXES so /oauth/gdrive/callback is rewritten to /app', () => {
+    expect(source).toMatch(/SPA_PREFIXES\s*=\s*\[/);
+    expect(source).toContain("'/oauth/'");
+  });
+});

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/index.ts
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/index.ts
@@ -1,0 +1,1 @@
+export { GDriveOAuthCallbackPage } from './GDriveOAuthCallbackPage';


### PR DESCRIPTION
## Summary

Bug G (Phase 6.A iter-2 PROD, 2026-05-04). The Drive OAuth popup is opened at 480 × 720 px. Returning to `/settings/integrations?connected=1` tripped AppShell's mobile-redirect rule (≤ 640 px → `/m/send`) BEFORE the popup-bridge effect (postMessage to opener + `window.close()`) could fire — popup ended up at `/m/send` and never closed; parent never refreshed.

**Fix** (canonical OAuth-popup pattern from Auth0 / Google / Stripe docs): dedicated `/oauth/gdrive/callback` route mounted **OUTSIDE** `<AppShell />`.

- **Popup mode** (`window.opener` present): `postMessage({type:'gdrive-oauth-complete'}, origin)` → `window.close()`. Existing `useGDriveOAuthMessageListener` on the parent invalidates the accounts query → connected row appears with no hard refresh.
- **Same-tab fallback** (popup-blocker collapsed popup into parent → no opener): `<Navigate to="/settings/integrations?connected=1" replace />` so the existing in-page bridge handles it.

Also:
- `apps/landing/_worker.js` — add `/oauth/` to `SPA_PREFIXES` (red-flag row 1; same outage class as 2026-05-02 missing-prefix bug).
- `apps/api/.../gdrive.controller.ts` — redirect target flips from `/settings/integrations?connected=1` → `/oauth/gdrive/callback?connected=1`.

## Test plan

- [x] `pnpm --filter web vitest run src/pages/GDriveOAuthCallbackPage` — 5/5
- [x] `pnpm --filter web vitest run` — 1398/1398
- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint` ✓
- [x] `pnpm --filter api jest src/integrations/gdrive/gdrive.controller.spec.ts` — 18/18
- [ ] Post-deploy: prod popup retry → popup closes + connected row appears with no refresh

## Pinned by

- `apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx` (component contract)
- `apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx` (route OUTSIDE AppShell)
- `apps/web/src/pages/GDriveOAuthCallbackPage/_worker-spa-routing.test.ts` (`/oauth/` in SPA_PREFIXES)
- `apps/api/.../gdrive.controller.spec.ts` (redirect target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)