### PR TITLE
fix(api): co-deploy Gotenberg with API so .docx conversion works in prod

### DIFF
--- a/apps/api/test/gdrive-conversion-deploy.contract.spec.ts
+++ b/apps/api/test/gdrive-conversion-deploy.contract.spec.ts
@@ -1,0 +1,114 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Phase-6 prod-bug-loop regression (2026-05-04):
+ *
+ * Selecting a .docx from the Drive picker on prod returned
+ * `{ status: "failed", errorCode: "conversion-failed" }` because the
+ * deploy pipeline (`.github/workflows/deploy.yml`) only brought up the
+ * services declared in the ROOT `docker-compose.yml` — and that file
+ * historically defined `api` + `caddy` only. The Gotenberg sidecar
+ * lived in `deploy/docker-compose.yml` on a separate docker network
+ * (`gdrive` bridge) that nothing in the pipeline ever started, and
+ * even when started manually it was unreachable from the API
+ * container's default network. Result: every .docx hit ECONNREFUSED
+ * on `http://gotenberg:3000` and the runJob catch surfaced
+ * `conversion-failed`.
+ *
+ * This contract test asserts that the canonical deploy compose file
+ * co-deploys Gotenberg with the API in a way that:
+ *   1. matches the API's default `GDRIVE_GOTENBERG_URL` (gotenberg:3000),
+ *   2. keeps the sidecar unreachable from the public internet,
+ *   3. pins the major version + bounds resource usage.
+ *
+ * The test reads the compose file as text and asserts on substrings +
+ * structural shape. We avoid pulling in `js-yaml` for one test (not in
+ * the api package's deps); the assertions below are tight enough that
+ * a regression PR can't pass them without restoring the contract.
+ */
+describe('root docker-compose.yml — Gotenberg co-deploy contract', () => {
+  const composePath = join(__dirname, '..', '..', '..', 'docker-compose.yml');
+  const compose = readFileSync(composePath, 'utf8');
+
+  it('declares a `gotenberg` service alongside `api`', () => {
+    // crude top-level service detection: lines that start with two-space
+    // indent and end in a colon, inside the `services:` block.
+    const servicesMatch = compose.match(/^services:\s*$([\s\S]*?)(?=^volumes:|^networks:)/m);
+    expect(servicesMatch).not.toBeNull();
+    const block = servicesMatch![1] ?? '';
+    const serviceNames = Array.from(block.matchAll(/^ {2}([a-z0-9_-]+):\s*$/gm)).map((m) => m[1]);
+    expect(serviceNames).toEqual(expect.arrayContaining(['api', 'gotenberg']));
+  });
+
+  it('pins gotenberg image to the major `gotenberg/gotenberg:8`', () => {
+    expect(compose).toMatch(/image:\s*gotenberg\/gotenberg:8\b/);
+  });
+
+  it('does NOT publish a host port for gotenberg (must remain internal)', () => {
+    // Find the gotenberg block (from `  gotenberg:` until the next
+    // top-level service / section).
+    const gotMatch = compose.match(
+      /^ {2}gotenberg:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
+    );
+    expect(gotMatch).not.toBeNull();
+    const gotBlock = gotMatch![1] ?? '';
+    // No `ports:` key inside the gotenberg service block — exposure
+    // would surface an unauth'd /forms/libreoffice/convert endpoint to
+    // the internet.
+    expect(gotBlock).not.toMatch(/^ {4}ports:\s*$/m);
+  });
+
+  it('api `depends_on:` includes `gotenberg` so compose starts the sidecar first', () => {
+    const apiMatch = compose.match(
+      /^ {2}api:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
+    );
+    expect(apiMatch).not.toBeNull();
+    const apiBlock = apiMatch![1] ?? '';
+    // `depends_on` may be a list (-) or a map; both forms are accepted
+    // as long as `gotenberg` appears under it.
+    const dependsOnIdx = apiBlock.search(/^ {4}depends_on:\s*$/m);
+    expect(dependsOnIdx).toBeGreaterThanOrEqual(0);
+    const dependsOnTail = apiBlock.slice(dependsOnIdx);
+    expect(dependsOnTail).toMatch(/(?:- gotenberg\b|^ {6}gotenberg:\s*$)/m);
+  });
+
+  it('api + gotenberg share the compose default network (no custom `networks:` on gotenberg)', () => {
+    // The simplest path that works: neither service declares an
+    // explicit `networks:` key, so they both join the compose default
+    // bridge — and `http://gotenberg:3000` resolves via service-name
+    // DNS. If a future PR introduces a custom network, both services
+    // must be on it, but we keep the contract minimal here: assert no
+    // `networks:` block under gotenberg so the default-bridge contract
+    // is preserved.
+    const gotMatch = compose.match(
+      /^ {2}gotenberg:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
+    );
+    expect(gotMatch).not.toBeNull();
+    const gotBlock = gotMatch![1] ?? '';
+    expect(gotBlock).not.toMatch(/^ {4}networks:\s*$/m);
+  });
+
+  it('caps gotenberg memory at 1.5 GB and CPU at 1.5 vCPU (mirrors deploy/docker-compose.yml)', () => {
+    const gotMatch = compose.match(
+      /^ {2}gotenberg:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
+    );
+    expect(gotMatch).not.toBeNull();
+    const gotBlock = gotMatch![1] ?? '';
+    expect(gotBlock).toMatch(/memory:\s*1536M\b/);
+    expect(gotBlock).toMatch(/cpus:\s*['"]?1\.5['"]?/);
+  });
+
+  it('hard-disables non-LibreOffice routes via the gotenberg command', () => {
+    const gotMatch = compose.match(
+      /^ {2}gotenberg:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
+    );
+    expect(gotMatch).not.toBeNull();
+    const gotBlock = gotMatch![1] ?? '';
+    expect(gotBlock).toMatch(/--api-port=3000/);
+    expect(gotBlock).toMatch(/--api-timeout=30s/);
+    expect(gotBlock).toMatch(/--chromium-disable-routes=true/);
+    expect(gotBlock).toMatch(/--webhook-disable-routes=true/);
+    expect(gotBlock).toMatch(/--pdfengines-disable-routes=true/);
+  });
+});

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,5 +1,17 @@
-# WT-D Drive doc → PDF conversion sidecar.
+# WT-D Drive doc → PDF conversion sidecar — HISTORICAL / DEPRECATED.
 #
+# As of 2026-05-04 the canonical Gotenberg sidecar definition lives in
+# the repo-root `docker-compose.yml`, alongside `api` and `caddy`, so
+# the existing deploy step (`docker compose up -d --build` against
+# /opt/seald/docker-compose.yml on the EC2 host) brings the sidecar up
+# automatically AND on the same default bridge network as the API.
+# This file is kept around for historical reference and standalone
+# Gotenberg restarts; do NOT edit the sidecar contract here without
+# mirroring the change to the root compose. A separate cleanup PR
+# will delete this file once we're confident no operator runbook
+# still references it.
+#
+# Original notes (still accurate):
 # This file ships ONLY the Gotenberg LibreOffice converter today. It is
 # additive — the API itself runs on the host EC2 directly via systemd +
 # Caddy (see deploy/Caddyfile); we do NOT compose the API process here.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,9 @@
 # Single-node deploy template for Seald.
 #
 # Runs the API + in-process worker behind Caddy (auto-HTTPS + reverse
-# proxy). Postgres and Storage live in Supabase so we don't provision
-# them here.
+# proxy), plus the Gotenberg LibreOffice sidecar that the Drive
+# integration uses to convert .docx selections to PDF. Postgres and
+# Storage live in Supabase so we don't provision them here.
 #
 # Usage:
 #   1. Copy .env.example to .env and fill in:
@@ -20,6 +21,18 @@
 #   2. docker compose up -d
 #   3. Cron: 'curl -fsS -X POST -H "X-Cron-Secret: $CRON_SECRET" \
 #            http://localhost:3000/internal/cron/expire' every 15 min.
+#
+# Gotenberg (Drive .docx → PDF):
+#   The `gotenberg` service is co-deployed with the API on the compose
+#   default bridge network so the API resolves it as
+#   `http://gotenberg:3000` (matches the GDRIVE_GOTENBERG_URL default
+#   in apps/api/src/config/env.schema.ts). It is intentionally NOT
+#   published to the host (no `ports:` block) — the LibreOffice convert
+#   endpoint must remain unreachable from the public internet, since
+#   Gotenberg ships without authentication. Resource caps (1.5 GB RAM /
+#   1.5 vCPU) bound a malicious upload from OOMing the box; the 25 MB
+#   inbound size cap (apps/api GDRIVE_CONVERSION_MAX_BYTES) bounds the
+#   input. Doc + PDF Drive branches do not depend on Gotenberg.
 
 services:
   api:
@@ -51,6 +64,11 @@ services:
     # signer is configured for the local-P12 path.
     volumes:
       - /opt/seald/secrets:/opt/seald/secrets:ro
+    # Wait for the LibreOffice sidecar before accepting traffic so the
+    # first .docx Drive conversion after a deploy doesn't race a still-
+    # booting Gotenberg.
+    depends_on:
+      - gotenberg
     healthcheck:
       test: ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))\""]
       interval: 30s
@@ -61,6 +79,49 @@ services:
     cap_drop: ["ALL"]
     security_opt:
       - no-new-privileges:true
+
+  gotenberg:
+    # WT-D Drive doc → PDF conversion sidecar. Definition mirrors
+    # deploy/docker-compose.yml (kept around as historical reference;
+    # the canonical sidecar config now lives here so a single
+    # `docker compose up -d --build` brings the whole stack up).
+    image: gotenberg/gotenberg:8
+    restart: unless-stopped
+    # CRITICAL: no `ports:` block. Gotenberg listens on :3000 inside
+    # the container; we reach it from the API as `http://gotenberg:3000`
+    # over the compose default bridge network only. Adding a
+    # `ports: ["3000:3000"]` line here would expose an unauth'd
+    # /forms/libreoffice/convert endpoint to the public internet —
+    # flag any such PR in review.
+    command:
+      - 'gotenberg'
+      - '--api-port=3000'
+      # API timeout caps every conversion at 30s — matches the
+      # AbortSignal cancel window the SPA expects (long-poll with
+      # 100 ms cancel latency budget per WT-D test plan). Keep in sync
+      # with `GDRIVE_CONVERSION_TIMEOUT_MS` (future-flag) if added.
+      - '--api-timeout=30s'
+      # Hard-disable webhook + chromium routes; we only use LibreOffice.
+      # Closing every other route reduces attack surface in the unlikely
+      # event the network barrier ever leaks.
+      - '--chromium-disable-routes=true'
+      - '--webhook-disable-routes=true'
+      - '--pdfengines-disable-routes=true'
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    # Resource caps to prevent a malicious upload from OOMing the box.
+    # The 25 MB inbound size cap (apps/api GDRIVE_CONVERSION_MAX_BYTES)
+    # bounds the input; LibreOffice peak memory for a 25 MB .docx is
+    # under 1 GB in practice. 1.5 GB gives headroom; tighten via runbook
+    # once we have steady-state telemetry.
+    deploy:
+      resources:
+        limits:
+          memory: 1536M
+          cpus: '1.5'
 
   caddy:
     image: caddy:2.8-alpine


### PR DESCRIPTION
## Summary

Production .docx selections from the Drive picker were returning
`{"status":"failed","errorCode":"conversion-failed"}` because the API
container hit ECONNREFUSED on `http://gotenberg:3000`. This PR moves
the Gotenberg sidecar definition into the **root** `docker-compose.yml`
so the existing deploy step (`docker compose up -d --build` against
`/opt/seald/docker-compose.yml`) brings it up alongside the API on the
same default bridge network — and `gotenberg:3000` resolves via
service-name DNS.

## Reproduction (user-supplied prod failure)

```
POST https://api.seald.nromomentum.com/integrations/gdrive/conversion/start
  body: { fileId: "<docx-file-id>",
          mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" }
-> 202 { jobId: "<jobId>" }

GET https://api.seald.nromomentum.com/integrations/gdrive/conversion/<jobId>
-> 200 { "jobId":"<jobId>", "status":"failed", "errorCode":"conversion-failed" }
```

## Root cause

- `apps/api/src/integrations/gdrive/conversion/conversion.service.ts:181`
  posts to Gotenberg using env `GDRIVE_GOTENBERG_URL` (default
  `http://gotenberg:3000` — see `apps/api/src/config/env.schema.ts:148`).
- The deploy workflow (`.github/workflows/deploy.yml`) only brings up
  services declared in the root `docker-compose.yml`, which historically
  defined `api` + `caddy` only. **No `gotenberg` service.**
- A separate `deploy/docker-compose.yml` defined the sidecar on its own
  `gdrive` bridge network — but nothing in the deploy pipeline ever
  brought it up, and even if started manually it was on a different
  network so the API container's DNS resolver could never see
  `gotenberg`.
- Doc + PDF Drive branches never call Gotenberg (they hit
  `googleapis.com` directly), so only `.docx` failed in prod.

## Changes

- `docker-compose.yml` (root): adds the `gotenberg` service mirroring
  the historical sidecar contract — `gotenberg/gotenberg:8`, no
  `ports:`, 1.5 GB RAM / 1.5 vCPU caps, all routes except LibreOffice
  hard-disabled, healthcheck. Also adds `gotenberg` to the api
  service's `depends_on:` so the sidecar is up before the API accepts
  traffic.
- `deploy/docker-compose.yml`: marked deprecated/historical (kept for
  reference; sidecar contract now canonical in root compose).
- `apps/api/test/gdrive-conversion-deploy.contract.spec.ts`: new
  contract test that asserts the root compose declares + secures the
  sidecar. Was **RED before this PR (7 failing assertions)**, now
  **GREEN (7/7)**. Guards against regressions (e.g. a future PR that
  drops the sidecar or accidentally adds a `ports:` mapping that would
  expose the unauth'd `/forms/libreoffice/convert` endpoint).

Test count delta: 881 → **888** (+7).

## Test plan

- [x] Local: `cd apps/api && pnpm typecheck && pnpm lint` — clean.
- [x] Local: `cd apps/api && pnpm test` — 73 suites, 888 tests pass
  (was 881; added 7 contract assertions).
- [x] Pre-fix RED proof: stashing the compose change leaves the contract
  test failing on all 7 assertions — confirms the test would catch the
  bug.
- [ ] **Post-deploy prod re-verify** (deploy-pending — needs the user
  with a fresh `.docx` Drive file ID + bearer token):
  ```
  POST /integrations/gdrive/conversion/start
    body: { fileId, mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" }
  GET  /integrations/gdrive/conversion/<jobId>
    -> { status: "done", url: "<signed-url>" }
  ```

## Rollback

Revert this PR and redeploy. Doc + PDF Drive branches keep working;
`.docx` regresses to `conversion-failed` exactly as before. The
`deploy/docker-compose.yml` standalone path (`docker compose -f
deploy/docker-compose.yml up -d gotenberg`) remains as a manual fallback
but is on the wrong network — it would not actually fix the bug.

## Security note

The sidecar deliberately has **no `ports:` block**. Gotenberg ships
without authentication, and the contract test asserts on the absence of
`ports:` under the `gotenberg:` service so a future PR can't silently
expose `/forms/libreoffice/convert` to the public internet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)