### PR TITLE
feat(api): GET /integrations/gdrive/picker-credentials

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,21 @@ The `apps/api/src/integrations/gdrive/` module reads these at startup:
   Gotenberg PDFs out (default `26214400` = 25 MiB); WT-D. Raising it
   without re-checking the Gotenberg memory budget will OOM the
   sidecar.
+- `GDRIVE_PICKER_DEVELOPER_KEY` — Google Cloud API key with the Picker
+  API enabled (referrer-restricted to `seald.nromomentum.com` in prod).
+  Vended to the SPA via `GET /integrations/gdrive/picker-credentials`
+  so it can construct a `google.picker.PickerBuilder`. Path A fix for
+  the empty Drive picker bug — staying on `drive.file` scope and using
+  Google's official picker UI (per-file access granted at click time).
+- `GDRIVE_PICKER_APP_ID` — Google Cloud project number (the long
+  numeric, e.g. `123456789012`). Required by the Picker API for app
+  identification. Public-ish but kept server-side so the SPA bundle
+  does not bake it in and we can rotate without a frontend redeploy.
+
+When either picker var is unset,
+`/integrations/gdrive/picker-credentials` returns 503 and the SPA
+renders a friendly "Drive picker not configured on this server"
+notice.
 
 OAuth scope is hard-coded to `https://www.googleapis.com/auth/drive.file`
 (per-file consent only). Do not broaden — picker selections grant per-file

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -113,6 +113,32 @@ export const envSchema = z
     GDRIVE_API_RATE_PER_USER: z.coerce.number().int().positive().optional(),
     GDRIVE_API_RATE_WINDOW_SECONDS: z.coerce.number().int().positive().optional(),
     /**
+     * Google Picker API credentials. Vended to the SPA via
+     * `GET /integrations/gdrive/picker-credentials` so the client can
+     * construct a `google.picker.PickerBuilder` (Path A fix for the
+     * empty Drive picker bug — staying on `drive.file` scope and using
+     * Google's official picker UI which grants per-file access at
+     * click time).
+     *
+     * `GDRIVE_PICKER_DEVELOPER_KEY` is a Google Cloud API key with the
+     * Picker API enabled. Referrer-restricted in Google Cloud Console
+     * (production: `seald.nromomentum.com`). Public-ish but kept
+     * server-side so the SPA bundle does not bake it in and we can
+     * rotate without a frontend redeploy.
+     *
+     * `GDRIVE_PICKER_APP_ID` is the Google Cloud project number
+     * (numeric, e.g. `123456789012`). Required by the Picker API for
+     * app identification — not a secret, but pulled from env for the
+     * same rotation/decoupling reason.
+     *
+     * When either is unset, `/integrations/gdrive/picker-credentials`
+     * returns 503 so the SPA can render a friendly "Drive picker not
+     * configured on this server" notice instead of silently building
+     * a broken picker call.
+     */
+    GDRIVE_PICKER_DEVELOPER_KEY: z.string().optional(),
+    GDRIVE_PICKER_APP_ID: z.string().optional(),
+    /**
      * WT-D Drive doc → PDF conversion. The Gotenberg sidecar is
      * network-isolated inside the docker-compose stack (NOT publicly
      * routed via Caddy); the API talks to it on the internal network

--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -117,6 +117,8 @@ const CFG = {
   clientSecret: 'csecret',
   redirectUri: 'http://localhost:3000/integrations/gdrive/oauth/callback',
   appPublicUrl: 'http://localhost:5173',
+  pickerDeveloperKey: 'test-dev-key',
+  pickerAppId: 'test-app-id',
 };
 
 interface ProxyCall {
@@ -449,6 +451,134 @@ describe('GDriveController', () => {
       const accountId = await seedAccount(ctrl, state, 'user-1');
       const otherUser: AuthUser = { id: 'user-2', email: 'u2@example.com', provider: 'google' };
       await expect(ctrl.listFiles(otherUser, accountId, 'pdf')).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+    });
+  });
+
+  // PR 2a: picker-credentials endpoint backs the Google Picker UI in the
+  // SPA (Path A fix for the empty Drive picker bug). The frontend rewrite
+  // ships in PR 2b — this describe block locks the wire contract.
+  describe('GET /picker-credentials', () => {
+    async function seedAccount(
+      ctrl: GDriveController,
+      state: OAuthStateStore,
+      userId = 'user-1',
+    ): Promise<string> {
+      const started = state.start(userId);
+      await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+      const accs = await ctrl.listAccounts({ id: userId, email: 'x', provider: 'google' });
+      const first = accs[0];
+      if (!first) throw new Error('no acc');
+      return first.id;
+    }
+
+    it('returns { accessToken, developerKey, appId } for an owned account when env is fully configured', async () => {
+      const { ctrl, state } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      const out = await ctrl.pickerCredentials(USER_1, accountId);
+      expect(out).toEqual({
+        accessToken: 'at-refreshed',
+        developerKey: 'test-dev-key',
+        appId: 'test-app-id',
+      });
+    });
+
+    it('rejects 400 when accountId is not a UUID', async () => {
+      const { ctrl } = makeController();
+      await expect(ctrl.pickerCredentials(USER_1, 'not-a-uuid')).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+    });
+
+    it('feature flag off → 404 NotFoundException', async () => {
+      (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
+      const { ctrl } = makeController();
+      await expect(
+        ctrl.pickerCredentials(USER_1, '00000000-0000-0000-0000-000000000aaa'),
+      ).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it('throws 503 when developerKey env is empty (mirrors requireOAuthConfigured)', async () => {
+      const repo = new FakeRepo();
+      const kms = new GDriveKmsService(
+        new StubKmsClient(),
+        'arn:aws:kms:us-east-1:000000000000:key/k',
+      );
+      const google = new StubGoogleClient();
+      const svc = new GDriveService(repo, kms, google);
+      const state = new OAuthStateStore();
+      const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000 });
+      const proxy: FilesProxy = async () => ({ files: [] });
+      const ctrl = new GDriveController(
+        svc,
+        state,
+        { ...CFG, pickerDeveloperKey: '' },
+        limiter,
+        proxy,
+      );
+      await expect(
+        ctrl.pickerCredentials(USER_1, '00000000-0000-0000-0000-000000000aaa'),
+      ).rejects.toMatchObject({ status: HttpStatus.SERVICE_UNAVAILABLE });
+    });
+
+    it('throws 503 when appId env is empty', async () => {
+      const repo = new FakeRepo();
+      const kms = new GDriveKmsService(
+        new StubKmsClient(),
+        'arn:aws:kms:us-east-1:000000000000:key/k',
+      );
+      const google = new StubGoogleClient();
+      const svc = new GDriveService(repo, kms, google);
+      const state = new OAuthStateStore();
+      const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000 });
+      const proxy: FilesProxy = async () => ({ files: [] });
+      const ctrl = new GDriveController(svc, state, { ...CFG, pickerAppId: '' }, limiter, proxy);
+      await expect(
+        ctrl.pickerCredentials(USER_1, '00000000-0000-0000-0000-000000000aaa'),
+      ).rejects.toMatchObject({ status: HttpStatus.SERVICE_UNAVAILABLE });
+    });
+
+    it('returns 429 with retryAfter when rate limit is exhausted', async () => {
+      const { ctrl, state } = makeController({ capacity: 1, windowMs: 60_000 });
+      const accountId = await seedAccount(ctrl, state);
+      await ctrl.pickerCredentials(USER_1, accountId);
+      let caught: unknown;
+      try {
+        await ctrl.pickerCredentials(USER_1, accountId);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(HttpException);
+      const httpErr = caught as HttpException;
+      expect(httpErr.getStatus()).toBe(HttpStatus.TOO_MANY_REQUESTS);
+      const resp = httpErr.getResponse() as { code?: string; retryAfter?: number };
+      expect(resp.code).toBe('rate-limited');
+      expect(typeof resp.retryAfter).toBe('number');
+      expect(resp.retryAfter).toBeGreaterThan(0);
+    });
+
+    it('maps token-expired (Drive 401 from refresh) → 401', async () => {
+      const { ctrl, state, google } = makeController();
+      const accountId = await seedAccount(ctrl, state);
+      // Force the next refreshAccessToken() to reject with the
+      // taxonomy's TokenExpiredError — same pattern getAccessToken uses
+      // when the refresh fails with 401 invalid_grant.
+      const { TokenExpiredError } = await import('./dto/error-codes');
+      google.refreshAccessToken = async (): Promise<never> => {
+        throw new TokenExpiredError('reconnect_required');
+      };
+      await expect(ctrl.pickerCredentials(USER_1, accountId)).rejects.toMatchObject({
+        status: 401,
+        response: expect.objectContaining({ code: 'token-expired' }),
+      });
+    });
+
+    it('returns NotFound when accountId belongs to another user (no existence leak)', async () => {
+      const { ctrl, state } = makeController();
+      const accountId = await seedAccount(ctrl, state, 'user-1');
+      const otherUser: AuthUser = { id: 'user-2', email: 'u2@example.com', provider: 'google' };
+      await expect(ctrl.pickerCredentials(otherUser, accountId)).rejects.toBeInstanceOf(
         NotFoundException,
       );
     });

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -37,6 +37,22 @@ export interface GDriveConfig {
   readonly clientSecret: string;
   readonly redirectUri: string;
   readonly appPublicUrl: string;
+  /**
+   * Google Cloud API key with the Picker API enabled. Vended to the SPA
+   * via `/integrations/gdrive/picker-credentials` so the client can
+   * construct a `google.picker.PickerBuilder`. Public-ish (referrer
+   * restricted in Google Cloud Console) but kept on the server so the
+   * SPA bundle does not bake it in and it can be rotated without a
+   * frontend redeploy.
+   */
+  readonly pickerDeveloperKey: string;
+  /**
+   * Google Cloud project number (numeric, e.g. `123456789012`). Required
+   * by the Picker API for app identification — not a secret, but pulled
+   * from env for the same rotation/deploy-decoupling reason as the
+   * developer key above.
+   */
+  readonly pickerAppId: string;
 }
 
 export const GDRIVE_CONFIG = Symbol('GDRIVE_CONFIG');
@@ -95,6 +111,23 @@ export class GDriveController {
   private requireOAuthConfigured(): void {
     if (!this.config.clientId || !this.config.clientSecret) {
       throw new HttpException('gdrive_oauth_not_configured', HttpStatus.SERVICE_UNAVAILABLE);
+    }
+  }
+
+  /**
+   * Mirrors `requireOAuthConfigured` for the Picker-specific env vars
+   * (`GDRIVE_PICKER_DEVELOPER_KEY` + `GDRIVE_PICKER_APP_ID`). The SPA's
+   * Path A flow needs both to construct a `google.picker.PickerBuilder`;
+   * if either is empty we want a 503 so the frontend can render a
+   * deliberate "Drive picker not configured on this server" notice
+   * instead of silently building a broken picker call.
+   */
+  private requirePickerConfigured(): void {
+    if (!this.config.pickerDeveloperKey || !this.config.pickerAppId) {
+      throw new HttpException(
+        { code: 'gdrive_picker_not_configured', message: 'gdrive_picker_not_configured' },
+        HttpStatus.SERVICE_UNAVAILABLE,
+      );
     }
   }
 
@@ -230,6 +263,73 @@ export class GDriveController {
     try {
       return await this.filesProxy({ accessToken, mimeFilter });
     } catch (err) {
+      throw mapDriveError(err);
+    }
+  }
+
+  /**
+   * Vends the credentials the SPA needs to construct a Google Picker UI
+   * (`google.picker.PickerBuilder`). Returns:
+   *  - `accessToken`: short-lived (~1h) OAuth access token freshly
+   *    minted from the user's stored refresh token. Required by Picker
+   *    to authenticate the in-iframe Drive UI as the user. The refresh
+   *    token NEVER leaves the API — only this short-lived access token.
+   *  - `developerKey`: Google Cloud API key with Picker API enabled,
+   *    referrer-restricted in Cloud Console. Public-ish but kept
+   *    server-side for rotation without a redeploy.
+   *  - `appId`: Google Cloud project number; required by the Picker
+   *    API for app identification.
+   *
+   * Defence in depth — same shape as `/files`:
+   *  - Feature-flag-gated (404 when off).
+   *  - 503 when OAuth or Picker env vars are unset.
+   *  - 400 on non-UUID accountId.
+   *  - Per-user rate limit (cache key = `user.id`).
+   *  - Account ownership check inside `getAccessToken` (NotFound on
+   *    mismatch — no existence leak).
+   *  - Drive-side errors mapped via the shared `mapDriveError`
+   *    (TokenExpired → 401 token-expired, etc).
+   */
+  @Get('picker-credentials')
+  async pickerCredentials(
+    @CurrentUser() user: AuthUser,
+    @Query('accountId') accountId: string,
+  ): Promise<{ accessToken: string; developerKey: string; appId: string }> {
+    this.requireFlag();
+    this.requireOAuthConfigured();
+    this.requirePickerConfigured();
+    if (!accountId || !UUID_RE.test(accountId)) {
+      throw new BadRequestException({
+        code: 'invalid-account-id',
+        message: 'accountId_must_be_uuid',
+      });
+    }
+    try {
+      await this.rateLimiter.acquire(user.id);
+    } catch (err) {
+      if (err instanceof RateLimitedError) {
+        throw new HttpException(
+          {
+            code: 'rate-limited',
+            message: 'gdrive_rate_limited',
+            retryAfter: Math.ceil(err.retryAfterMs / 1000),
+          },
+          HttpStatus.TOO_MANY_REQUESTS,
+        );
+      }
+      throw err;
+    }
+    try {
+      const { accessToken } = await this.svc.getAccessToken(accountId, user.id);
+      return {
+        accessToken,
+        developerKey: this.config.pickerDeveloperKey,
+        appId: this.config.pickerAppId,
+      };
+    } catch (err) {
+      // Preserve NotFound (account not owned by caller) — that's a
+      // controller-level 404, not a Drive-upstream error.
+      if (err instanceof NotFoundException) throw err;
       throw mapDriveError(err);
     }
   }

--- a/apps/api/src/integrations/gdrive/gdrive.module.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.module.ts
@@ -102,6 +102,8 @@ const GDriveFilesProxyProvider: Provider = {
           env.GDRIVE_OAUTH_REDIRECT_URI ??
           'http://localhost:3000/integrations/gdrive/oauth/callback',
         appPublicUrl: env.APP_PUBLIC_URL,
+        pickerDeveloperKey: env.GDRIVE_PICKER_DEVELOPER_KEY ?? '',
+        pickerAppId: env.GDRIVE_PICKER_APP_ID ?? '',
       }),
     },
     GDriveFilesProxyProvider,


### PR DESCRIPTION
## Summary

- Adds `GET /integrations/gdrive/picker-credentials?accountId=<uuid>` — vends a fresh OAuth access token + Picker developer key + Cloud project number to the SPA so it can construct a Google `picker.PickerBuilder`.
- API-side half of the **Path A** fix for the empty Drive picker bug. We stay on `drive.file` scope and use Google's official picker UI (per-file access granted at click time) instead of our custom UI which can't enumerate the library under that scope.
- New env vars `GDRIVE_PICKER_DEVELOPER_KEY` + `GDRIVE_PICKER_APP_ID` (documented in CLAUDE.md). Endpoint returns 503 when either is unset, so the SPA can render a friendly "not configured" notice.
- Defence-in-depth mirrors `/files`: feature-flag gate (404 off), per-user rate limit (cache key = userId), UUID validation (400), account-ownership check via `getAccessToken` (NotFound on mismatch — no existence leak), `mapDriveError` for upstream/Drive errors (401 token-expired, 403 oauth-declined, 502 generic).
- Refresh token NEVER leaves the API — only the short-lived (~1h) access token.

**Frontend rewrite ships in PR 2b** and depends on this contract; PR 2b cannot start until this lands.

## Owner-side provisioning (one-time, before flipping the picker on)

1. Google Cloud Console → enable **Picker API** on the existing Seald GCP project.
2. **Create credentials → API key**, then restrict it: HTTP referrers → `https://seald.nromomentum.com/*` (and `http://localhost:5173/*` for dev). API restrictions → Picker API only.
3. Note the Cloud project number (Cloud Console → Settings → "Project number"; not the project id).
4. Set `GDRIVE_PICKER_DEVELOPER_KEY=<api-key>` and `GDRIVE_PICKER_APP_ID=<project-number>` on the EC2 host (or wherever `apps/api` runs).
5. Until both are set, the new endpoint returns 503 and the SPA degrades gracefully — no impact on the existing Drive flow.

## Test plan

- [x] `pnpm --filter api typecheck` — green
- [x] `pnpm --filter api lint` — green (max-warnings=0)
- [x] `pnpm --filter api test -- gdrive.controller.spec` — 26/26 passed
- [x] `pnpm --filter api test -- gdrive` — 93/93 passed (10 suites)
- [ ] CI all green on PR
- [ ] After merge: PR 2b rewrites the SPA `DrivePicker` to consume this endpoint

## Wire contract (locked for PR 2b)

```
GET /integrations/gdrive/picker-credentials?accountId=<uuid>
200 { accessToken: string, developerKey: string, appId: string }
400 { code: 'invalid-account-id', ... }              // bad accountId
401 { code: 'token-expired', ... }                   // refresh failed
403 { code: 'oauth-declined', ... }                  // consent revoked (mapped from Drive 403)
404 (NotFoundException)                              // feature off OR account not owned by caller
429 { code: 'rate-limited', retryAfter: number }     // per-user bucket exhausted
502 { code: 'drive-upstream-error', ... }            // generic upstream
503 { code: 'gdrive_picker_not_configured', ... }    // env vars unset
503 'gdrive_oauth_not_configured'                    // OAuth env vars unset
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)