### PR TITLE
fix(web): collapse Drive picker to single tab + enable folder navigation

### DIFF
--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -31,11 +31,14 @@ interface PickerSpyState {
   readonly setOAuthToken: ReturnType<typeof vi.fn>;
   readonly setDeveloperKey: ReturnType<typeof vi.fn>;
   readonly setAppId: ReturnType<typeof vi.fn>;
+  readonly setOrigin: ReturnType<typeof vi.fn>;
   readonly addView: ReturnType<typeof vi.fn>;
   readonly setCallback: ReturnType<typeof vi.fn>;
   readonly build: ReturnType<typeof vi.fn>;
   readonly setVisible: ReturnType<typeof vi.fn>;
   readonly setMimeTypes: ReturnType<typeof vi.fn>;
+  readonly setIncludeFolders: ReturnType<typeof vi.fn>;
+  readonly setSelectFolderEnabled: ReturnType<typeof vi.fn>;
   readonly docsViewCtor: ReturnType<typeof vi.fn>;
   readonly pickerBuilderCtor: ReturnType<typeof vi.fn>;
   triggerCallback: (data: PickerCallbackData) => void;
@@ -46,11 +49,21 @@ let pickerSpy: PickerSpyState;
 function installGooglePickerStub(): PickerSpyState {
   let registered: ((data: PickerCallbackData) => void) | null = null;
   const setVisible = vi.fn();
-  const docsViewBuilder: { setMimeTypes: ReturnType<typeof vi.fn> } = {
+  const docsViewBuilder: {
+    setMimeTypes: ReturnType<typeof vi.fn>;
+    setIncludeFolders: ReturnType<typeof vi.fn>;
+    setSelectFolderEnabled: ReturnType<typeof vi.fn>;
+  } = {
     setMimeTypes: vi.fn(),
+    setIncludeFolders: vi.fn(),
+    setSelectFolderEnabled: vi.fn(),
   };
   docsViewBuilder.setMimeTypes.mockReturnValue(docsViewBuilder);
+  docsViewBuilder.setIncludeFolders.mockReturnValue(docsViewBuilder);
+  docsViewBuilder.setSelectFolderEnabled.mockReturnValue(docsViewBuilder);
   const setMimeTypes = docsViewBuilder.setMimeTypes;
+  const setIncludeFolders = docsViewBuilder.setIncludeFolders;
+  const setSelectFolderEnabled = docsViewBuilder.setSelectFolderEnabled;
 
   function DocsViewCtorImpl(this: unknown): unknown {
     return docsViewBuilder;
@@ -61,6 +74,7 @@ function installGooglePickerStub(): PickerSpyState {
     setOAuthToken: vi.fn(),
     setDeveloperKey: vi.fn(),
     setAppId: vi.fn(),
+    setOrigin: vi.fn(),
     addView: vi.fn(),
     setCallback: vi.fn(function setCallbackImpl(cb: (data: PickerCallbackData) => void) {
       registered = cb;
@@ -71,6 +85,7 @@ function installGooglePickerStub(): PickerSpyState {
   builder.setOAuthToken.mockReturnValue(builder);
   builder.setDeveloperKey.mockReturnValue(builder);
   builder.setAppId.mockReturnValue(builder);
+  builder.setOrigin.mockReturnValue(builder);
   builder.addView.mockReturnValue(builder);
 
   function PickerBuilderCtorImpl(this: unknown): unknown {
@@ -91,11 +106,14 @@ function installGooglePickerStub(): PickerSpyState {
     setOAuthToken: builder.setOAuthToken,
     setDeveloperKey: builder.setDeveloperKey,
     setAppId: builder.setAppId,
+    setOrigin: builder.setOrigin,
     addView: builder.addView,
     setCallback: builder.setCallback,
     build: builder.build,
     setVisible,
     setMimeTypes,
+    setIncludeFolders,
+    setSelectFolderEnabled,
     docsViewCtor,
     pickerBuilderCtor,
     triggerCallback: (data) => {
@@ -178,16 +196,43 @@ describe('DrivePicker — happy path', () => {
     expect(mimeCalls).toEqual(['application/pdf']);
   });
 
-  it('mimeFilter="all" configures pdf + gdoc + docx views', async () => {
+  /*
+   * 2026-05-04 — production bug: with mimeFilter="all" (the default
+   * for UploadRoute), the picker rendered THREE identical "Google
+   * Drive" tabs — one per DocsView we added. Google's picker labels
+   * each tab from the ViewId, so passing the same ViewId.DOCS three
+   * times produces three duplicate tabs. Folders were also missing
+   * because every view filtered by file MIME (folders have their
+   * own application/vnd.google-apps.folder MIME). Fix is to use a
+   * single DocsView with comma-joined MIME types + setIncludeFolders.
+   */
+  it('mimeFilter="all" configures a SINGLE view with comma-joined MIMEs (no duplicate tabs)', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(1);
+    expect(pickerSpy.addView).toHaveBeenCalledTimes(1);
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
     expect(mimeCalls).toEqual([
-      'application/pdf',
-      'application/vnd.google-apps.document',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document',
     ]);
+  });
+
+  it('enables folder navigation so users can browse into Drive folders', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    // Folders visible in the file list…
+    expect(pickerSpy.setIncludeFolders).toHaveBeenCalledWith(true);
+    // …but not selectable (we only accept files, not folders).
+    expect(pickerSpy.setSelectFolderEnabled).toHaveBeenCalledWith(false);
+  });
+
+  it('sets builder origin to window.location.origin so picker postMessage works', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    expect(pickerSpy.setOrigin).toHaveBeenCalledWith(window.location.origin);
   });
 
   it('callback action="picked" forwards the doc to onPick + closes', async () => {

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -114,12 +114,36 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const builder = new picker.PickerBuilder()
       .setOAuthToken(creds.creds.accessToken)
       .setDeveloperKey(creds.creds.developerKey)
-      .setAppId(creds.creds.appId);
+      .setAppId(creds.creds.appId)
+      // Required for cross-origin postMessage from the picker iframe
+      // back to our SPA. Picker prod is at docs.google.com.
+      .setOrigin(window.location.origin);
 
-    for (const mime of MIMES_FOR_FILTER[mimeFilter]) {
-      const view = new picker.DocsView(picker.ViewId.DOCS).setMimeTypes(mime);
-      builder.addView(view);
-    }
+    // 2026-05-04 — single DocsView with comma-joined MIME types
+    // instead of one view per MIME. Reasons:
+    //   1. The picker labels each tab from its ViewId; passing
+    //      ViewId.DOCS three times rendered three identical
+    //      "Google Drive" tabs in prod.
+    //   2. setMimeTypes accepts a comma-separated list per
+    //      Google's Picker API ref:
+    //      https://developers.google.com/drive/picker/reference#docs-view
+    //   3. setIncludeFolders(true) re-enables folder navigation,
+    //      which was lost because every per-MIME view filtered
+    //      folders out (folders have application/vnd.google-apps.folder).
+    //      setSelectFolderEnabled(false) keeps "Select" disabled
+    //      until the user clicks an actual file.
+    //
+    // KNOWN ISSUE — Google-side: the modular picker's thumbnail
+    // requests to lh3.googleusercontent.com return without a
+    // Cross-Origin-Resource-Policy header, so Chrome's ORB blocks
+    // them with net::ERR_BLOCKED_BY_ORB. The picker still works
+    // for selection — only the thumbnail previews stay grey. Track:
+    // https://issuetracker.google.com (modular picker thumbnails).
+    const view = new picker.DocsView(picker.ViewId.DOCS)
+      .setMimeTypes(MIMES_FOR_FILTER[mimeFilter].join(','))
+      .setIncludeFolders(true)
+      .setSelectFolderEnabled(false);
+    builder.addView(view);
 
     builder.setCallback((data) => {
       if (data.action === 'picked') {

--- a/apps/web/src/components/drive-picker/google-picker-types.ts
+++ b/apps/web/src/components/drive-picker/google-picker-types.ts
@@ -30,6 +30,13 @@ export interface PickerBuilder {
   setOAuthToken(token: string): PickerBuilder;
   setDeveloperKey(key: string): PickerBuilder;
   setAppId(id: string): PickerBuilder;
+  /**
+   * Required when the picker iframe is embedded in a different origin
+   * than the parent — without it, Google's picker can't postMessage
+   * back the selection. Defensive even when origins match (HMR /
+   * preview deployments).
+   */
+  setOrigin(origin: string): PickerBuilder;
   addView(view: unknown): PickerBuilder;
   setCallback(cb: (data: PickerCallbackData) => void): PickerBuilder;
   build(): PickerInstance;
@@ -37,6 +44,10 @@ export interface PickerBuilder {
 
 export interface DocsViewBuilder {
   setMimeTypes(mimes: string): DocsViewBuilder;
+  /** Show folders in the listing so the user can navigate into them. */
+  setIncludeFolders(include: boolean): DocsViewBuilder;
+  /** When false, folders are visible but not selectable as a result. */
+  setSelectFolderEnabled(enabled: boolean): DocsViewBuilder;
 }
 
 export interface PickerNamespace {


### PR DESCRIPTION
## Summary
- Production bug — opening the Drive picker rendered **three identical \"Google Drive\" tabs** and showed **no folders**.
- Root cause was the picker config in [DrivePicker.tsx](apps/web/src/components/drive-picker/DrivePicker.tsx): it added one \`DocsView\` per MIME type, all pinned to \`ViewId.DOCS\`. Google's picker labels each tab from its ViewId, so 3 MIMEs → 3 duplicate tabs. Folders were filtered out because every per-MIME view excluded \`application/vnd.google-apps.folder\`.
- Fix: single \`DocsView\` with comma-joined MIMEs (Picker API explicitly accepts CSV), \`setIncludeFolders(true)\` so folders appear, \`setSelectFolderEnabled(false)\` so only files remain pickable, and \`setOrigin(window.location.origin)\` for cross-origin postMessage from the \`docs.google.com\` iframe.

### Known Google-side limitation (documented in code)
Modular picker thumbnail fetches to \`lh3.googleusercontent.com\` come back without \`Cross-Origin-Resource-Policy\`, so Chrome's ORB blocks them with \`net::ERR_BLOCKED_BY_ORB\`. The picker still works for selection — only the thumbnail previews stay grey. This is a Google-side issue, not fixable from our SPA.

### TDD evidence
3 RED tests then GREEN:
- \`mimeFilter=\"all\"\` configures **a single view** with comma-joined MIMEs (was 3 separate views)
- \`setIncludeFolders(true)\` + \`setSelectFolderEnabled(false)\`
- \`setOrigin(window.location.origin)\`

Full web vitest 1395/1395 ✓.

## Test plan
- [x] \`pnpm --filter web typecheck\` ✓
- [x] \`pnpm --filter web lint\` ✓
- [x] \`pnpm --filter web vitest run\` ✓
- [ ] After deploy: open Drive picker on prod — single \"Google Drive\" tab, folders visible, file selection round-trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)