### PR TITLE
fix(web): friendlier 'Drive picker not available' copy (no env-var leak)

### DIFF
--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -230,9 +230,20 @@ describe('DrivePicker — error states', () => {
     const err = Object.assign(new Error('service_unavailable'), { status: 503 });
     fetchMock.mockRejectedValue(err);
     const { onClose } = renderPicker();
-    expect(
-      await screen.findByRole('heading', { name: /drive picker is not configured/i }),
-    ).toBeInTheDocument();
+    const heading = await screen.findByRole('heading', {
+      name: /drive picker isn['’]t available/i,
+    });
+    expect(heading).toBeInTheDocument();
+    // 2026-05-04 — the prior copy leaked env var names
+    // (GDRIVE_PICKER_DEVELOPER_KEY / GDRIVE_PICKER_APP_ID) into a
+    // user-facing modal. End users can't act on env-var names; the
+    // friendly copy should point them at an administrator instead.
+    const dialog = heading.closest('[role="alert"]');
+    expect(dialog).not.toBeNull();
+    const text = dialog?.textContent ?? '';
+    expect(text).not.toMatch(/GDRIVE_PICKER_DEVELOPER_KEY/);
+    expect(text).not.toMatch(/GDRIVE_PICKER_APP_ID/);
+    expect(text).toMatch(/administrator/i);
     expect(pickerSpy.pickerBuilderCtor).not.toHaveBeenCalled();
     await userEvent.click(screen.getByRole('button', { name: /^close$/i }));
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/apps/web/src/components/drive-picker/states.tsx
+++ b/apps/web/src/components/drive-picker/states.tsx
@@ -23,13 +23,17 @@ export interface NotConfiguredStateProps {
 }
 
 export function NotConfiguredState({ onClose }: NotConfiguredStateProps): JSX.Element {
+  // 2026-05-04 — prior copy named the missing env vars
+  // (GDRIVE_PICKER_DEVELOPER_KEY / GDRIVE_PICKER_APP_ID) directly in
+  // a user-facing modal. End users can't act on env-var names; admins
+  // already have the operational details in CLAUDE.md. Keep this copy
+  // user-friendly and point at "an administrator" instead.
   return (
     <Card role="alert">
-      <Title>Drive picker is not configured</Title>
+      <Title>Drive picker isn&rsquo;t available</Title>
       <Body>
-        Drive picker is not configured on this server. An administrator needs to set
-        <code> GDRIVE_PICKER_DEVELOPER_KEY</code> and <code>GDRIVE_PICKER_APP_ID</code> before this
-        feature is available.
+        Picking from Google Drive isn&rsquo;t available on this server right now. Please contact
+        your administrator.
       </Body>
       <Actions>
         <Button variant="primary" type="button" onClick={onClose}>


### PR DESCRIPTION
## Summary
- The 503 path of `/integrations/gdrive/picker-credentials` rendered a user-facing modal that named `GDRIVE_PICKER_DEVELOPER_KEY` and `GDRIVE_PICKER_APP_ID` directly. End users can't act on env-var names — admins already have the operational details in CLAUDE.md. New copy points end users at "an administrator".
- Test-first: extended the existing 503 case in DrivePicker.test.tsx to assert the new heading + the absence of either env var name in the rendered dialog. RED → GREEN.

## Test plan
- [x] Vitest scoped: \`pnpm --filter web exec vitest run src/components/drive-picker/DrivePicker.test.tsx\` (10/10)
- [x] Vitest full: 1390/1390
- [x] Typecheck + lint clean across web

🤖 Generated with [Claude Code](https://claude.com/claude-code)