### PR TITLE
fix(web): Templates upload step uses Sign-flow's inline Drive layout

### DIFF
--- a/apps/web/src/pages/UploadPage/UploadPage.tsx
+++ b/apps/web/src/pages/UploadPage/UploadPage.tsx
@@ -135,6 +135,7 @@ export const UploadPage = forwardRef<HTMLDivElement, UploadPageProps>((props, re
     onError,
     title = DEFAULT_TITLE,
     subtitle = DEFAULT_SUBTITLE,
+    hideHeader = false,
     dropHeading = DEFAULT_DROP_HEADING,
     dropSubheading,
     chooseLabel = DEFAULT_CHOOSE,
@@ -251,10 +252,12 @@ export const UploadPage = forwardRef<HTMLDivElement, UploadPageProps>((props, re
     <Body {...rest} ref={ref}>
       <Main>
         <Inner>
-          <div>
-            <Heading>{title}</Heading>
-            <Subtitle>{subtitle}</Subtitle>
-          </div>
+          {hideHeader ? null : (
+            <div>
+              <Heading>{title}</Heading>
+              <Subtitle>{subtitle}</Subtitle>
+            </div>
+          )}
           {templateBannerTitle ? (
             <TemplateBanner
               $tone={templateBannerTone}

--- a/apps/web/src/pages/UploadPage/UploadPage.types.ts
+++ b/apps/web/src/pages/UploadPage/UploadPage.types.ts
@@ -33,6 +33,13 @@ export interface UploadPageProps extends Omit<HTMLAttributes<HTMLDivElement>, 'o
   // Dropzone copy / limits -----------------------------------------------
   readonly title?: string | undefined;
   readonly subtitle?: string | undefined;
+  /**
+   * When `true`, the page-level `title` + `subtitle` block is omitted —
+   * useful when the host page already renders its own header chrome
+   * (e.g. the templates wizard's `DocumentTitleRow`) and only wants to
+   * embed the dropzone surface. Defaults to `false`.
+   */
+  readonly hideHeader?: boolean | undefined;
   readonly dropHeading?: string | undefined;
   readonly dropSubheading?: ReactNode | undefined;
   readonly chooseLabel?: string | undefined;

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.layout.test.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.layout.test.tsx
@@ -1,0 +1,139 @@
+import type { JSX } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import * as flagsModule from 'shared';
+import { renderWithProviders } from '../../test/renderWithProviders';
+import { setTemplates } from '../../features/templates';
+import { SAMPLE_TEMPLATES as TEMPLATES } from '../../test/templateFixtures';
+
+const connectMutateMock = vi.fn();
+vi.mock('../../routes/settings/integrations/useGDriveAccounts', () => ({
+  useGDriveAccounts: vi.fn(),
+  GDRIVE_ACCOUNTS_KEY: ['integrations', 'gdrive', 'accounts'],
+  useConnectGDrive: () => ({ mutate: connectMutateMock }),
+  useDisconnectGDrive: vi.fn(),
+  useGDriveOAuthMessageListener: vi.fn(),
+}));
+
+import * as gdriveAccountsHook from '../../routes/settings/integrations/useGDriveAccounts';
+
+vi.mock('../../components/drive-picker', () => ({
+  DrivePicker: (props: { open: boolean }): JSX.Element | null => {
+    if (!props.open) return null;
+    return <div data-testid="drive-picker-stub" />;
+  },
+  PICKER_HEIGHT_PX: 600,
+  PICKER_WIDTH_PX: 760,
+}));
+
+import { UseTemplatePage } from './UseTemplatePage';
+
+const SAMPLE = TEMPLATES[0]!;
+
+function renderAt(path: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/templates/:id/use" element={<UseTemplatePage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+/**
+ * Layout-parity test (parent: fix/web-templates-upload-layout-parity).
+ *
+ * The Sign flow's UploadPage hosts the "Pick from Google Drive" /
+ * "Connect Google Drive" CTA INSIDE the dropzone, alongside the
+ * "Start from a template" link, in the secondary-actions row
+ * (TemplatePromptDivider). Pre-fix the Templates flow showed the
+ * Drive CTA as a wide standalone card BELOW the dropzone — visually
+ * inconsistent and treating Drive as a heavier affordance than
+ * the primary "Choose file" button.
+ *
+ * Both surfaces (the wizard-`new` mode upload screen and the
+ * `using` mode "Upload a new one" branch) must place the Drive CTA
+ * INSIDE the same accessible region as the dropzone.
+ */
+describe('UseTemplatePage layout parity with Sign flow', () => {
+  let isFeatureEnabledSpy: ReturnType<typeof vi.spyOn>;
+  const useGDriveAccountsMock = vi.mocked(gdriveAccountsHook.useGDriveAccounts);
+
+  beforeEach(() => {
+    setTemplates(TEMPLATES);
+    isFeatureEnabledSpy = vi.spyOn(flagsModule, 'isFeatureEnabled');
+    useGDriveAccountsMock.mockReset();
+    isFeatureEnabledSpy.mockReturnValue(true);
+  });
+  afterEach(() => {
+    setTemplates([]);
+    isFeatureEnabledSpy.mockRestore();
+  });
+
+  function mockAccounts(connected: boolean) {
+    useGDriveAccountsMock.mockReturnValue({
+      data: connected
+        ? [{ id: 'acct-1', email: 'jamie@example.com', connectedAt: '', lastUsedAt: null }]
+        : [],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof gdriveAccountsHook.useGDriveAccounts>);
+  }
+
+  it('new-template upload screen renders the "Upload an example document" hero copy', () => {
+    mockAccounts(true);
+    renderAt('/templates/new/use');
+    expect(
+      screen.getByRole('heading', { level: 1, name: /upload an example document/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/representative copy works best/i)).toBeInTheDocument();
+    expect(screen.getByText(/drop a sample pdf/i)).toBeInTheDocument();
+    expect(screen.getByText(/up to 25 mb/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /choose file/i })).toBeInTheDocument();
+  });
+
+  it('new-template upload screen places "Pick from Google Drive" INSIDE the dropzone region', () => {
+    mockAccounts(true);
+    renderAt('/templates/new/use');
+    const region = screen.getByRole('region', { name: /upload a pdf/i });
+    const driveCta = within(region).getByRole('button', {
+      name: /pick from google drive/i,
+    });
+    expect(driveCta).toBeInTheDocument();
+    // The CTA must NOT be a wide standalone card sibling of the dropzone:
+    // the only Drive button on the page should be the inline one.
+    const allDriveButtons = screen.getAllByRole('button', {
+      name: /pick from google drive/i,
+    });
+    expect(allDriveButtons).toHaveLength(1);
+  });
+
+  it('new-template upload screen places "Connect Google Drive" INSIDE the dropzone region when no account', () => {
+    mockAccounts(false);
+    renderAt('/templates/new/use');
+    const region = screen.getByRole('region', { name: /upload a pdf/i });
+    const connectCta = within(region).getByRole('button', {
+      name: /connect google drive/i,
+    });
+    expect(connectCta).toBeInTheDocument();
+    expect(connectCta).toBeEnabled();
+    fireEvent.click(connectCta);
+    expect(connectMutateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('using-template "Upload a new one" branch places "Pick from Google Drive" INSIDE the dropzone region', () => {
+    mockAccounts(true);
+    renderAt(`/templates/${encodeURIComponent(SAMPLE.id)}/use`);
+    fireEvent.click(screen.getByRole('radio', { name: /upload a new one/i }));
+    const region = screen.getByRole('region', { name: /upload a pdf/i });
+    const driveCta = within(region).getByRole('button', {
+      name: /pick from google drive/i,
+    });
+    expect(driveCta).toBeInTheDocument();
+    const allDriveButtons = screen.getAllByRole('button', {
+      name: /pick from google drive/i,
+    });
+    expect(allDriveButtons).toHaveLength(1);
+  });
+});

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.styles.ts
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.styles.ts
@@ -53,30 +53,6 @@ export const StepLede = styled.p`
   max-width: 560px;
 `;
 
-/**
- * "Upload an example document" — Step 1 heading used by the `new`
- * mode path (no segmented chooser, just an upload prompt).
- * Centered hero-style heading + lede, mirrors the design guide's
- * UploadScreen visuals.
- */
-export const NewDocHeading = styled.h1`
-  font-family: ${({ theme }) => theme.font.serif};
-  font-size: 36px;
-  font-weight: ${({ theme }) => theme.font.weight.medium};
-  letter-spacing: -0.02em;
-  line-height: 1.15;
-  margin: 0;
-  color: ${({ theme }) => theme.color.fg[1]};
-`;
-
-export const NewDocLede = styled.p`
-  font-size: 14px;
-  color: ${({ theme }) => theme.color.fg[3]};
-  margin: 8px 0 0;
-  line-height: 1.55;
-  max-width: 640px;
-`;
-
 export const StepFooter = styled.div`
   display: flex;
   align-items: center;

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
@@ -4,7 +4,6 @@ import { ArrowRight, Bookmark, Info, UploadCloud } from 'lucide-react';
 import { isFeatureEnabled } from 'shared';
 import type { AddSignerContact } from '@/components/AddSignerDropdown/AddSignerDropdown.types';
 import { Button } from '@/components/Button';
-import { DropArea } from '@/components/DropArea';
 import { Icon } from '@/components/Icon';
 import { SignersStepCard } from '@/components/SignersStepCard';
 import type { SignersStepSigner } from '@/components/SignersStepCard';
@@ -14,9 +13,9 @@ import { DrivePicker } from '@/components/drive-picker';
 import {
   ConversionFailedDialog,
   ConversionProgressDialog,
-  DriveTemplateReplaceButton,
   useDriveImport,
 } from '@/features/gdriveImport';
+import { UploadPage } from '@/pages/UploadPage';
 import {
   useConnectGDrive,
   useGDriveAccounts,
@@ -36,8 +35,6 @@ import {
   NotFoundCard,
   NotFoundLede,
   NotFoundTitle,
-  NewDocHeading,
-  NewDocLede,
   Page,
   SavedDocBody,
   SavedDocCard,
@@ -380,19 +377,7 @@ export function UseTemplatePage() {
       {step === 1 ? (
         <StepBody>
           <StepInner $wide>
-            {isNewTemplate ? (
-              // New-mode hero: matches the design guide's UploadScreen
-              // (`Design-Guide/.../UseTemplate.jsx` DocumentStep mode 'new').
-              // Big serif heading + lede over the dropzone — no segmented
-              // chooser because there's no saved doc to fall back to.
-              <div>
-                <NewDocHeading>Upload an example document</NewDocHeading>
-                <NewDocLede>
-                  A representative copy works best — we&apos;ll use it to place fields. Real
-                  documents go in later.
-                </NewDocLede>
-              </div>
-            ) : (
+            {!isNewTemplate ? (
               <DocumentTitleRow>
                 <DocumentTitle>Document</DocumentTitle>
                 <TooltipWrap
@@ -415,7 +400,7 @@ export function UseTemplatePage() {
                   ) : null}
                 </TooltipWrap>
               </DocumentTitleRow>
-            )}
+            ) : null}
 
             {!isNewTemplate ? (
               <Segmented role="radiogroup" aria-label="Document source">
@@ -510,28 +495,39 @@ export function UseTemplatePage() {
                     </Button>
                   </SavedDocCard>
                 ) : (
-                  <>
-                    <DropArea
-                      onFileSelected={(f) => {
-                        setUploadError(null);
-                        setPendingFile(f);
-                      }}
-                      onError={(_, message) => setUploadError(message)}
-                      heading={template ? 'Drop a different PDF' : 'Drop a sample PDF'}
-                      subheading={
-                        template ? 'Saved layout will snap onto it · up to 25 MB' : 'up to 25 MB'
-                      }
-                    />
-                    {gdriveOn ? (
-                      <div style={{ marginTop: 12 }}>
-                        <DriveTemplateReplaceButton
-                          connected={driveAccountId !== null}
-                          onPickDrive={() => setDrivePickerOpen(true)}
-                          onConnect={handleConnectDrive}
-                        />
-                      </div>
-                    ) : null}
-                  </>
+                  // Reuse the Sign-flow's UploadPage so the secondary
+                  // actions row (Drive picker / Connect Drive) lives
+                  // INSIDE the dropzone — same layout pattern as
+                  // `/document/new`. Pre-2026-05-04 the templates flow
+                  // hosted Drive as a wide standalone card below the
+                  // dropzone (DriveTemplateReplaceButton); the inline
+                  // composition matches the operator design feedback
+                  // and treats Drive as a peer of "Choose file".
+                  <UploadPage
+                    hideHeader={!isNewTemplate}
+                    {...(isNewTemplate
+                      ? {
+                          title: 'Upload an example document',
+                          subtitle:
+                            "A representative copy works best — we'll use it to place fields. Real documents go in later.",
+                        }
+                      : {})}
+                    dropHeading={template ? 'Drop a different PDF' : 'Drop a sample PDF'}
+                    {...(template
+                      ? { dropSubheading: 'Saved layout will snap onto it · up to 25 MB' }
+                      : {})}
+                    onFileSelected={(f) => {
+                      setUploadError(null);
+                      setPendingFile(f);
+                    }}
+                    onError={(_, message) => setUploadError(message)}
+                    {...(gdriveOn && driveAccountId !== null
+                      ? { onPickDrive: () => setDrivePickerOpen(true) }
+                      : {})}
+                    {...(gdriveOn && driveAccountId === null
+                      ? { onConnectDrive: handleConnectDrive }
+                      : {})}
+                  />
                 )}
                 {uploadError ? <FooterHint role="alert">{uploadError}</FooterHint> : null}
               </>


### PR DESCRIPTION
## Summary
- Templates wizard's upload step (`UseTemplatePage`) now reuses the Sign-flow's `UploadPage` component, so the "Pick from Google Drive" / "Connect Google Drive" CTA renders **inside** the dropzone (in the same `TemplatePromptDivider` row that already hosts "Start from a template"), not as a wide standalone card below it.
- Adds `hideHeader?: boolean` to `UploadPageProps` so the using-mode branch (which already has `DocumentTitleRow` + segmented chooser as page chrome) can suppress the redundant page-level title block. New-mode hero copy still renders via the existing `title`/`subtitle` props.
- Removes the now-unused `DropArea` + `DriveTemplateReplaceButton` instantiations from the templates flow plus the orphaned `NewDocHeading` / `NewDocLede` styled-components. Drive picker logic, OAuth bridge, and `useDriveImport` orchestrator are untouched — only the position of the CTA changes.

### Before / After
- **Before**: dropzone → wide button card "Pick from Google Drive" / "Connect Google Drive" stacked below.
- **After**: dropzone with inline secondary-actions row: `[GDrive] Pick from Google Drive · [GDrive] Connect Google Drive` (mutually exclusive based on connection state), exactly like `/document/new`.

## Test plan
- [x] New RED→GREEN test: `apps/web/src/pages/UseTemplatePage/UseTemplatePage.layout.test.tsx` — 4 assertions covering (a) new-mode hero copy ("Upload an example document" / "representative copy works best" / "Drop a sample PDF" / "up to 25 MB" / "Choose file"), (b) Drive CTA INSIDE the `region[name="Upload a PDF"]` for new mode, (c) Connect-Drive CTA inside the same region + wires to `useConnectGDrive().mutate()`, (d) Drive CTA inside the region in using-mode "Upload a new one" branch.
- [x] All 18 existing `UseTemplatePage` tests pass (gdrive + flow + pre-fill).
- [x] `pnpm --filter web typecheck`
- [x] `pnpm --filter web lint`
- [x] `pnpm --filter web vitest run` — 1397/1397 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)