### PR TITLE
fix(gdrive): make completeOAuth idempotent on (user, googleUser) — Bug H

### DIFF
--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -13,14 +13,55 @@ class FakeRepo implements GDriveRepository {
   rows = new Map<string, GDriveAccount>();
   async findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null> {
     const r = this.rows.get(id);
-    return r && r.userId === userId ? r : null;
+    return r && r.userId === userId && !r.deletedAt ? r : null;
   }
   async listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
     return [...this.rows.values()].filter((r) => r.userId === userId && !r.deletedAt);
   }
   async insert(row: GDriveAccount): Promise<GDriveAccount> {
+    // Mirrors the prod partial UNIQUE index from migration 0013 — see
+    // gdrive.service.spec.ts FakeRepo for the rationale.
+    for (const r of this.rows.values()) {
+      if (!r.deletedAt && r.userId === row.userId && r.googleUserId === row.googleUserId) {
+        const e = new Error(
+          'duplicate key value violates unique constraint "gdrive_accounts_user_google_uniq"',
+        ) as Error & { code?: string };
+        e.code = '23505';
+        throw e;
+      }
+    }
     this.rows.set(row.id, row);
     return row;
+  }
+  async findActiveByUserAndGoogleUser(
+    userId: string,
+    googleUserId: string,
+  ): Promise<GDriveAccount | null> {
+    return (
+      [...this.rows.values()].find(
+        (r) => r.userId === userId && r.googleUserId === googleUserId && !r.deletedAt,
+      ) ?? null
+    );
+  }
+  async replaceToken(args: {
+    id: string;
+    refreshTokenCiphertext: Buffer;
+    refreshTokenKmsKeyArn: string;
+    scope: string;
+    googleEmail: string;
+  }): Promise<GDriveAccount> {
+    const r = this.rows.get(args.id);
+    if (!r) throw new Error('replaceToken: row not found');
+    const next: GDriveAccount = {
+      ...r,
+      refreshTokenCiphertext: args.refreshTokenCiphertext,
+      refreshTokenKmsKeyArn: args.refreshTokenKmsKeyArn,
+      scope: args.scope,
+      googleEmail: args.googleEmail,
+      lastUsedAt: null,
+    };
+    this.rows.set(args.id, next);
+    return next;
   }
   async softDelete(id: string, userId: string): Promise<boolean> {
     const r = this.rows.get(id);

--- a/apps/api/src/integrations/gdrive/gdrive.repository.pg.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.repository.pg.ts
@@ -66,6 +66,45 @@ export class GDrivePgRepository implements GDriveRepository {
     return toDomain(inserted);
   }
 
+  async findActiveByUserAndGoogleUser(
+    userId: string,
+    googleUserId: string,
+  ): Promise<GDriveAccount | null> {
+    const r = await this.db
+      .selectFrom('gdrive_accounts')
+      .selectAll()
+      .where('user_id', '=', userId)
+      .where('google_user_id', '=', googleUserId)
+      .where('deleted_at', 'is', null)
+      .executeTakeFirst();
+    return r ? toDomain(r) : null;
+  }
+
+  async replaceToken(args: {
+    id: string;
+    refreshTokenCiphertext: Buffer;
+    refreshTokenKmsKeyArn: string;
+    scope: string;
+    googleEmail: string;
+  }): Promise<GDriveAccount> {
+    // `connected_at` is intentionally NOT bumped — it records the first
+    // OAuth grant for this (user, googleUser) pair. Reconnects rotate
+    // the token but preserve the original connection date for audit.
+    const updated = await this.db
+      .updateTable('gdrive_accounts')
+      .set({
+        refresh_token_ciphertext: args.refreshTokenCiphertext,
+        refresh_token_kms_key_arn: args.refreshTokenKmsKeyArn,
+        scope: args.scope,
+        google_email: args.googleEmail,
+        last_used_at: null,
+      })
+      .where('id', '=', args.id)
+      .returningAll()
+      .executeTakeFirstOrThrow();
+    return toDomain(updated);
+  }
+
   async softDelete(id: string, userId: string): Promise<boolean> {
     const r = await this.db
       .updateTable('gdrive_accounts')

--- a/apps/api/src/integrations/gdrive/gdrive.repository.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.repository.ts
@@ -27,6 +27,28 @@ export interface GDriveRepository {
   findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null>;
   listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>>;
   insert(row: GDriveAccount): Promise<GDriveAccount>;
+  /**
+   * Look up an active (non-soft-deleted) row by (userId, googleUserId).
+   * Used by `completeOAuth` to make reconnect idempotent — the partial
+   * UNIQUE index `gdrive_accounts_user_google_uniq` would otherwise
+   * fire a 23505 on the second insert (Bug H).
+   */
+  findActiveByUserAndGoogleUser(
+    userId: string,
+    googleUserId: string,
+  ): Promise<GDriveAccount | null>;
+  /**
+   * Rotate an existing row's encrypted refresh token + scope + email
+   * in place. The (userId, googleUserId) pair is immutable for the row;
+   * this is the idempotent counterpart to insert.
+   */
+  replaceToken(args: {
+    id: string;
+    refreshTokenCiphertext: Buffer;
+    refreshTokenKmsKeyArn: string;
+    scope: string;
+    googleEmail: string;
+  }): Promise<GDriveAccount>;
   softDelete(id: string, userId: string): Promise<boolean>;
   touchLastUsed(id: string): Promise<void>;
 }

--- a/apps/api/src/integrations/gdrive/gdrive.service.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.service.spec.ts
@@ -7,14 +7,61 @@ class FakeRepo implements GDriveRepository {
   rows = new Map<string, GDriveAccount>();
   async findByIdForUser(id: string, userId: string): Promise<GDriveAccount | null> {
     const r = this.rows.get(id);
-    return r && r.userId === userId ? r : null;
+    return r && r.userId === userId && !r.deletedAt ? r : null;
   }
   async listForUser(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
-    return [...this.rows.values()].filter((r) => r.userId === userId);
+    return [...this.rows.values()].filter((r) => r.userId === userId && !r.deletedAt);
   }
   async insert(row: GDriveAccount): Promise<GDriveAccount> {
+    // Enforce the partial UNIQUE index from migration 0013_gdrive_accounts.sql:
+    //   create unique index gdrive_accounts_user_google_uniq
+    //     on gdrive_accounts (user_id, google_user_id) where deleted_at is null;
+    // Without this, the fake silently accepts duplicates and Bug H is
+    // unreproducible in unit tests. Match the real Postgres error so the
+    // service layer can branch on it (or, post-fix, avoid hitting it).
+    for (const r of this.rows.values()) {
+      if (!r.deletedAt && r.userId === row.userId && r.googleUserId === row.googleUserId) {
+        const e = new Error(
+          'duplicate key value violates unique constraint "gdrive_accounts_user_google_uniq"',
+        ) as Error & { code?: string };
+        e.code = '23505';
+        throw e;
+      }
+    }
     this.rows.set(row.id, row);
     return row;
+  }
+  async findActiveByUserAndGoogleUser(
+    userId: string,
+    googleUserId: string,
+  ): Promise<GDriveAccount | null> {
+    return (
+      [...this.rows.values()].find(
+        (r) => r.userId === userId && r.googleUserId === googleUserId && !r.deletedAt,
+      ) ?? null
+    );
+  }
+  async replaceToken(args: {
+    id: string;
+    refreshTokenCiphertext: Buffer;
+    refreshTokenKmsKeyArn: string;
+    scope: string;
+    googleEmail: string;
+  }): Promise<GDriveAccount> {
+    const r = this.rows.get(args.id);
+    if (!r) throw new Error('replaceToken: row not found');
+    // Preserve the original connectedAt — it's immutable in the real
+    // schema (ColumnType<…, never>) and represents the first OAuth grant.
+    const next: GDriveAccount = {
+      ...r,
+      refreshTokenCiphertext: args.refreshTokenCiphertext,
+      refreshTokenKmsKeyArn: args.refreshTokenKmsKeyArn,
+      scope: args.scope,
+      googleEmail: args.googleEmail,
+      lastUsedAt: null,
+    };
+    this.rows.set(args.id, next);
+    return next;
   }
   async softDelete(id: string, _userId: string): Promise<boolean> {
     const r = this.rows.get(id);
@@ -43,9 +90,17 @@ class StubGoogleClient implements GoogleOAuthClient {
   refreshDelayMs = 0;
   refreshFailWith: 'invalid_grant' | null = null;
   abortObserved = false;
+  exchange = {
+    refreshToken: 'rt-from-google',
+    accessToken: 'at-from-google',
+    expiresAt: Date.now() + 3600_000,
+    googleUserId: 'g-1',
+    googleEmail: 'a@example.com',
+    scope: 'https://www.googleapis.com/auth/drive.file',
+  };
 
-  async exchangeCode(): Promise<never> {
-    throw new Error('not used in this spec');
+  async exchangeCode(): Promise<typeof this.exchange> {
+    return this.exchange;
   }
   async refreshAccessToken(
     _refreshToken: string,
@@ -155,5 +210,66 @@ describe('GDriveService', () => {
     await seedAccount(repo, kms, 'rt');
     await expect(svc.getAccessToken('acc-1', 'user-2')).rejects.toThrow();
     await expect(svc.getAccessToken('missing', 'user-1')).rejects.toThrow();
+  });
+
+  // Bug H (Phase 6.A iter-2 PROD, 2026-05-04). Connecting the same Google
+  // account twice for the same user fired the partial UNIQUE
+  //   gdrive_accounts (user_id, google_user_id) WHERE deleted_at IS NULL
+  // and surfaced as `internal_error` (500) on the API callback — popup
+  // never reached the bridge page, never closed. Fix: completeOAuth is
+  // idempotent — finds the existing active row, rotates the refresh
+  // token in place, returns the existing id.
+  describe('completeOAuth idempotency (Bug H)', () => {
+    it('reconnecting the same Google account reuses the existing row', async () => {
+      // First connect → row inserted.
+      google.exchange = { ...google.exchange, refreshToken: 'rt-1', googleUserId: 'g-1' };
+      const id1 = await svc.completeOAuth({
+        userId: 'u-1',
+        code: 'code-1',
+        codeVerifier: 'v-1',
+      });
+
+      // Second connect for the SAME (user, google) pair must NOT throw
+      // a duplicate-key error — it should land on the existing row.
+      google.exchange = { ...google.exchange, refreshToken: 'rt-2', googleUserId: 'g-1' };
+      const id2 = await svc.completeOAuth({
+        userId: 'u-1',
+        code: 'code-2',
+        codeVerifier: 'v-2',
+      });
+
+      expect(id2).toBe(id1);
+      const accs = await repo.listForUser('u-1');
+      expect(accs).toHaveLength(1);
+    });
+
+    it('reconnecting rotates the encrypted refresh token in place', async () => {
+      google.exchange = { ...google.exchange, refreshToken: 'rt-old', googleUserId: 'g-1' };
+      await svc.completeOAuth({ userId: 'u-1', code: 'code-1', codeVerifier: 'v-1' });
+
+      google.exchange = { ...google.exchange, refreshToken: 'rt-new', googleUserId: 'g-1' };
+      await svc.completeOAuth({ userId: 'u-1', code: 'code-2', codeVerifier: 'v-2' });
+
+      const [acc] = await repo.listForUser('u-1');
+      if (!acc) throw new Error('expected one account');
+      const decrypted = await kms.decrypt(acc.refreshTokenCiphertext, acc.refreshTokenKmsKeyArn);
+      expect(decrypted).toBe('rt-new');
+    });
+
+    it('different users connecting the same Google account each get their own row', async () => {
+      google.exchange = { ...google.exchange, refreshToken: 'rt-a', googleUserId: 'g-shared' };
+      const idA = await svc.completeOAuth({
+        userId: 'u-A',
+        code: 'code-A',
+        codeVerifier: 'v-A',
+      });
+      google.exchange = { ...google.exchange, refreshToken: 'rt-b', googleUserId: 'g-shared' };
+      const idB = await svc.completeOAuth({
+        userId: 'u-B',
+        code: 'code-B',
+        codeVerifier: 'v-B',
+      });
+      expect(idA).not.toBe(idB);
+    });
   });
 });

--- a/apps/api/src/integrations/gdrive/gdrive.service.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.service.ts
@@ -101,8 +101,15 @@ export class GDriveService {
 
   /**
    * Completes the OAuth dance: exchanges `code` for tokens, encrypts the
-   * refresh token via KMS envelope, and inserts a new `gdrive_accounts`
-   * row owned by `userId`. Returns the inserted row id.
+   * refresh token via KMS envelope, and persists a `gdrive_accounts` row
+   * owned by `userId`. Returns the row id.
+   *
+   * Idempotent on (userId, googleUserId): if an active row already exists
+   * for that pair, rotate its token in place and return its id. Without
+   * this short-circuit, the partial UNIQUE index
+   * `gdrive_accounts_user_google_uniq` (migration 0013) fires a Postgres
+   * 23505 on the second connect and the popup surfaces `internal_error`
+   * (Bug H, Phase 6.A iter-2 PROD, 2026-05-04).
    */
   async completeOAuth(args: {
     userId: string;
@@ -111,6 +118,23 @@ export class GDriveService {
   }): Promise<string> {
     const exchange = await this.google.exchangeCode(args.code, args.codeVerifier);
     const enc = await this.kms.encrypt(exchange.refreshToken);
+    const existing = await this.repo.findActiveByUserAndGoogleUser(
+      args.userId,
+      exchange.googleUserId,
+    );
+    if (existing) {
+      await this.repo.replaceToken({
+        id: existing.id,
+        refreshTokenCiphertext: enc.ciphertext,
+        refreshTokenKmsKeyArn: enc.kmsKeyArn,
+        scope: exchange.scope,
+        googleEmail: exchange.googleEmail,
+      });
+      // Drop any cached access token tied to the old refresh token so the
+      // next getAccessToken() pulls a fresh one.
+      this.cache.delete(existing.id);
+      return existing.id;
+    }
     const id = newUuid();
     await this.repo.insert({
       id,

--- a/apps/api/test/gdrive-conversion.e2e-spec.ts
+++ b/apps/api/test/gdrive-conversion.e2e-spec.ts
@@ -83,6 +83,36 @@ class InMemoryGDriveRepo implements GDriveRepository {
     this.rows.set(row.id, row);
     return row;
   }
+  async findActiveByUserAndGoogleUser(
+    userId: string,
+    googleUserId: string,
+  ): Promise<GDriveAccount | null> {
+    return (
+      [...this.rows.values()].find(
+        (r) => r.userId === userId && r.googleUserId === googleUserId && !r.deletedAt,
+      ) ?? null
+    );
+  }
+  async replaceToken(args: {
+    id: string;
+    refreshTokenCiphertext: Buffer;
+    refreshTokenKmsKeyArn: string;
+    scope: string;
+    googleEmail: string;
+  }): Promise<GDriveAccount> {
+    const r = this.rows.get(args.id);
+    if (!r) throw new Error('replaceToken: row not found');
+    const next: GDriveAccount = {
+      ...r,
+      refreshTokenCiphertext: args.refreshTokenCiphertext,
+      refreshTokenKmsKeyArn: args.refreshTokenKmsKeyArn,
+      scope: args.scope,
+      googleEmail: args.googleEmail,
+      lastUsedAt: null,
+    };
+    this.rows.set(args.id, next);
+    return next;
+  }
   async softDelete(id: string, userId: string): Promise<boolean> {
     const r = this.rows.get(id);
     if (!r || r.userId !== userId) return false;


### PR DESCRIPTION
## Summary

Bug H (Phase 6.A iter-2 PROD, 2026-05-04). Reconnecting the same Google
account fired the partial UNIQUE index `gdrive_accounts_user_google_uniq`
(migration 0013) and surfaced as the popup error
`{\"error\":\"internal_error\"}` — popup never reached the bridge page,
never closed.

- Add `findActiveByUserAndGoogleUser` + `replaceToken` to the
  `GDriveRepository` port; implement on `GDrivePgRepository` (Kysely).
- `GDriveService.completeOAuth` now: exchange → encrypt → look up
  active row → if present, `replaceToken` + invalidate cached access
  token + return existing id; else insert new row.
- `connected_at` preserved on rotate (it's `ColumnType<…, never>` and
  represents the first OAuth grant — honest audit semantics).

## Test plan (TDD Iron Law: RED → GREEN)

- [x] `FakeRepo.insert` in unit specs simulates the partial UNIQUE so
  the prod constraint is reproducible without Postgres.
- [x] 3 new specs under `completeOAuth idempotency (Bug H)`:
  - reconnecting reuses the existing row (id stable)
  - reconnecting rotates the encrypted refresh token in place
  - different users sharing a Google account each get their own row
- [x] `pnpm typecheck` ✓
- [x] `pnpm lint` ✓
- [x] `pnpm --filter api test` ✓ 871/871
- [x] `pnpm --filter web test` ✓ 1398/1398
- [ ] After merge + deploy: prod re-verify — user retries Connect; popup
  auto-closes; integrations row appears without refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)