### PR TITLE
fix(web): expose Drive Integrations entry in avatar dropdown

### DIFF
--- a/apps/web/src/components/NavBar/NavBar.tsx
+++ b/apps/web/src/components/NavBar/NavBar.tsx
@@ -45,6 +45,7 @@ interface RightClusterArgs {
   readonly onSignOut: (() => void) | undefined;
   readonly onExportData: (() => void) | undefined;
   readonly onDeleteAccount: (() => void) | undefined;
+  readonly onOpenIntegrations: (() => void) | undefined;
   readonly isExporting: boolean;
   readonly isDeleting: boolean;
 }
@@ -58,6 +59,7 @@ function renderRightCluster(args: RightClusterArgs): ReactNode {
     onSignOut,
     onExportData,
     onDeleteAccount,
+    onOpenIntegrations,
     isExporting,
     isDeleting,
   } = args;
@@ -88,6 +90,7 @@ function renderRightCluster(args: RightClusterArgs): ReactNode {
         onSignOut={onSignOut}
         {...(onExportData ? { onExportData } : {})}
         {...(onDeleteAccount ? { onDeleteAccount } : {})}
+        {...(onOpenIntegrations ? { onOpenIntegrations } : {})}
         isExporting={isExporting}
         isDeleting={isDeleting}
       />
@@ -140,6 +143,7 @@ export const NavBar = forwardRef<HTMLElement, NavBarProps>((props, ref) => {
     onSignOut,
     onExportData,
     onDeleteAccount,
+    onOpenIntegrations,
     isExporting = false,
     isDeleting = false,
     ...rest
@@ -206,6 +210,7 @@ export const NavBar = forwardRef<HTMLElement, NavBarProps>((props, ref) => {
           onSignOut,
           onExportData,
           onDeleteAccount,
+          onOpenIntegrations,
           isExporting,
           isDeleting,
         })}

--- a/apps/web/src/components/NavBar/NavBar.types.ts
+++ b/apps/web/src/components/NavBar/NavBar.types.ts
@@ -32,6 +32,13 @@ export interface NavBarProps extends HTMLAttributes<HTMLElement> {
   readonly onExportData?: (() => void) | undefined;
   /** Optional — wires the UserMenu's "Delete account" danger item. */
   readonly onDeleteAccount?: (() => void) | undefined;
+  /**
+   * Optional — wires the UserMenu's "Integrations" item that navigates
+   * to /settings/integrations (Google Drive feature). Pass `undefined`
+   * to hide the item (e.g. when the feature flag is off, or in guest
+   * mode).
+   */
+  readonly onOpenIntegrations?: (() => void) | undefined;
   /** Mirrors UserMenu.isExporting; disables the item while in flight. */
   readonly isExporting?: boolean | undefined;
   /** Mirrors UserMenu.isDeleting; disables the item while in flight. */

--- a/apps/web/src/components/UserMenu/UserMenu.test.tsx
+++ b/apps/web/src/components/UserMenu/UserMenu.test.tsx
@@ -107,4 +107,28 @@ describe('UserMenu', () => {
     await userEvent.click(item);
     expect(onDeleteAccount).not.toHaveBeenCalled();
   });
+
+  // Discoverability: /settings/integrations was added by the Drive-feature work
+  // but had no entry in the avatar dropdown — so authed users could not reach
+  // it without typing the URL. The gdrive-feature-manager skill forbids new
+  // top-level NAV_ITEMS, so the avatar dropdown is the natural home.
+  it('renders an Integrations menuitem when onOpenIntegrations is provided', async () => {
+    const onOpenIntegrations = vi.fn();
+    const { getByRole, queryByRole } = renderWithTheme(
+      <UserMenu user={user} onSignOut={() => {}} onOpenIntegrations={onOpenIntegrations} />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    await userEvent.click(getByRole('menuitem', { name: /integrations/i }));
+    expect(onOpenIntegrations).toHaveBeenCalledTimes(1);
+    // Activating an item closes the menu — same contract as Sign out / Export.
+    expect(queryByRole('menu')).toBeNull();
+  });
+
+  it('does NOT render Integrations when onOpenIntegrations is absent', async () => {
+    const { getByRole, queryByRole } = renderWithTheme(
+      <UserMenu user={user} onSignOut={() => {}} />,
+    );
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    expect(queryByRole('menuitem', { name: /integrations/i })).toBeNull();
+  });
 });

--- a/apps/web/src/components/UserMenu/UserMenu.tsx
+++ b/apps/web/src/components/UserMenu/UserMenu.tsx
@@ -15,6 +15,7 @@ export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) =
     onSignOut,
     onExportData,
     onDeleteAccount,
+    onOpenIntegrations,
     isExporting = false,
     isDeleting = false,
     ...rest
@@ -55,6 +56,12 @@ export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) =
     setOpen(false);
     onDeleteAccount();
   }, [onDeleteAccount]);
+
+  const handleOpenIntegrations = useCallback((): void => {
+    if (!onOpenIntegrations) return;
+    setOpen(false);
+    onOpenIntegrations();
+  }, [onOpenIntegrations]);
 
   // Forward the external ref to the wrapper, but keep the internal ref for
   // outside-click detection.
@@ -99,6 +106,11 @@ export const UserMenu = forwardRef<HTMLDivElement, UserMenuProps>((props, ref) =
               aria-busy={isExporting || undefined}
             >
               {isExporting ? 'Preparing download…' : 'Download my data'}
+            </Item>
+          ) : null}
+          {onOpenIntegrations ? (
+            <Item type="button" role="menuitem" onClick={handleOpenIntegrations}>
+              Integrations
             </Item>
           ) : null}
           <Item type="button" role="menuitem" onClick={handleSignOut}>

--- a/apps/web/src/components/UserMenu/UserMenu.types.ts
+++ b/apps/web/src/components/UserMenu/UserMenu.types.ts
@@ -21,6 +21,15 @@ export interface UserMenuProps extends HTMLAttributes<HTMLDivElement> {
    * intent (the wired implementation prompts for a confirm phrase).
    */
   readonly onDeleteAccount?: (() => void) | undefined;
+  /**
+   * Optional — when provided, renders an "Integrations" item that
+   * navigates to /settings/integrations. Discoverability home for the
+   * Google Drive feature; AppShell only passes a handler when
+   * `feature.gdriveIntegration` is on AND the user is authed. The
+   * `gdrive-feature-manager` skill forbids new top-level NAV_ITEMS, so
+   * the avatar dropdown is the canonical entry point.
+   */
+  readonly onOpenIntegrations?: (() => void) | undefined;
   /** Disables the export item while a request is in flight. */
   readonly isExporting?: boolean | undefined;
   /** Disables the delete item while a request is in flight. */

--- a/apps/web/src/layout/AppShell.gdrive-integrations-link.test.tsx
+++ b/apps/web/src/layout/AppShell.gdrive-integrations-link.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { AppShell } from './AppShell';
+
+/**
+ * Discoverability gate for /settings/integrations. The Drive integration
+ * page exists at AppRoutes.tsx:211–217 but had no nav entry — authed
+ * users could only reach it by typing the URL. The
+ * `gdrive-feature-manager` skill forbids new top-level NAV_ITEMS, so
+ * the avatar dropdown is the canonical entry point. AppShell now passes
+ * an `onOpenIntegrations` handler to NavBar/UserMenu when:
+ *   - the user is authed (mode === 'authed'), AND
+ *   - feature.gdriveIntegration is enabled.
+ *
+ * `feature.gdriveIntegration` defaults to `true` in
+ * `packages/shared/src/feature-flags.ts`, so the dropdown shows the
+ * row in production today. These tests pin the contract.
+ */
+vi.mock('@/features/account', () => ({
+  useAccountActions: () => ({
+    exportData: vi.fn(),
+    deleteAccount: vi.fn(),
+    isExporting: false,
+    isDeleting: false,
+  }),
+}));
+
+// useIsMobileViewport returns true on tiny viewports — AppShell then short-
+// circuits to <Navigate to="/m/send" />, which would skip our dropdown
+// entirely. Pin the desktop branch.
+vi.mock('../hooks/useIsMobileViewport', () => ({
+  useIsMobileViewport: () => false,
+  readIsMobileViewport: () => false,
+  MOBILE_VIEWPORT_QUERY: '(max-width: 640px)',
+}));
+
+function renderShellAt(initialPath: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/documents" element={<div>doc list</div>} />
+          <Route path="/settings/integrations" element={<h1>integrations page (test stub)</h1>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('AppShell — Drive Integrations entry in avatar dropdown', () => {
+  it('shows Integrations in the dropdown and navigates to /settings/integrations on click', async () => {
+    const { getByRole, findByRole } = renderShellAt('/documents');
+    await userEvent.click(getByRole('button', { name: /open menu for/i }));
+    const integrationsItem = await findByRole('menuitem', { name: /integrations/i });
+    await userEvent.click(integrationsItem);
+    // The route stub renders an h1 once Navigate completes.
+    expect(
+      await findByRole('heading', { name: /integrations page \(test stub\)/i }),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
+import { isFeatureEnabled } from 'shared';
 import styled from 'styled-components';
 import { NavBar } from '../components/NavBar';
 import { useAppState } from '../providers/AppStateProvider';
@@ -154,6 +155,17 @@ export function AppShell() {
 
   const mode = !user && guest ? 'guest' : 'authed';
 
+  // Discoverability for /settings/integrations — only an entry in the
+  // avatar dropdown when the feature is on AND the user is authed. Guest
+  // mode + flag-off both render the menu without the row, so the dropdown
+  // stays lean. The `gdrive-feature-manager` skill forbids new top-level
+  // NAV_ITEMS, so this is the canonical home for the entry point.
+  const handleOpenIntegrations = useCallback((): void => {
+    navigate('/settings/integrations');
+  }, [navigate]);
+  const onOpenIntegrations =
+    mode === 'authed' && isFeatureEnabled('gdriveIntegration') ? handleOpenIntegrations : undefined;
+
   // 2026-05-03 (refined a second time per user) — the desktop AppShell
   // pages (/documents, /templates, /signers, /document/<id>,
   // /document/new, /templates/:id/use, /templates/:id/edit) were not
@@ -182,6 +194,7 @@ export function AppShell() {
         onSignOut={handleSignOut}
         onExportData={mode === 'authed' ? account.exportData : undefined}
         onDeleteAccount={mode === 'authed' ? account.deleteAccount : undefined}
+        onOpenIntegrations={onOpenIntegrations}
         isExporting={account.isExporting}
         isDeleting={account.isDeleting}
       />


### PR DESCRIPTION
## Summary
- /settings/integrations was reachable only by typing the URL — closes the discoverability gap surfaced when auditing the Drive feature flow end-to-end.
- Adds an "Integrations" item to the **avatar dropdown** (UserMenu), gated by `mode === 'authed' && isFeatureEnabled('gdriveIntegration')`. The `gdrive-feature-manager` skill forbids new top-level NAV_ITEMS, so the dropdown is the canonical home.
- Wiring: UserMenu (new prop + render) → NavBar (forwarding) → AppShell (handler + flag check + navigate).

## Test plan
- [x] `UserMenu.test.tsx`: pin item rendered + handler fires + menu closes (mirrors existing Download my data / Delete account contract).
- [x] `UserMenu.test.tsx`: pin item is HIDDEN when prop is omitted (Storybook / guest mode).
- [x] `AppShell.gdrive-integrations-link.test.tsx`: pin click in dropdown navigates to `/settings/integrations`.
- [x] vitest 1401/1401 ✓
- [x] typecheck ✓ / lint ✓

## react-pr-review walk
- 1.6 path aliases — relative imports match existing pattern ✓
- 2.4 measured perf — no speculative useMemo/useCallback added; the new useCallback wraps a navigate() and is cheap ✓
- 3.1 strict tsconfig — explicit `| undefined` on the optional prop (exactOptionalPropertyTypes) ✓
- 4.4 single-effect-concern — no new effects added ✓
- 4.6 accessible queries — tests use role + name (`menuitem`, `heading`) ✓

MUST-FIX 0 / SHOULD-FIX 0 / NICE-TO-HAVE 0 — APPROVED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)