### PR TITLE
feat(web): add Starred tab to Drive picker

### DIFF
--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -33,6 +33,7 @@ interface DocsViewSpy {
   readonly setSelectFolderEnabledCalls: ReadonlyArray<unknown>;
   readonly setOwnedByMeCalls: ReadonlyArray<unknown>;
   readonly setEnableDrivesCalls: ReadonlyArray<unknown>;
+  readonly setStarredCalls: ReadonlyArray<boolean | undefined>;
 }
 
 interface PickerSpyState {
@@ -80,6 +81,7 @@ function installGooglePickerStub(): PickerSpyState {
     const setSelectFolderEnabledCalls: unknown[] = [];
     const setOwnedByMeCalls: unknown[] = [];
     const setEnableDrivesCalls: unknown[] = [];
+    const setStarredCalls: Array<boolean | undefined> = [];
 
     const view: Record<string, (arg: unknown) => unknown> = {
       setMimeTypes(arg) {
@@ -105,6 +107,10 @@ function installGooglePickerStub(): PickerSpyState {
         setEnableDrivesCalls.push(arg);
         return view;
       },
+      setStarred(arg) {
+        setStarredCalls.push(typeof arg === 'boolean' ? arg : undefined);
+        return view;
+      },
     };
 
     docsViews.push({
@@ -113,6 +119,7 @@ function installGooglePickerStub(): PickerSpyState {
       setSelectFolderEnabledCalls,
       setOwnedByMeCalls,
       setEnableDrivesCalls,
+      setStarredCalls,
     });
 
     return view;
@@ -252,36 +259,65 @@ describe('DrivePicker — happy path', () => {
     renderPicker({ mimeFilter: 'pdf' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    // One application/pdf entry per DocsView (3 views, see below).
-    expect(mimeCalls).toEqual(['application/pdf', 'application/pdf', 'application/pdf']);
+    // One application/pdf entry per DocsView (4 views: Starred, My
+    // Drive, Shared with me, Shared drives).
+    expect(mimeCalls).toEqual([
+      'application/pdf',
+      'application/pdf',
+      'application/pdf',
+      'application/pdf',
+    ]);
   });
 
   /*
-   * 2026-05-04 — re-introduces multiple DocsViews to match Google's
-   * canonical import-file UX (My Drive / Shared with me / Shared
-   * drives), after PR #146 collapsed the picker to one view as a
-   * tactical fix for three duplicate "Google Drive" tabs caused by
-   * passing ViewId.DOCS thrice. Now the views are differentiated by
-   * ownership / shared-drives flags, so the picker labels each tab
-   * distinctly.
+   * 2026-05-04 — adds a Starred tab in front of the three views that
+   * shipped in PR #149 (My Drive / Shared with me / Shared drives).
+   * Putting Starred first matches the canonical Google import-file UX
+   * (Sheets/Slides put Recent first; we don't have a Recent surface
+   * yet, so Starred leads). Each view is differentiated by
+   * ownership / shared-drives / starred flags so the picker labels
+   * every tab distinctly.
    */
-  it('configures three views: My Drive, Shared with me, Shared drives', async () => {
+  it('configures four views in order: Starred, My Drive, Shared with me, Shared drives', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(3);
-    expect(pickerSpy.addView).toHaveBeenCalledTimes(3);
-    expect(pickerSpy.docsViews).toHaveLength(3);
-    const [myDrive, sharedWithMe, sharedDrives] = pickerSpy.docsViews;
-    // My Drive — owned-by-me=true.
+    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(4);
+    expect(pickerSpy.addView).toHaveBeenCalledTimes(4);
+    expect(pickerSpy.docsViews).toHaveLength(4);
+    const [starred, myDrive, sharedWithMe, sharedDrives] = pickerSpy.docsViews;
+    // Starred — setStarred(true), no enable-drives.
+    expect(starred?.setStarredCalls).toEqual([true]);
+    expect(starred?.setEnableDrivesCalls).toEqual([]);
+    // My Drive — owned-by-me=true, no setStarred call.
     expect(myDrive?.setOwnedByMeCalls).toEqual([true]);
     expect(myDrive?.setEnableDrivesCalls).toEqual([]);
+    expect(myDrive?.setStarredCalls).toEqual([]);
     // Shared with me — owned-by-me=false.
     expect(sharedWithMe?.setOwnedByMeCalls).toEqual([false]);
     expect(sharedWithMe?.setEnableDrivesCalls).toEqual([]);
     // Shared drives — enable-drives=true (no ownership filter).
     expect(sharedDrives?.setEnableDrivesCalls).toEqual([true]);
     expect(sharedDrives?.setOwnedByMeCalls).toEqual([]);
+  });
+
+  it('Starred view applies the same MIME filter as the other tabs', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    const expectedMimes =
+      'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+    const [starred] = pickerSpy.docsViews;
+    expect(starred?.setMimeTypesCalls).toEqual([expectedMimes]);
+  });
+
+  it('Starred view enables folder navigation but disables folder-as-result', async () => {
+    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
+    renderPicker({ mimeFilter: 'all' });
+    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
+    const [starred] = pickerSpy.docsViews;
+    expect(starred?.setIncludeFoldersCalls).toEqual([true]);
+    expect(starred?.setSelectFolderEnabledCalls).toEqual([false]);
   });
 
   it('enables SUPPORT_DRIVES feature on the picker builder', async () => {
@@ -292,14 +328,14 @@ describe('DrivePicker — happy path', () => {
     expect(pickerSpy.enableFeatureCalls).toContain('sdr');
   });
 
-  it('all three views apply the comma-joined MIME-type filter for the requested mimeFilter', async () => {
+  it('all four views apply the comma-joined MIME-type filter for the requested mimeFilter', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
     const expectedMimes =
       'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    expect(mimeCalls).toEqual([expectedMimes, expectedMimes, expectedMimes]);
+    expect(mimeCalls).toEqual([expectedMimes, expectedMimes, expectedMimes, expectedMimes]);
     // And per-view: each DocsView called setMimeTypes exactly once
     // with the same comma-joined filter.
     for (const view of pickerSpy.docsViews) {

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -123,23 +123,26 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
       // Google requires the builder-level feature flag too.
       .enableFeature(picker.Feature.SUPPORT_DRIVES);
 
-    // 2026-05-04 — three DocsViews, one per canonical Google import-
-    // file tab (My Drive / Shared with me / Shared drives). PR #146
-    // collapsed this to a single view as a tactical fix for three
-    // duplicate "Google Drive" tabs caused by passing the same
-    // `ViewId.DOCS` three times without distinguishing flags. Now
-    // each view is differentiated by ownership / shared-drives flags
-    // so the picker labels each tab distinctly:
-    //   1. My Drive       → setOwnedByMe(true)
-    //   2. Shared with me → setOwnedByMe(false)
-    //   3. Shared drives  → setEnableDrives(true) +
+    // 2026-05-04 — four DocsViews, one per canonical Google import-
+    // file tab. PR #146 collapsed this to a single view as a tactical
+    // fix for duplicate "Google Drive" tabs caused by passing the
+    // same `ViewId.DOCS` without distinguishing flags. PR #149
+    // re-introduced three views (My Drive / Shared with me / Shared
+    // drives). This change prepends a Starred tab so the final order
+    // matches Google's canonical import-file UX (Sheets/Slides put
+    // Recent first; we don't have a Recent surface yet, so Starred
+    // leads):
+    //   1. Starred       → setStarred(true) + setOwnedByMe(true)
+    //   2. My Drive      → setOwnedByMe(true)
+    //   3. Shared with me → setOwnedByMe(false)
+    //   4. Shared drives → setEnableDrives(true) +
     //                       builder.enableFeature(SUPPORT_DRIVES)
-    // All three apply the same comma-joined MIME-type filter and keep
+    // All four apply the same comma-joined MIME-type filter and keep
     // setIncludeFolders(true)/setSelectFolderEnabled(false) so users
     // can browse into folders but only select files. OAuth scope
-    // remains pinned to drive.file (per CLAUDE.md) — the picker grants
-    // per-file access at click time regardless of which tab the user
-    // picks from, including shared drives.
+    // remains pinned to drive.file (per CLAUDE.md) — the Starred
+    // filter is a client-side picker capability, not a scope
+    // expansion; per-file access is still granted at click time.
     //
     // KNOWN ISSUE — Google-side: the modular picker's thumbnail
     // requests to lh3.googleusercontent.com return without a
@@ -148,6 +151,14 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     // for selection — only the thumbnail previews stay grey. Track:
     // https://issuetracker.google.com (modular picker thumbnails).
     const mimes = MIMES_FOR_FILTER[mimeFilter].join(',');
+
+    const starredView = new picker.DocsView(picker.ViewId.DOCS)
+      .setStarred(true)
+      .setOwnedByMe(true)
+      .setMimeTypes(mimes)
+      .setIncludeFolders(true)
+      .setSelectFolderEnabled(false);
+    builder.addView(starredView);
 
     const myDriveView = new picker.DocsView(picker.ViewId.DOCS)
       .setOwnedByMe(true)

--- a/apps/web/src/components/drive-picker/google-picker-types.ts
+++ b/apps/web/src/components/drive-picker/google-picker-types.ts
@@ -65,6 +65,12 @@ export interface DocsViewBuilder {
    * have `enableFeature(Feature.SUPPORT_DRIVES)` set as well.
    */
   setEnableDrives(enable: boolean): DocsViewBuilder;
+  /**
+   * Filter the view to starred items only. Combined with
+   * `setOwnedByMe(true)` produces the canonical "Starred" tab —
+   * the user's own files filtered to starred.
+   */
+  setStarred(starred: boolean): DocsViewBuilder;
 }
 
 export interface PickerNamespace {


### PR DESCRIPTION
## Summary

Stacks on top of #149 (My Drive / Shared with me / Shared drives) by
prepending a **Starred** view that uses the Picker API's
`setStarred(true)` filter. #149 has already merged into `main`, so this
PR targets `main` directly.

Tab order now matches Google's canonical import-file UX (Sheets/Slides
put Recent first; we don't have a Recent surface yet, so Starred
leads):

1. **Starred** — `setStarred(true) + setOwnedByMe(true)`
2. **My Drive** — `setOwnedByMe(true)`
3. **Shared with me** — `setOwnedByMe(false)`
4. **Shared drives** — `setEnableDrives(true) + Feature.SUPPORT_DRIVES`

OAuth scope stays pinned to `drive.file` — the Starred filter is a
client-side picker capability, not a scope expansion; per-file access
is still granted at click time via Google's `drive.file` consent.

## Test plan

- [x] RED-then-GREEN TDD: 3 new/updated assertions failed against
      pre-fix code (3 views, no `setStarred`), pass after.
- [x] `apps/web` typecheck ✓
- [x] `apps/web` lint ✓
- [x] `apps/web` vitest run ✓ (16/16 in DrivePicker, 1403/1403 overall)
- [ ] Manual verify after deploy: open the Drive picker, confirm 4 tabs
      in order (Starred → My Drive → Shared with me → Shared drives),
      click **Starred** and confirm only starred files appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)