### PR TITLE
fix(api): correct Gotenberg v8 CLI flags so the sidecar stays up

### DIFF
--- a/apps/api/test/gdrive-conversion-deploy.contract.spec.ts
+++ b/apps/api/test/gdrive-conversion-deploy.contract.spec.ts
@@ -99,7 +99,23 @@ describe('root docker-compose.yml — Gotenberg co-deploy contract', () => {
     expect(gotBlock).toMatch(/cpus:\s*['"]?1\.5['"]?/);
   });
 
-  it('hard-disables non-LibreOffice routes via the gotenberg command', () => {
+  it('hard-disables non-LibreOffice routes via the gotenberg command (v8 flag set)', () => {
+    // Phase-6 prod-bug-loop regression (2026-05-04): the previous flag
+    // set was copied from a gotenberg v7 reference and contained
+    // `--webhook-disable-routes=true`, which gotenberg v8 rejects with
+    // `unknown flag: --webhook-disable-routes` (captured via the
+    // prod-diagnose workflow on prod after the PR #148 deploy). The
+    // container exited with code 2 and entered a restart loop, so the
+    // API got `fetch failed` on every .docx Drive conversion.
+    //
+    // v8 renamed the webhook route disabler from
+    //   --webhook-disable-routes (v7)
+    // to
+    //   --webhook-disable (v8 — disables the whole webhook feature).
+    //
+    // chromium-disable-routes and pdfengines-disable-routes still exist
+    // in v8 and are kept. We assert the corrected flag set so a future
+    // copy-paste of v7 flags fails CI here, not on prod.
     const gotMatch = compose.match(
       /^ {2}gotenberg:\s*$([\s\S]*?)(?=^ {2}[a-z0-9_-]+:\s*$|^volumes:|^networks:)/m,
     );
@@ -108,7 +124,13 @@ describe('root docker-compose.yml — Gotenberg co-deploy contract', () => {
     expect(gotBlock).toMatch(/--api-port=3000/);
     expect(gotBlock).toMatch(/--api-timeout=30s/);
     expect(gotBlock).toMatch(/--chromium-disable-routes=true/);
-    expect(gotBlock).toMatch(/--webhook-disable-routes=true/);
+    expect(gotBlock).toMatch(/--webhook-disable=true/);
     expect(gotBlock).toMatch(/--pdfengines-disable-routes=true/);
+    // Defence-in-depth: a v7-era `--webhook-disable-routes` flag must
+    // never reappear as an actual command-line entry, since it would
+    // crash the sidecar at boot on v8. We only flag the YAML list-item
+    // form (a leading `-`/`'`) so that a comment that explains the
+    // historical flag name doesn't trip this guard.
+    expect(gotBlock).not.toMatch(/^\s*-\s*'--webhook-disable-routes/m);
   });
 });

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -70,8 +70,14 @@ services:
       # Hard-disable webhook + chromium routes; we only use LibreOffice.
       # Closing every other route reduces attack surface in the unlikely
       # event the network barrier ever leaks.
+      #
+      # NOTE: gotenberg v8 renamed the webhook flag from
+      # `--webhook-disable-routes` (v7) to `--webhook-disable`. Keep the
+      # canonical root docker-compose.yml in sync; the contract test
+      # apps/api/test/gdrive-conversion-deploy.contract.spec.ts pins
+      # the v8 flag set there.
       - '--chromium-disable-routes=true'
-      - '--webhook-disable-routes=true'
+      - '--webhook-disable=true'
       - '--pdfengines-disable-routes=true'
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,8 +104,16 @@ services:
       # Hard-disable webhook + chromium routes; we only use LibreOffice.
       # Closing every other route reduces attack surface in the unlikely
       # event the network barrier ever leaks.
+      #
+      # NOTE: gotenberg v8 renamed the webhook flag from
+      # `--webhook-disable-routes` (v7) to `--webhook-disable` (the
+      # whole feature is gone, not just the routes). Booting v8 with the
+      # v7 spelling exits with `unknown flag: --webhook-disable-routes`
+      # and the container restart-loops; see contract test
+      # apps/api/test/gdrive-conversion-deploy.contract.spec.ts which
+      # pins the v8 flag set.
       - '--chromium-disable-routes=true'
-      - '--webhook-disable-routes=true'
+      - '--webhook-disable=true'
       - '--pdfengines-disable-routes=true'
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:3000/health']


### PR DESCRIPTION
## Summary

P0 prod regression after PR #148 (`b91052a`, 2026-05-04 17:39 UTC). The Gotenberg sidecar entered a container restart loop because the CLI flag set was copied from a v7 reference. Today's `prod-diagnose` capture showed:

```
seald-gotenberg-1   gotenberg/gotenberg:8   ...   Restarting (2) 36 seconds ago
```

```
gotenberg-1  | unknown flag: --webhook-disable-routes
```

API logs paired with that:
```
ERROR [ConversionService] conversion_unhandled jobId=... err=fetch failed
```

So .docx Drive picker selections still failed with `errorCode=conversion-failed` because the API couldn't reach Gotenberg — Gotenberg wouldn't stay up.

## Root cause + flag-by-flag rationale

Gotenberg v8 renamed the webhook route disabler. The other four flags survive verbatim.

| Flag | v7 (broken) | v8 (correct) | Action |
|---|---|---|---|
| `--api-port` | OK | OK | Kept as-is |
| `--api-timeout` | OK | OK | Kept as-is |
| `--chromium-disable-routes` | OK | OK | Kept as-is |
| `--webhook-disable-routes` | **BREAKS BOOT** | renamed to `--webhook-disable` | **Fixed** |
| `--pdfengines-disable-routes` | OK | OK | Kept as-is |

The v8 spelling `--webhook-disable` disables the entire webhook feature (broader than v7's route-only disabler), which is what we want — we never use webhooks.

## Diff

- `docker-compose.yml` — replaced `--webhook-disable-routes=true` with `--webhook-disable=true`. Added an inline comment pointing at the contract test.
- `deploy/docker-compose.yml` — same swap to keep the historical/standalone reference accurate (operators occasionally bring up the sidecar standalone via this file).
- `apps/api/test/gdrive-conversion-deploy.contract.spec.ts` — pinned the corrected v8 flag set + a defence-in-depth assertion that fails CI if `--webhook-disable-routes` ever reappears as an actual command-line entry.

## Security invariants preserved

- No `ports:` block on `gotenberg` (still internal-only).
- Resource caps unchanged (1.5 GB / 1.5 vCPU).
- Routes we don't use stay disabled (chromium, pdfengines). Webhook is now disabled at the feature level (stricter than v7 routes-only).

## Test plan

- [x] Local: `pnpm --filter api typecheck && pnpm --filter api lint && pnpm exec jest test/gdrive-conversion-deploy.contract.spec.ts --runInBand` — green (7 passed). RED confirmed against pre-fix `docker-compose.yml`, GREEN after fix.
- [ ] Post-deploy: run `gh workflow run prod-diagnose.yml --ref main` and confirm `seald-gotenberg-1` shows `Up <duration>` instead of `Restarting`. Also confirm no `unknown flag:` lines in `docker compose logs gotenberg`.
- [ ] User .docx curl re-run on prod: expect `{ status: 'done', url: ... }` instead of `{ status: 'failed', errorCode: 'conversion-failed' }`. (Cannot perform locally — no live bearer token.)

## Rollback note

Revert this PR — Gotenberg v8 crashes again on `--webhook-disable-routes`, and .docx conversions fail with `conversion-failed`. Doc/PDF Drive branches are unaffected either way (they don't touch Gotenberg).

## Related

- PR #148 (deployed sidecar with the v7 flags)
- PR #150 (chore: include gotenberg logs in prod-diagnose — that's how we captured the `unknown flag` line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)