### PR TITLE
fix(gdrive): disable api COOP + add BroadcastChannel popup signal (Bug I)

### DIFF
--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -2,9 +2,9 @@ import 'reflect-metadata';
 import { resolve } from 'node:path';
 import { NestFactory } from '@nestjs/core';
 import { Logger, ValidationPipe } from '@nestjs/common';
-import helmet from 'helmet';
 import { json, urlencoded } from 'express';
 import { AppModule } from './app.module';
+import { securityHeaders } from './security-headers';
 import { APP_ENV } from './config/config.module';
 import type { AppEnv } from './config/env.schema';
 
@@ -77,9 +77,9 @@ async function bootstrap() {
     maxAge: 600,
   });
 
-  // Security headers: Helmet defaults cover X-Content-Type-Options,
-  // Strict-Transport-Security, X-Frame-Options, Referrer-Policy, etc.
-  app.use(helmet());
+  // Security headers — see security-headers.ts for the rationale on
+  // disabling Cross-Origin-Opener-Policy (Bug I).
+  app.use(securityHeaders());
 
   // JSON / urlencoded body limits — file uploads use FileInterceptor with
   // their own multer limits, so 1mb here just bounds JSON payloads.

--- a/apps/api/src/security-headers.spec.ts
+++ b/apps/api/src/security-headers.spec.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import request from 'supertest';
+import { securityHeaders } from './security-headers';
+
+/**
+ * Bug I (Phase 6.A iter-2 PROD, 2026-05-04). Helmet's defaults set
+ *   Cross-Origin-Opener-Policy: same-origin
+ * which permanently severs `window.opener` for the Drive OAuth popup
+ * (web → api → web bridge): the cross-origin api response with
+ * `same-origin` puts the popup in a fresh browsing context group,
+ * and the severance survives the redirect back to the same-origin
+ * bridge route. The popup's bridge then sees opener=null, falls
+ * through to its same-tab fallback, and AppShell's mobile-viewport
+ * guard navigates the popup to /m/send.
+ *
+ * The api is JSON-only + one OAuth redirect — COOP gives no
+ * meaningful protection here, so we disable it.
+ */
+describe('securityHeaders()', () => {
+  it('does NOT set Cross-Origin-Opener-Policy: same-origin (would sever popup opener)', async () => {
+    const app = express();
+    app.use(securityHeaders());
+    app.get('/', (_req, res) => res.json({ ok: true }));
+    const res = await request(app).get('/');
+    // `same-origin` is the helmet default that we MUST override.
+    expect(res.headers['cross-origin-opener-policy']).not.toBe('same-origin');
+  });
+
+  it('still sets the other helmet protections (HSTS, X-Content-Type-Options, X-Frame-Options)', async () => {
+    const app = express();
+    app.use(securityHeaders());
+    app.get('/', (_req, res) => res.json({ ok: true }));
+    const res = await request(app).get('/');
+    expect(res.headers['strict-transport-security']).toBeDefined();
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+    expect(res.headers['x-frame-options']).toBe('SAMEORIGIN');
+  });
+});

--- a/apps/api/src/security-headers.ts
+++ b/apps/api/src/security-headers.ts
@@ -1,0 +1,29 @@
+import helmet from 'helmet';
+import type { RequestHandler } from 'express';
+
+/**
+ * Helmet middleware factory for the API.
+ *
+ * Why a factory: the helmet config is non-trivial (one explicit
+ * override) and we need to unit-test the resulting headers without
+ * importing `main.ts` (which calls `bootstrap()` at module load).
+ *
+ * Cross-Origin-Opener-Policy is explicitly disabled. Helmet's default
+ * is `same-origin`, which puts a cross-origin popup into a fresh
+ * browsing-context group and severs `window.opener` permanently — even
+ * after the popup later navigates back to the opener's origin. That
+ * breaks the Drive OAuth popup-bridge flow (web → api → web bridge),
+ * because the bridge component sees `window.opener === null` and falls
+ * through to its same-tab fallback.
+ *
+ * The API is JSON-only plus one OAuth redirect; COOP gives no
+ * meaningful protection here. The other helmet defaults (HSTS,
+ * nosniff, frameguard, referrer-policy, etc.) stay on.
+ *
+ * Bug I (Phase 6.A iter-2 PROD, 2026-05-04).
+ */
+export function securityHeaders(): RequestHandler {
+  return helmet({
+    crossOriginOpenerPolicy: false,
+  });
+}

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
@@ -47,10 +47,10 @@ import { AppRoutes } from '../../AppRoutes';
 describe('AppRoutes /oauth/gdrive/callback (Bug G — bypass mobile redirect)', () => {
   beforeEach(() => {
     mobileViewport = true;
-    // Popup mode: opener is set, so the bridge renders the "Connecting
-    // Drive…" surface (and would postMessage + close — both no-ops on
-    // window mocks below). The "Connecting Drive…" marker is the proof
-    // we did NOT mobile-redirect to /m/send.
+    // Popup mode: opener is set, so the bridge renders the "Drive
+    // connected" surface (and would postMessage + close — both no-ops
+    // on window mocks below). The marker text is the proof we did NOT
+    // mobile-redirect to /m/send.
     Object.defineProperty(window, 'opener', {
       value: { postMessage: vi.fn() } as unknown as Window,
       writable: true,
@@ -72,6 +72,6 @@ describe('AppRoutes /oauth/gdrive/callback (Bug G — bypass mobile redirect)', 
     // Pin: the bridge surface renders. If the route were inside AppShell,
     // the mobile-viewport guard would have replaced this with the
     // MobileSendPage at /m/send and the marker text below would be absent.
-    expect(await screen.findByText(/connecting drive/i)).toBeInTheDocument();
+    expect(await screen.findByText(/drive connected|connecting drive/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
@@ -2,26 +2,69 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { GDriveOAuthCallbackPage } from './GDriveOAuthCallbackPage';
+import { GDRIVE_OAUTH_BROADCAST_CHANNEL } from '@/routes/settings/integrations/useGDriveAccounts';
 
-// Bug G (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback popup
-// is opened at 480 × 720 px. Landing on `/settings/integrations?connected=1`
-// triggered AppShell's mobile-redirect rule (≤ 640 px → /m/send) before
-// the popup-bridge effect could fire, so the popup ended up at /m/send
-// and never closed. Fix: dedicated `/oauth/gdrive/callback` route mounted
-// OUTSIDE AppShell. This file pins the component contract; the routing
-// pin lives in AppRoutes.gdrive-oauth-callback.test.tsx.
-
-describe('GDriveOAuthCallbackPage (Bug G)', () => {
+/**
+ * Bug G + Bug I (Phase 6.A iter-2 PROD, 2026-05-04). The OAuth-callback
+ * popup is opened at 480 × 720 px. Two compounding failures:
+ *
+ *   - Bug G: landing on /settings/integrations triggered AppShell's
+ *     mobile-redirect (≤ 640 px → /m/send) before the bridge effect
+ *     could close the popup. Fixed by mounting /oauth/gdrive/callback
+ *     OUTSIDE AppShell (PR #134).
+ *
+ *   - Bug I: the api response carries `Cross-Origin-Opener-Policy:
+ *     same-origin` (helmet default). For a cross-origin popup, that
+ *     header puts the popup in a fresh browsing-context group and
+ *     severs `window.opener` PERMANENTLY — even after the popup later
+ *     redirects back to the same-origin bridge route. The bridge then
+ *     saw opener=null, fell through to its same-tab Navigate, and
+ *     AppShell's mobile-redirect fired again → /m/send.
+ *
+ * Two-pronged fix here:
+ *   1. Bridge ALWAYS posts on a same-origin `BroadcastChannel` so the
+ *      parent tab is notified even when COOP severs `window.opener`.
+ *   2. Bridge NEVER navigates to /settings/integrations from inside
+ *      the popup — it just renders a static "Drive connected" surface
+ *      so the popup-on-mobile-viewport never trips AppShell's guard.
+ */
+describe('GDriveOAuthCallbackPage (Bug G + Bug I)', () => {
   let originalOpener: Window | null;
   let postMessageSpy: ReturnType<typeof vi.fn>;
   let closeSpy: ReturnType<typeof vi.fn>;
+  let bcInstances: Array<{
+    name: string;
+    postMessage: ReturnType<typeof vi.fn>;
+    close: ReturnType<typeof vi.fn>;
+  }>;
+  let originalBroadcastChannel: typeof globalThis.BroadcastChannel | undefined;
 
   beforeEach(() => {
     originalOpener = window.opener;
     postMessageSpy = vi.fn();
     closeSpy = vi.fn();
+    bcInstances = [];
     Object.defineProperty(window, 'close', {
       value: closeSpy,
+      writable: true,
+      configurable: true,
+    });
+    // Stub BroadcastChannel — jsdom doesn't ship it.
+    originalBroadcastChannel = globalThis.BroadcastChannel;
+    class StubBC {
+      postMessage: ReturnType<typeof vi.fn>;
+      close: ReturnType<typeof vi.fn>;
+      onmessage: ((ev: MessageEvent) => void) | null = null;
+      constructor(public readonly name: string) {
+        this.postMessage = vi.fn();
+        this.close = vi.fn();
+        bcInstances.push({ name, postMessage: this.postMessage, close: this.close });
+      }
+      addEventListener() {}
+      removeEventListener() {}
+    }
+    Object.defineProperty(globalThis, 'BroadcastChannel', {
+      value: StubBC as unknown as typeof globalThis.BroadcastChannel,
       writable: true,
       configurable: true,
     });
@@ -33,9 +76,38 @@ describe('GDriveOAuthCallbackPage (Bug G)', () => {
       writable: true,
       configurable: true,
     });
+    if (originalBroadcastChannel) {
+      Object.defineProperty(globalThis, 'BroadcastChannel', {
+        value: originalBroadcastChannel,
+        writable: true,
+        configurable: true,
+      });
+    }
   });
 
-  it('popup mode: posts gdrive-oauth-complete to opener and closes the window', async () => {
+  it('always posts on the same-origin BroadcastChannel even when window.opener is null (Bug I — COOP severed)', async () => {
+    Object.defineProperty(window, 'opener', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      const ch = bcInstances.find((b) => b.name === GDRIVE_OAUTH_BROADCAST_CHANNEL);
+      expect(ch).toBeDefined();
+      expect(ch?.postMessage).toHaveBeenCalledWith({ type: 'gdrive-oauth-complete' });
+    });
+  });
+
+  it('popup mode: posts gdrive-oauth-complete to opener AND BroadcastChannel, then closes', async () => {
     const fakeOpener = { postMessage: postMessageSpy } as unknown as Window;
     Object.defineProperty(window, 'opener', {
       value: fakeOpener,
@@ -57,29 +129,14 @@ describe('GDriveOAuthCallbackPage (Bug G)', () => {
         window.location.origin,
       );
     });
+    await waitFor(() => {
+      const ch = bcInstances.find((b) => b.name === GDRIVE_OAUTH_BROADCAST_CHANNEL);
+      expect(ch?.postMessage).toHaveBeenCalledWith({ type: 'gdrive-oauth-complete' });
+    });
     await waitFor(() => expect(closeSpy).toHaveBeenCalled());
   });
 
-  it('popup mode: shows a small "Connecting Drive…" surface so the popup does not flash blank', async () => {
-    const fakeOpener = { postMessage: postMessageSpy } as unknown as Window;
-    Object.defineProperty(window, 'opener', {
-      value: fakeOpener,
-      writable: true,
-      configurable: true,
-    });
-
-    render(
-      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
-        <Routes>
-          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
-        </Routes>
-      </MemoryRouter>,
-    );
-
-    expect(await screen.findByText(/connecting drive/i)).toBeInTheDocument();
-  });
-
-  it('same-tab fallback (no opener): redirects to /settings/integrations?connected=1', async () => {
+  it('renders a static "Drive connected" surface — never <Navigate> to /settings/integrations (would trip mobile guard)', async () => {
     Object.defineProperty(window, 'opener', {
       value: null,
       writable: true,
@@ -90,12 +147,12 @@ describe('GDriveOAuthCallbackPage (Bug G)', () => {
       <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
         <Routes>
           <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
-          <Route path="/settings/integrations" element={<h1>integrations stub</h1>} />
+          <Route path="/settings/integrations" element={<h1>SHOULD NOT REACH integrations</h1>} />
         </Routes>
       </MemoryRouter>,
     );
 
-    expect(await screen.findByRole('heading', { name: /integrations stub/i })).toBeInTheDocument();
-    expect(closeSpy).not.toHaveBeenCalled();
+    expect(await screen.findByText(/drive connected|connecting drive/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /SHOULD NOT REACH/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
@@ -1,55 +1,94 @@
 import { useEffect, type ReactElement } from 'react';
-import { Navigate, useSearchParams } from 'react-router-dom';
-import { GDRIVE_OAUTH_COMPLETE_MESSAGE } from '@/routes/settings/integrations/useGDriveAccounts';
+import {
+  GDRIVE_OAUTH_BROADCAST_CHANNEL,
+  GDRIVE_OAUTH_COMPLETE_MESSAGE,
+} from '@/routes/settings/integrations/useGDriveAccounts';
 
 /**
  * Dedicated OAuth-callback bridge for the Google Drive popup. Mounted
  * at `/oauth/gdrive/callback` OUTSIDE `<AppShell />` so the AppShell
  * mobile-redirect rule (≤ 640 px → /m/send) does NOT fire — the popup
- * is opened at 480 × 720 px and was getting redirected before the
- * postMessage + close effect could run. Bug G (Phase 6.A iter-2 PROD,
- * 2026-05-04). The canonical OAuth-popup pattern: dedicated callback
- * route, postMessage to opener (same-origin), then window.close().
+ * is opened at 480 × 720 px.
  *
- * Same-tab fallback (popup blocker collapsed the popup into the parent
- * tab → no opener): redirect to /settings/integrations?connected=1 so
- * the integrations page picks up the connected query param and
- * invalidates the accounts query (handled by the existing bridge in
- * useGDriveAccounts.ts).
+ * Bug G (Phase 6.A iter-2 PROD, 2026-05-04): mounting the bridge
+ * outside AppShell stopped the immediate /m/send redirect.
+ *
+ * Bug I (Phase 6.A iter-2 PROD, 2026-05-04): the api response carries
+ * `Cross-Origin-Opener-Policy: same-origin` (helmet default). For a
+ * cross-origin popup that header puts the popup in a fresh
+ * browsing-context group and severs `window.opener` PERMANENTLY — even
+ * after the popup later redirects back to the same-origin bridge route.
+ * The bridge then saw opener=null, fell through to its same-tab
+ * `<Navigate to="/settings/integrations">`, and AppShell's
+ * mobile-redirect fired again on that mobile-sized viewport → /m/send.
+ *
+ * Two-pronged fix:
+ *   1. The api now disables COOP (see apps/api/src/security-headers.ts)
+ *      so `window.opener` survives the round-trip.
+ *   2. We ALWAYS post on a same-origin `BroadcastChannel`, in addition
+ *      to `opener.postMessage`, as belt-and-suspenders. BroadcastChannel
+ *      works between same-origin tabs even when COOP severs the opener,
+ *      so a future regression of (1) does not silently break the flow.
+ *   3. The bridge NEVER navigates to /settings/integrations from inside
+ *      the popup. It just renders a static "Drive connected" surface
+ *      and calls `window.close()`. Even if the popup blocker collapsed
+ *      the popup into the parent tab, the parent's listener
+ *      (useGDriveOAuthMessageListener) picks up the BroadcastChannel
+ *      message and refreshes the accounts list.
  */
 export function GDriveOAuthCallbackPage(): ReactElement {
-  const [params] = useSearchParams();
-  const opener = typeof window !== 'undefined' ? window.opener : null;
-  const isPopup = Boolean(opener) && opener !== window;
-
   useEffect(() => {
-    if (!isPopup) return;
-    try {
-      (opener as Window).postMessage(
-        { type: GDRIVE_OAUTH_COMPLETE_MESSAGE },
-        window.location.origin,
-      );
-    } catch {
-      // Same-origin postMessage shouldn't throw; if the parent
-      // navigated away the call is a no-op. Either way, fall through
-      // to window.close() so the popup goes away.
+    const message = { type: GDRIVE_OAUTH_COMPLETE_MESSAGE } as const;
+
+    // Belt: post to opener when the reference survived COOP.
+    const opener = window.opener as Window | null;
+    if (opener && opener !== window) {
+      try {
+        opener.postMessage(message, window.location.origin);
+      } catch {
+        // Same-origin postMessage shouldn't throw; if the parent
+        // navigated away the call is a no-op. Fall through to the
+        // BroadcastChannel + window.close() path below.
+      }
     }
-    window.close();
-  }, [isPopup, opener]);
 
-  if (!isPopup) {
-    const connected = params.get('connected');
-    const target = connected
-      ? `/settings/integrations?connected=${encodeURIComponent(connected)}`
-      : '/settings/integrations';
-    return <Navigate to={target} replace />;
-  }
+    // Suspenders: BroadcastChannel works between same-origin tabs
+    // regardless of opener state. SSR-safe — guard for older browsers
+    // / non-browser test envs that don't ship the constructor.
+    let channel: BroadcastChannel | null = null;
+    if (typeof BroadcastChannel !== 'undefined') {
+      try {
+        channel = new BroadcastChannel(GDRIVE_OAUTH_BROADCAST_CHANNEL);
+        channel.postMessage(message);
+      } catch {
+        // No-op: a partner on the parent tab will time out and the
+        // user can close the popup manually.
+      }
+    }
 
-  // Tiny surface so the popup doesn't flash blank between landing and
-  // window.close(). Inline styles to avoid pulling in the styled
-  // components weight for a sub-second render.
+    // Schedule close on a macrotask so the BroadcastChannel `postMessage`
+    // has a chance to flush before the popup teardown nukes its event
+    // loop. The static surface below renders during that window so the
+    // user sees a confirmation rather than a blank page.
+    const timer = setTimeout(() => {
+      channel?.close();
+      window.close();
+    }, 0);
+
+    return () => {
+      clearTimeout(timer);
+      channel?.close();
+    };
+  }, []);
+
+  // Static surface — never <Navigate>. If the popup-blocker collapsed
+  // the popup into the parent tab, the parent's BroadcastChannel
+  // listener still picks up the signal; the user is left on a tiny
+  // confirmation screen rather than getting bounced to /m/send by
+  // AppShell's mobile-viewport guard.
   return (
     <div
+      role="status"
       style={{
         display: 'flex',
         alignItems: 'center',
@@ -59,7 +98,7 @@ export function GDriveOAuthCallbackPage(): ReactElement {
         color: '#1f2937',
       }}
     >
-      <p>Connecting Drive…</p>
+      <p>Drive connected — you can close this window.</p>
     </div>
   );
 }

--- a/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
+++ b/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
@@ -11,6 +11,18 @@ import { apiClient, type ApiError } from '@/lib/api/apiClient';
 export const GDRIVE_OAUTH_COMPLETE_MESSAGE = 'gdrive-oauth-complete' as const;
 type GdriveOAuthCompleteMessage = { readonly type: typeof GDRIVE_OAUTH_COMPLETE_MESSAGE };
 
+/**
+ * Same-origin BroadcastChannel name used as a belt-and-suspenders
+ * fallback alongside `window.opener.postMessage`. The api currently
+ * sends `Cross-Origin-Opener-Policy: same-origin` — and Chrome 120+
+ * is rolling out stricter COOP defaults — so opener references can be
+ * severed at any time. BroadcastChannel works between any same-origin
+ * tabs regardless of opener state, so the parent receives the
+ * connect signal even when COOP nukes the postMessage path.
+ * Bug I (Phase 6.A iter-2 PROD, 2026-05-04).
+ */
+export const GDRIVE_OAUTH_BROADCAST_CHANNEL = 'seald-gdrive-oauth' as const;
+
 function isOAuthCompleteMessage(data: unknown): data is GdriveOAuthCompleteMessage {
   return (
     typeof data === 'object' &&
@@ -142,13 +154,32 @@ export function useGDriveOAuthCallbackBridge(isCallbackReturn: boolean): boolean
 export function useGDriveOAuthMessageListener(): void {
   const qc = useQueryClient();
   useEffect(() => {
-    function handler(event: MessageEvent): void {
-      if (event.origin !== window.location.origin) return;
-      if (!isOAuthCompleteMessage(event.data)) return;
+    function invalidate(): void {
       void qc.invalidateQueries({ queryKey: GDRIVE_ACCOUNTS_KEY });
     }
-    window.addEventListener('message', handler);
-    return () => window.removeEventListener('message', handler);
+    function postMessageHandler(event: MessageEvent): void {
+      if (event.origin !== window.location.origin) return;
+      if (!isOAuthCompleteMessage(event.data)) return;
+      invalidate();
+    }
+    window.addEventListener('message', postMessageHandler);
+
+    // Belt-and-suspenders: BroadcastChannel works between same-origin
+    // tabs even when COOP severs `window.opener`. SSR-safe — guard on
+    // typeof for older browsers / non-browser environments.
+    let channel: BroadcastChannel | null = null;
+    if (typeof BroadcastChannel !== 'undefined') {
+      channel = new BroadcastChannel(GDRIVE_OAUTH_BROADCAST_CHANNEL);
+      channel.onmessage = (event: MessageEvent) => {
+        if (!isOAuthCompleteMessage(event.data)) return;
+        invalidate();
+      };
+    }
+
+    return () => {
+      window.removeEventListener('message', postMessageHandler);
+      channel?.close();
+    };
   }, [qc]);
 }
 

--- a/cspell.json
+++ b/cspell.json
@@ -492,7 +492,9 @@
     "gotenberg",
     "unwired",
     "KARN",
-    "KREG"
+    "KREG",
+    "HSTS",
+    "hsts"
   ],
   "ignoreRegExpList": [
     "Base64",


### PR DESCRIPTION
## Summary

- Drive OAuth popup was still landing on `/m/send` even after Bug G (PR #134) mounted the bridge outside `<AppShell />`. Root cause: api response carried `Cross-Origin-Opener-Policy: same-origin` (helmet default) — which puts the cross-origin popup in a fresh browsing-context group and severs `window.opener` PERMANENTLY (the severance survives the redirect back to the same-origin bridge). Bridge then saw `opener=null`, fell through to its same-tab `<Navigate to="/settings/integrations">`, AppShell's mobile guard fired on the 480 × 720 popup viewport → `/m/send`.
- Two-pronged fix: (a) disable COOP on the api (it's JSON-only + one OAuth redirect — COOP gives no meaningful protection), (b) add a same-origin `BroadcastChannel` belt-and-suspenders so a future regression of (a) — e.g. someone re-adds default helmet, Chrome's planned stricter COOP defaults — doesn't silently break the flow.
- Bridge no longer `<Navigate>`s to `/settings/integrations` from inside the popup — renders a static "Drive connected" surface and `window.close()`s. Even if the popup-blocker collapses the popup into the parent tab, the parent's `BroadcastChannel` listener picks up the signal.

## Changes

**api**
- `apps/api/src/security-headers.ts` (new) — helmet factory with `crossOriginOpenerPolicy: false`, comment explaining why.
- `apps/api/src/security-headers.spec.ts` (new) — pins COOP not 'same-origin' + the rest of the helmet protections still on.
- `apps/api/src/main.ts` — replaced inline `helmet()` with `securityHeaders()`.

**web**
- `apps/web/src/routes/settings/integrations/useGDriveAccounts.ts` — added `GDRIVE_OAUTH_BROADCAST_CHANNEL` constant; `useGDriveOAuthMessageListener` now subscribes to BOTH `window.message` and the `BroadcastChannel`.
- `apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx` — always posts on BroadcastChannel (in addition to opener.postMessage when alive); always `window.close()`s; renders static "Drive connected" surface; dropped the `<Navigate to="/settings/integrations">` same-tab fallback.
- `apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx` — rewrote 3 tests for the new contract.
- `apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx` — loosened marker text to match new surface.

## Test plan

- [x] api jest — `pnpm --filter api test` → 873/873 pass (security-headers.spec included)
- [x] web vitest — `pnpm --filter web test` → 1398/1398 pass
- [x] typecheck — `pnpm -r typecheck` ✓
- [x] lint — `pnpm -r lint` ✓
- [x] `seald-react-pr-review` skill: MUST-FIX 0 / SHOULD-FIX 0 / NICE-TO-HAVE 0
- [ ] Post-deploy: open prod, retry Connect Google Drive, verify popup auto-closes AND the connected account row appears WITHOUT manual refresh
- [ ] Post-deploy: confirm `curl -I https://api.seald.nromomentum.com/healthz` no longer returns `Cross-Origin-Opener-Policy: same-origin`

## Tracking

- Bug F (auto-close): #133
- Bug G (mount outside AppShell): #134
- Bug H (idempotent OAuth retry): #135
- Bug I (this PR): COOP + BroadcastChannel — Phase 6.A iter-2 PROD bug-loop, 2026-05-04

🤖 Generated with [Claude Code](https://claude.com/claude-code)