### PR TITLE
feat(web): Drive picker — My Drive + Shared with me + Shared drives tabs

### DIFF
--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -27,6 +27,14 @@ const ACCOUNT_ID = '11111111-1111-4111-8111-111111111111';
 const fetchMock = fetchPickerCredentials as unknown as ReturnType<typeof vi.fn>;
 const useGoogleApiMock = useGoogleApi as unknown as ReturnType<typeof vi.fn>;
 
+interface DocsViewSpy {
+  readonly setMimeTypesCalls: ReadonlyArray<unknown>;
+  readonly setIncludeFoldersCalls: ReadonlyArray<unknown>;
+  readonly setSelectFolderEnabledCalls: ReadonlyArray<unknown>;
+  readonly setOwnedByMeCalls: ReadonlyArray<unknown>;
+  readonly setEnableDrivesCalls: ReadonlyArray<unknown>;
+}
+
 interface PickerSpyState {
   readonly setOAuthToken: ReturnType<typeof vi.fn>;
   readonly setDeveloperKey: ReturnType<typeof vi.fn>;
@@ -36,11 +44,19 @@ interface PickerSpyState {
   readonly setCallback: ReturnType<typeof vi.fn>;
   readonly build: ReturnType<typeof vi.fn>;
   readonly setVisible: ReturnType<typeof vi.fn>;
+  readonly enableFeature: ReturnType<typeof vi.fn>;
+  /** All `setMimeTypes` calls aggregated across every DocsView. */
   readonly setMimeTypes: ReturnType<typeof vi.fn>;
+  /** All `setIncludeFolders` calls aggregated across every DocsView. */
   readonly setIncludeFolders: ReturnType<typeof vi.fn>;
+  /** All `setSelectFolderEnabled` calls aggregated across every DocsView. */
   readonly setSelectFolderEnabled: ReturnType<typeof vi.fn>;
   readonly docsViewCtor: ReturnType<typeof vi.fn>;
   readonly pickerBuilderCtor: ReturnType<typeof vi.fn>;
+  /** First-arg of every `enableFeature` invocation, in order. */
+  readonly enableFeatureCalls: ReadonlyArray<string>;
+  /** One entry per `new DocsView()` invocation, in construction order. */
+  readonly docsViews: ReadonlyArray<DocsViewSpy>;
   triggerCallback: (data: PickerCallbackData) => void;
 }
 
@@ -49,32 +65,71 @@ let pickerSpy: PickerSpyState;
 function installGooglePickerStub(): PickerSpyState {
   let registered: ((data: PickerCallbackData) => void) | null = null;
   const setVisible = vi.fn();
-  const docsViewBuilder: {
-    setMimeTypes: ReturnType<typeof vi.fn>;
-    setIncludeFolders: ReturnType<typeof vi.fn>;
-    setSelectFolderEnabled: ReturnType<typeof vi.fn>;
-  } = {
-    setMimeTypes: vi.fn(),
-    setIncludeFolders: vi.fn(),
-    setSelectFolderEnabled: vi.fn(),
-  };
-  docsViewBuilder.setMimeTypes.mockReturnValue(docsViewBuilder);
-  docsViewBuilder.setIncludeFolders.mockReturnValue(docsViewBuilder);
-  docsViewBuilder.setSelectFolderEnabled.mockReturnValue(docsViewBuilder);
-  const setMimeTypes = docsViewBuilder.setMimeTypes;
-  const setIncludeFolders = docsViewBuilder.setIncludeFolders;
-  const setSelectFolderEnabled = docsViewBuilder.setSelectFolderEnabled;
+
+  // Aggregated spies — collect calls across every DocsView instance so
+  // existing single-view tests keep working unchanged.
+  const setMimeTypesAll = vi.fn();
+  const setIncludeFoldersAll = vi.fn();
+  const setSelectFolderEnabledAll = vi.fn();
+
+  const docsViews: DocsViewSpy[] = [];
 
   function DocsViewCtorImpl(this: unknown): unknown {
-    return docsViewBuilder;
+    const setMimeTypesCalls: unknown[] = [];
+    const setIncludeFoldersCalls: unknown[] = [];
+    const setSelectFolderEnabledCalls: unknown[] = [];
+    const setOwnedByMeCalls: unknown[] = [];
+    const setEnableDrivesCalls: unknown[] = [];
+
+    const view: Record<string, (arg: unknown) => unknown> = {
+      setMimeTypes(arg) {
+        setMimeTypesCalls.push(arg);
+        setMimeTypesAll(arg);
+        return view;
+      },
+      setIncludeFolders(arg) {
+        setIncludeFoldersCalls.push(arg);
+        setIncludeFoldersAll(arg);
+        return view;
+      },
+      setSelectFolderEnabled(arg) {
+        setSelectFolderEnabledCalls.push(arg);
+        setSelectFolderEnabledAll(arg);
+        return view;
+      },
+      setOwnedByMe(arg) {
+        setOwnedByMeCalls.push(arg);
+        return view;
+      },
+      setEnableDrives(arg) {
+        setEnableDrivesCalls.push(arg);
+        return view;
+      },
+    };
+
+    docsViews.push({
+      setMimeTypesCalls,
+      setIncludeFoldersCalls,
+      setSelectFolderEnabledCalls,
+      setOwnedByMeCalls,
+      setEnableDrivesCalls,
+    });
+
+    return view;
   }
   const docsViewCtor = vi.fn(DocsViewCtorImpl as () => unknown);
+
+  const enableFeatureCalls: string[] = [];
 
   const builder = {
     setOAuthToken: vi.fn(),
     setDeveloperKey: vi.fn(),
     setAppId: vi.fn(),
     setOrigin: vi.fn(),
+    enableFeature: vi.fn((name: string) => {
+      enableFeatureCalls.push(name);
+      return builder;
+    }),
     addView: vi.fn(),
     setCallback: vi.fn(function setCallbackImpl(cb: (data: PickerCallbackData) => void) {
       registered = cb;
@@ -99,6 +154,7 @@ function installGooglePickerStub(): PickerSpyState {
       DocsView: docsViewCtor,
       ViewId: { DOCS: 'DOCS' },
       Action: { PICKED: 'picked', CANCEL: 'cancel', LOADED: 'loaded' },
+      Feature: { SUPPORT_DRIVES: 'sdr' },
     },
   };
 
@@ -111,11 +167,14 @@ function installGooglePickerStub(): PickerSpyState {
     setCallback: builder.setCallback,
     build: builder.build,
     setVisible,
-    setMimeTypes,
-    setIncludeFolders,
-    setSelectFolderEnabled,
+    enableFeature: builder.enableFeature,
+    setMimeTypes: setMimeTypesAll,
+    setIncludeFolders: setIncludeFoldersAll,
+    setSelectFolderEnabled: setSelectFolderEnabledAll,
     docsViewCtor,
     pickerBuilderCtor,
+    enableFeatureCalls,
+    docsViews,
     triggerCallback: (data) => {
       if (!registered) throw new Error('callback not registered yet');
       registered(data);
@@ -188,44 +247,76 @@ describe('DrivePicker — happy path', () => {
     expect(pickerSpy.setVisible).toHaveBeenCalledWith(true);
   });
 
-  it('mimeFilter="pdf" configures a single application/pdf view', async () => {
+  it('mimeFilter="pdf" applies application/pdf to every view', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'pdf' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    expect(mimeCalls).toEqual(['application/pdf']);
+    // One application/pdf entry per DocsView (3 views, see below).
+    expect(mimeCalls).toEqual(['application/pdf', 'application/pdf', 'application/pdf']);
   });
 
   /*
-   * 2026-05-04 — production bug: with mimeFilter="all" (the default
-   * for UploadRoute), the picker rendered THREE identical "Google
-   * Drive" tabs — one per DocsView we added. Google's picker labels
-   * each tab from the ViewId, so passing the same ViewId.DOCS three
-   * times produces three duplicate tabs. Folders were also missing
-   * because every view filtered by file MIME (folders have their
-   * own application/vnd.google-apps.folder MIME). Fix is to use a
-   * single DocsView with comma-joined MIME types + setIncludeFolders.
+   * 2026-05-04 — re-introduces multiple DocsViews to match Google's
+   * canonical import-file UX (My Drive / Shared with me / Shared
+   * drives), after PR #146 collapsed the picker to one view as a
+   * tactical fix for three duplicate "Google Drive" tabs caused by
+   * passing ViewId.DOCS thrice. Now the views are differentiated by
+   * ownership / shared-drives flags, so the picker labels each tab
+   * distinctly.
    */
-  it('mimeFilter="all" configures a SINGLE view with comma-joined MIMEs (no duplicate tabs)', async () => {
+  it('configures three views: My Drive, Shared with me, Shared drives', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(1);
-    expect(pickerSpy.addView).toHaveBeenCalledTimes(1);
-    const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    expect(mimeCalls).toEqual([
-      'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    ]);
+    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(3);
+    expect(pickerSpy.addView).toHaveBeenCalledTimes(3);
+    expect(pickerSpy.docsViews).toHaveLength(3);
+    const [myDrive, sharedWithMe, sharedDrives] = pickerSpy.docsViews;
+    // My Drive — owned-by-me=true.
+    expect(myDrive?.setOwnedByMeCalls).toEqual([true]);
+    expect(myDrive?.setEnableDrivesCalls).toEqual([]);
+    // Shared with me — owned-by-me=false.
+    expect(sharedWithMe?.setOwnedByMeCalls).toEqual([false]);
+    expect(sharedWithMe?.setEnableDrivesCalls).toEqual([]);
+    // Shared drives — enable-drives=true (no ownership filter).
+    expect(sharedDrives?.setEnableDrivesCalls).toEqual([true]);
+    expect(sharedDrives?.setOwnedByMeCalls).toEqual([]);
   });
 
-  it('enables folder navigation so users can browse into Drive folders', async () => {
+  it('enables SUPPORT_DRIVES feature on the picker builder', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    // Folders visible in the file list…
-    expect(pickerSpy.setIncludeFolders).toHaveBeenCalledWith(true);
-    // …but not selectable (we only accept files, not folders).
-    expect(pickerSpy.setSelectFolderEnabled).toHaveBeenCalledWith(false);
+    // 'sdr' is the runtime value of google.picker.Feature.SUPPORT_DRIVES.
+    expect(pickerSpy.enableFeatureCalls).toContain('sdr');
+  });
+
+  it('all three views apply the comma-joined MIME-type filter for the requested mimeFilter', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    const expectedMimes =
+      'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
+    expect(mimeCalls).toEqual([expectedMimes, expectedMimes, expectedMimes]);
+    // And per-view: each DocsView called setMimeTypes exactly once
+    // with the same comma-joined filter.
+    for (const view of pickerSpy.docsViews) {
+      expect(view.setMimeTypesCalls).toEqual([expectedMimes]);
+    }
+  });
+
+  it('enables folder navigation on every view so users can browse into Drive folders', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    for (const view of pickerSpy.docsViews) {
+      // Folders visible in the file list…
+      expect(view.setIncludeFoldersCalls).toEqual([true]);
+      // …but not selectable (we only accept files, not folders).
+      expect(view.setSelectFolderEnabledCalls).toEqual([false]);
+    }
   });
 
   it('sets builder origin to window.location.origin so picker postMessage works', async () => {

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -117,21 +117,29 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
       .setAppId(creds.creds.appId)
       // Required for cross-origin postMessage from the picker iframe
       // back to our SPA. Picker prod is at docs.google.com.
-      .setOrigin(window.location.origin);
+      .setOrigin(window.location.origin)
+      // Required for the "Shared drives" tab below to actually list
+      // shared-drive content. The DocsView flag alone is not enough —
+      // Google requires the builder-level feature flag too.
+      .enableFeature(picker.Feature.SUPPORT_DRIVES);
 
-    // 2026-05-04 — single DocsView with comma-joined MIME types
-    // instead of one view per MIME. Reasons:
-    //   1. The picker labels each tab from its ViewId; passing
-    //      ViewId.DOCS three times rendered three identical
-    //      "Google Drive" tabs in prod.
-    //   2. setMimeTypes accepts a comma-separated list per
-    //      Google's Picker API ref:
-    //      https://developers.google.com/drive/picker/reference#docs-view
-    //   3. setIncludeFolders(true) re-enables folder navigation,
-    //      which was lost because every per-MIME view filtered
-    //      folders out (folders have application/vnd.google-apps.folder).
-    //      setSelectFolderEnabled(false) keeps "Select" disabled
-    //      until the user clicks an actual file.
+    // 2026-05-04 — three DocsViews, one per canonical Google import-
+    // file tab (My Drive / Shared with me / Shared drives). PR #146
+    // collapsed this to a single view as a tactical fix for three
+    // duplicate "Google Drive" tabs caused by passing the same
+    // `ViewId.DOCS` three times without distinguishing flags. Now
+    // each view is differentiated by ownership / shared-drives flags
+    // so the picker labels each tab distinctly:
+    //   1. My Drive       → setOwnedByMe(true)
+    //   2. Shared with me → setOwnedByMe(false)
+    //   3. Shared drives  → setEnableDrives(true) +
+    //                       builder.enableFeature(SUPPORT_DRIVES)
+    // All three apply the same comma-joined MIME-type filter and keep
+    // setIncludeFolders(true)/setSelectFolderEnabled(false) so users
+    // can browse into folders but only select files. OAuth scope
+    // remains pinned to drive.file (per CLAUDE.md) — the picker grants
+    // per-file access at click time regardless of which tab the user
+    // picks from, including shared drives.
     //
     // KNOWN ISSUE — Google-side: the modular picker's thumbnail
     // requests to lh3.googleusercontent.com return without a
@@ -139,11 +147,28 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     // them with net::ERR_BLOCKED_BY_ORB. The picker still works
     // for selection — only the thumbnail previews stay grey. Track:
     // https://issuetracker.google.com (modular picker thumbnails).
-    const view = new picker.DocsView(picker.ViewId.DOCS)
-      .setMimeTypes(MIMES_FOR_FILTER[mimeFilter].join(','))
+    const mimes = MIMES_FOR_FILTER[mimeFilter].join(',');
+
+    const myDriveView = new picker.DocsView(picker.ViewId.DOCS)
+      .setOwnedByMe(true)
+      .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
-    builder.addView(view);
+    builder.addView(myDriveView);
+
+    const sharedWithMeView = new picker.DocsView(picker.ViewId.DOCS)
+      .setOwnedByMe(false)
+      .setMimeTypes(mimes)
+      .setIncludeFolders(true)
+      .setSelectFolderEnabled(false);
+    builder.addView(sharedWithMeView);
+
+    const sharedDrivesView = new picker.DocsView(picker.ViewId.DOCS)
+      .setEnableDrives(true)
+      .setMimeTypes(mimes)
+      .setIncludeFolders(true)
+      .setSelectFolderEnabled(false);
+    builder.addView(sharedDrivesView);
 
     builder.setCallback((data) => {
       if (data.action === 'picked') {

--- a/apps/web/src/components/drive-picker/google-picker-types.ts
+++ b/apps/web/src/components/drive-picker/google-picker-types.ts
@@ -37,6 +37,12 @@ export interface PickerBuilder {
    * preview deployments).
    */
   setOrigin(origin: string): PickerBuilder;
+  /**
+   * Toggle a builder-level feature flag. We use this to enable
+   * `SUPPORT_DRIVES` so the "Shared drives" tab can list shared-drive
+   * content in addition to My Drive.
+   */
+  enableFeature(name: string): PickerBuilder;
   addView(view: unknown): PickerBuilder;
   setCallback(cb: (data: PickerCallbackData) => void): PickerBuilder;
   build(): PickerInstance;
@@ -48,6 +54,17 @@ export interface DocsViewBuilder {
   setIncludeFolders(include: boolean): DocsViewBuilder;
   /** When false, folders are visible but not selectable as a result. */
   setSelectFolderEnabled(enabled: boolean): DocsViewBuilder;
+  /**
+   * Filter the view by ownership.
+   *   - `true`  → "My Drive" tab (only files owned by the user).
+   *   - `false` → "Shared with me" tab (files shared with the user).
+   */
+  setOwnedByMe(owned: boolean): DocsViewBuilder;
+  /**
+   * Show shared-drive content in this view. Requires the builder to
+   * have `enableFeature(Feature.SUPPORT_DRIVES)` set as well.
+   */
+  setEnableDrives(enable: boolean): DocsViewBuilder;
 }
 
 export interface PickerNamespace {
@@ -58,6 +75,9 @@ export interface PickerNamespace {
     readonly PICKED: 'picked';
     readonly CANCEL: 'cancel';
     readonly LOADED: 'loaded';
+  };
+  readonly Feature: {
+    readonly SUPPORT_DRIVES: 'sdr';
   };
 }
 


### PR DESCRIPTION
## Summary

- Re-introduces **three** Google Picker `DocsView`s to match the canonical Google import-file UX (My Drive / Shared with me / Shared drives) — what users see in Google Sheets' file picker.
- PR #146 collapsed the picker to a single view as a tactical fix for three duplicate "Google Drive" tabs caused by passing `ViewId.DOCS` thrice. We now differentiate the views by ownership / shared-drives flags so the picker labels each tab distinctly.
- OAuth scope stays pinned to `drive.file` (per `CLAUDE.md` › "Google Drive integration env vars"). The picker grants per-file access at click time regardless of which tab the user picks from, including shared drives — `SUPPORT_DRIVES` is a UI feature flag, not a scope broadener.

## How it works

| Tab | Configuration |
|---|---|
| My Drive | `DocsView.setOwnedByMe(true)` |
| Shared with me | `DocsView.setOwnedByMe(false)` |
| Shared drives | `DocsView.setEnableDrives(true)` + builder `.enableFeature(Feature.SUPPORT_DRIVES)` |

All three views apply the same comma-joined MIME-type filter and keep `setIncludeFolders(true)` / `setSelectFolderEnabled(false)` so users can browse into folders but only select files.

## Files changed

- `apps/web/src/components/drive-picker/DrivePicker.tsx` — replaces single `DocsView` with three views; calls `enableFeature(Feature.SUPPORT_DRIVES)` on the builder. Added a multi-paragraph code comment explaining the history (PR #146 → this PR) so the next reader understands why we went 1 → 3.
- `apps/web/src/components/drive-picker/google-picker-types.ts` — extends the local Picker API type stubs with `PickerBuilder.enableFeature(name)`, `DocsViewBuilder.setOwnedByMe(owned)`, `DocsViewBuilder.setEnableDrives(enable)`, and the `Feature` namespace constant.
- `apps/web/src/components/drive-picker/DrivePicker.test.tsx` — Picker spy stub now records per-view config (one entry per `new DocsView()` call) plus aggregated cross-view spies for the existing single-view assertions. Adds three new behavioral tests + updates two pre-existing tests that asserted the single-view shape.

## Tests

Vitest, scoped: `pnpm exec vitest run src/components/drive-picker/DrivePicker.test.tsx` — **14/14 pass** (was 11/11 on `main`). New / updated tests:

- `configures three views: My Drive, Shared with me, Shared drives` — asserts exactly 3 `DocsView` instances, with the right `setOwnedByMe` / `setEnableDrives` calls per index.
- `enables SUPPORT_DRIVES feature on the picker builder` — asserts `enableFeature('sdr')` was called.
- `all three views apply the comma-joined MIME-type filter for the requested mimeFilter` — asserts each view receives the same MIME filter.
- `mimeFilter="pdf" applies application/pdf to every view` — generalizes the existing single-view assertion to the new 3-view shape.
- `enables folder navigation on every view` — asserts `setIncludeFolders(true)` + `setSelectFolderEnabled(false)` per-view (was previously aggregated).

TDD log: ran the new tests against pre-fix code → **4 failed with assertion errors** (RED) → applied the fix → **all 14 pass** (GREEN).

## Test plan

- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint` ✓
- [x] `pnpm --filter web exec vitest run` ✓ (1397/1397)
- [x] `seald-react-pr-review` — no MUST-FIX / SHOULD-FIX / NICE-TO-HAVE
- [ ] Post-deploy: open the picker on prod, confirm three tabs labeled My Drive / Shared with me / Shared drives, pick a file from each tab, verify the upload completes.

## Notes

- OAuth scope unchanged (`drive.file`).
- Picker API types are hand-rolled (no `@types/gapi.client.picker` dep) — extension is a 4-line type addition.
- Known Google-side issue (thumbnail ORB block) is unaffected and noted in the existing code comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)