### PR TITLE
feat(web): download signed PDF after signing (desktop + mobile)

### DIFF
--- a/apps/web/e2e/signing-flow.spec.ts
+++ b/apps/web/e2e/signing-flow.spec.ts
@@ -168,6 +168,22 @@ test.describe('signing flow', () => {
       });
     });
 
+    // GET /verify/<short_code> → SigningDonePage now polls this endpoint
+    // (via useSealedDownload) so the recipient can download the sealed
+    // PDF. Without a mock the polling errors out and the Done page
+    // renders the failure-fallback alert (no Hero heading).
+    await page.route('**/verify/TEST-001', async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          envelope: { id: ENVELOPE_ID, short_code: 'TEST-001', status: 'completed' },
+          sealed_url: 'https://example.test/sealed.pdf',
+          chain_intact: true,
+        }),
+      });
+    });
+
     // GET /sign/pdf → tiny inline fixture so pdf.js doesn't 404 on the
     // fill page. Content is intentionally minimal; the fill page renders
     // even if rasterization fails.

--- a/apps/web/e2e/template-sign-flow.spec.ts
+++ b/apps/web/e2e/template-sign-flow.spec.ts
@@ -358,6 +358,21 @@ async function installMocks(page: Page): Promise<ApiCallLog> {
     });
   });
 
+  // --- /verify/<short_code> — SigningDonePage polls this to surface
+  // the sealed-PDF download link. Without a mock the polling errors and
+  // the Done page renders the failure-fallback alert.
+  await page.route('**/verify/TPL-SIGN-01', async (route: Route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        envelope: { id: ENVELOPE_ID, short_code: 'TPL-SIGN-01', status: 'completed' },
+        sealed_url: 'https://example.test/sealed.pdf',
+        chain_intact: true,
+      }),
+    });
+  });
+
   // --- Signer PDF — small inline fixture so pdf.js doesn't 404 on /fill.
   await page.route('**/sign/pdf', async (route: Route) => {
     log.signPdf += 1;

--- a/apps/web/src/features/signing/index.ts
+++ b/apps/web/src/features/signing/index.ts
@@ -47,5 +47,7 @@ export type {
 } from './signingApi';
 export { readDoneSnapshot, writeDoneSnapshot, clearDoneSnapshot } from './doneSnapshot';
 export type { DoneSnapshot } from './doneSnapshot';
+export { useSealedDownload, SEALED_DOWNLOAD_KEY } from './useSealedDownload';
+export { safeDownloadName } from './safeDownloadName';
 export { reportSignerEvent, setSignerReporter } from './telemetry';
 export type { SignerEvent, SignerReporter } from './telemetry';

--- a/apps/web/src/features/signing/safeDownloadName.ts
+++ b/apps/web/src/features/signing/safeDownloadName.ts
@@ -1,0 +1,26 @@
+/**
+ * Slugify an envelope title into a safe, human-readable PDF filename.
+ *
+ * The browser `download` attribute, left empty, falls back to whatever
+ * basename the URL exposes. For Supabase pre-signed URLs that's an
+ * opaque path like `<envelope-id>/sealed.pdf?token=…` — useless in a
+ * downloads folder. Slugify the title so the saved file is searchable
+ * by the signer later.
+ *
+ * Mirrors the helper in `apps/web/src/pages/VerifyPage/VerifyPage.tsx`
+ * which is intentionally local to that page; the signing post-sign
+ * surface needs the same behaviour, so the logic lives here for both
+ * to import (rule 1.6 — use a shared helper rather than duplicating).
+ */
+export function safeDownloadName(title: string, suffix: string): string {
+  const slug = title
+    .normalize('NFKD')
+    // Strip combining accents.
+    .replace(/[\u0300-\u036f]/g, '')
+    // Anything that isn't a safe filesystem char becomes `-`.
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 80);
+  const base = slug.length > 0 ? slug : 'document';
+  return `${base}${suffix}.pdf`;
+}

--- a/apps/web/src/features/signing/useSealedDownload.ts
+++ b/apps/web/src/features/signing/useSealedDownload.ts
@@ -1,0 +1,65 @@
+import { useQuery } from '@tanstack/react-query';
+import type { UseQueryResult } from '@tanstack/react-query';
+import { verifyApiClient } from '@/lib/api/verifyApiClient';
+import type { VerifyResponse } from '@/features/verify';
+
+/**
+ * Polling helper for the post-sign Done page so a recipient can download
+ * the sealed PDF as soon as the API finishes sealing.
+ *
+ * Why a dedicated hook (and not `useVerifyEnvelope`):
+ *   - `useVerifyEnvelope` is a one-shot read with `retry: false` and a
+ *     60 s `staleTime` for the public verify page; both are wrong here.
+ *   - The Done page lands in the brief window between `POST /sign/submit`
+ *     (which transitions the envelope to `sealing`) and the seal worker
+ *     completing (`completed`, sealed_url populated). Poll until the
+ *     terminal status is reached, then stop.
+ *
+ * Caching key matches `useVerifyEnvelope`'s so a later visit to
+ * `/verify/:short_code` reuses the same cached data.
+ *
+ * The query is `enabled` only when a non-empty `shortCode` is provided —
+ * undefined snapshots (deep-link to /done) skip the network entirely.
+ */
+const POLL_MS = 2_000;
+
+export const SEALED_DOWNLOAD_KEY = (shortCode: string): readonly [string, string] =>
+  ['verify', shortCode] as const;
+
+export function useSealedDownload(shortCode: string): UseQueryResult<VerifyResponse, Error> {
+  return useQuery<VerifyResponse, Error>({
+    queryKey: SEALED_DOWNLOAD_KEY(shortCode),
+    queryFn: async ({ signal }) => {
+      const res = await verifyApiClient.get<VerifyResponse>(
+        `/verify/${encodeURIComponent(shortCode)}`,
+        { signal },
+      );
+      return res.data;
+    },
+    enabled: shortCode.length > 0,
+    // Refetch every 2 s ONLY while the envelope is still sealing — once
+    // it's `completed` (or any terminal non-completed status) we have the
+    // final answer and stop hammering the API.
+    refetchInterval: (query) => {
+      // Stop polling once we've surfaced an error — the page will offer
+      // the /verify/<short_code> fallback link. Hammering through a hard
+      // failure is just noise.
+      if (query.state.status === 'error') return false;
+      const data = query.state.data;
+      if (!data) return POLL_MS;
+      const status = data.envelope.status;
+      if (status === 'completed' && data.sealed_url) return false;
+      // Terminal-but-not-sealed statuses (declined / expired / canceled):
+      // no sealed_url will ever appear; stop polling.
+      if (status === 'declined' || status === 'expired' || status === 'canceled') {
+        return false;
+      }
+      return POLL_MS;
+    },
+    refetchIntervalInBackground: false,
+    staleTime: 0,
+    // One quiet retry — sealing is async, occasional 5xx blips shouldn't
+    // surface as a hard error to the signer.
+    retry: 1,
+  });
+}

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.test.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.test.tsx
@@ -1,10 +1,48 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderSigningRoute } from '../../test/renderSigningRoute';
 import { MOCK_ENVELOPE_ID } from '../../test/signingApiMock';
 import { writeDoneSnapshot } from '../../features/signing';
 import { SigningDonePage } from './SigningDonePage';
+
+vi.mock('../../lib/api/verifyApiClient', () => ({
+  verifyApiClient: { get: vi.fn() },
+}));
+
+// eslint-disable-next-line import/first, import/order
+import { verifyApiClient } from '../../lib/api/verifyApiClient';
+
+const verifyGet = verifyApiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+const COMPLETED_PAYLOAD = {
+  envelope: {
+    id: MOCK_ENVELOPE_ID,
+    title: 'Master Services Agreement',
+    short_code: 'TESTDONE00001',
+    status: 'completed' as const,
+    original_pages: 2,
+    original_sha256: null,
+    sealed_sha256: null,
+    tc_version: '1',
+    privacy_version: '1',
+    sent_at: '2026-04-25T21:20:50Z',
+    completed_at: '2026-04-25T21:21:08Z',
+    expires_at: '2026-05-25T21:20:50Z',
+  },
+  signers: [],
+  events: [],
+  chain_intact: true,
+  sealed_url: 'https://signed.example/sealed.pdf?sig=stub',
+  audit_url: 'https://signed.example/audit.pdf?sig=stub',
+};
+
+const SEALING_PAYLOAD = {
+  ...COMPLETED_PAYLOAD,
+  envelope: { ...COMPLETED_PAYLOAD.envelope, status: 'sealing' as const, completed_at: null },
+  sealed_url: null,
+  audit_url: null,
+};
 
 function renderDone() {
   return renderSigningRoute(<SigningDonePage />, {
@@ -15,6 +53,11 @@ function renderDone() {
 
 beforeEach(() => {
   window.sessionStorage.clear();
+  verifyGet.mockReset();
+  // Default: pretend no snapshot has been seeded yet — tests that
+  // exercise the verify path explicitly seed the snapshot AND wire up
+  // a verify response.
+  verifyGet.mockResolvedValue({ data: COMPLETED_PAYLOAD });
 });
 
 describe('SigningDonePage', () => {
@@ -195,6 +238,101 @@ describe('SigningDonePage', () => {
       await waitFor(() => {
         expect(screen.getByTestId('__pathname__').textContent).toBe('/signup');
       });
+    });
+  });
+
+  describe('Download signed PDF (post-sign action)', () => {
+    // The recipient lands here right after submitting; the seal worker
+    // is async so we may arrive while the envelope is still in
+    // `sealing` state. The button must:
+    //   - render disabled with "Preparing signed PDF…" while sealing
+    //   - flip to an enabled link with the sealed_url + a slugified
+    //     `download="…-signed.pdf"` filename once status === 'completed'
+    //   - poll the public verify endpoint (the only surface available
+    //     after the signer-session cookie is cleared by /sign/submit)
+    //   - surface an inline alert when the public verify endpoint
+    //     errors and there is still no sealed copy
+
+    function seedSnapshot() {
+      writeDoneSnapshot({
+        kind: 'submitted',
+        envelope_id: MOCK_ENVELOPE_ID,
+        short_code: 'TESTDONE00099',
+        title: 'Master Services Agreement',
+        sender_name: 'Eliran Azulay',
+        recipient_email: 'maya@example.com',
+        timestamp: '2026-04-25T21:21:08Z',
+      });
+    }
+
+    it('renders an enabled "Download signed PDF" link with slugified filename when the envelope is sealed', async () => {
+      seedSnapshot();
+      verifyGet.mockResolvedValue({ data: COMPLETED_PAYLOAD });
+      renderDone();
+
+      const link = await screen.findByRole('link', { name: /download signed pdf/i });
+      expect(link).toHaveAttribute('href', COMPLETED_PAYLOAD.sealed_url);
+      expect(link).toHaveAttribute('download', 'Master-Services-Agreement-signed.pdf');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    });
+
+    it('queries the public /verify endpoint (cookie-less) keyed by the snapshot short_code', async () => {
+      seedSnapshot();
+      verifyGet.mockResolvedValue({ data: COMPLETED_PAYLOAD });
+      renderDone();
+
+      await screen.findByRole('link', { name: /download signed pdf/i });
+      expect(verifyGet).toHaveBeenCalledWith(
+        '/verify/TESTDONE00099',
+        expect.objectContaining({ signal: expect.anything() }),
+      );
+    });
+
+    it('renders the action disabled with a "preparing" hint while the envelope is still sealing', async () => {
+      seedSnapshot();
+      verifyGet.mockResolvedValue({ data: SEALING_PAYLOAD });
+      renderDone();
+
+      const button = await screen.findByRole('button', { name: /preparing signed pdf/i });
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      // No download link until completion.
+      expect(screen.queryByRole('link', { name: /download signed pdf/i })).toBeNull();
+    });
+
+    it('flips from disabled "preparing" to enabled link when the seal completes on a later poll', async () => {
+      seedSnapshot();
+      verifyGet
+        .mockResolvedValueOnce({ data: SEALING_PAYLOAD })
+        .mockResolvedValue({ data: COMPLETED_PAYLOAD });
+      renderDone();
+
+      // First render: disabled / preparing.
+      await screen.findByRole('button', { name: /preparing signed pdf/i });
+      // Eventually: enabled link (poll picks up the completed payload).
+      const link = await screen.findByRole(
+        'link',
+        { name: /download signed pdf/i },
+        {
+          timeout: 5_000,
+        },
+      );
+      expect(link).toHaveAttribute('href', COMPLETED_PAYLOAD.sealed_url);
+    });
+
+    it('surfaces an inline alert when the verify request errors and no sealed_url is available', async () => {
+      seedSnapshot();
+      // react-query default retries are disabled in renderSigningRoute,
+      // and the hook's own retry: 1 still surfaces the failure once both
+      // attempts reject. Reject every time so the test is deterministic.
+      verifyGet.mockRejectedValue(new Error('network'));
+      renderDone();
+
+      const alert = await screen.findByRole('alert', undefined, { timeout: 5_000 });
+      expect(alert).toHaveTextContent(/couldn.?t prepare the signed pdf/i);
+      // Disabled fallback button is still present.
+      expect(screen.getByRole('button', { name: /download signed pdf/i })).toBeDisabled();
     });
   });
 });

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
@@ -1,9 +1,9 @@
 import { useMemo, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { CheckCircle2, FileText, ShieldCheck, Sparkles } from 'lucide-react';
+import { CheckCircle2, Download, ShieldCheck, Sparkles } from 'lucide-react';
 import { Icon } from '@/components/Icon';
-import { readDoneSnapshot } from '@/features/signing';
+import { readDoneSnapshot, safeDownloadName, useSealedDownload } from '@/features/signing';
 
 /**
  * T-18 — keep this in sync with `ENVELOPE_RETENTION_YEARS` (default `7`)
@@ -58,22 +58,71 @@ const Body = styled.p`
 
 const Actions = styled.div`
   margin-top: ${({ theme }) => theme.space[8]};
-  display: inline-flex;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 10px;
 `;
 
-const SecondaryBtn = styled.button`
-  padding: 12px 18px;
-  border: 1px solid ${({ theme }) => theme.color.border[2]};
-  border-radius: ${({ theme }) => theme.radius.md};
-  background: ${({ theme }) => theme.color.paper};
-  font-size: ${({ theme }) => theme.font.size.caption};
-  font-weight: ${({ theme }) => theme.font.weight.semibold};
-  color: ${({ theme }) => theme.color.fg[1]};
-  cursor: pointer;
+// Shared button base — applied to both <a> (enabled) and <button>
+// (disabled / sealing) so screen-readers see consistent visual chrome
+// regardless of element. Mobile breakpoint (≤ 640 px) snaps the action
+// row to full-width per CLAUDE.md mobile lock contract.
+const buttonBase = `
+  padding: 14px 20px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 15px;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+`;
+
+const PrimaryDownloadLink = styled.a`
+  ${buttonBase}
+  background: ${({ theme }) => theme.color.ink[900]};
+  color: ${({ theme }) => theme.color.paper};
+  border: 1px solid ${({ theme }) => theme.color.ink[900]};
+  &:hover {
+    background: ${({ theme }) => theme.color.ink[700]};
+  }
+  @media (max-width: 640px) {
+    width: 100%;
+  }
+`;
+
+const PrimaryDownloadBtn = styled.button`
+  ${buttonBase}
+  background: ${({ theme }) => theme.color.ink[900]};
+  color: ${({ theme }) => theme.color.paper};
+  border: 1px solid ${({ theme }) => theme.color.ink[900]};
+  &:disabled {
+    background: ${({ theme }) => theme.color.ink[200]};
+    color: ${({ theme }) => theme.color.fg[3]};
+    border-color: ${({ theme }) => theme.color.ink[200]};
+    cursor: not-allowed;
+  }
+  @media (max-width: 640px) {
+    width: 100%;
+  }
+`;
+
+const DownloadHint = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.micro};
+  color: ${({ theme }) => theme.color.fg[3]};
+  line-height: 1.4;
+`;
+
+const DownloadError = styled.p`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.micro};
+  color: ${({ theme }) => theme.color.danger[700]};
+  line-height: 1.4;
 `;
 
 const Upsell = styled.div`
@@ -201,9 +250,19 @@ export function SigningDonePage() {
   const [email, setEmail] = useState(snap?.recipient_email ?? '');
   const [saveError, setSaveError] = useState<string | null>(null);
 
+  // Poll the public verify endpoint for this envelope's seal status.
+  // Hook is always mounted (rule 4.4 — single responsibility) but the
+  // query is gated by `enabled: shortCode.length > 0` inside the hook,
+  // so this is safe even when the snapshot is missing on the next line.
+  const verify = useSealedDownload(snap?.short_code ?? '');
+
   if (!snap || snap.kind !== 'submitted') {
     return <Navigate to={`/sign/${envelopeId}`} replace />;
   }
+
+  const sealedUrl = verify.data?.envelope.status === 'completed' ? verify.data.sealed_url : null;
+  const isSealing = !sealedUrl && !verify.isError;
+  const downloadName = safeDownloadName(snap.title, '-signed');
 
   const handleSave = (e: React.FormEvent): void => {
     e.preventDefault();
@@ -246,10 +305,40 @@ export function SigningDonePage() {
         </Body>
 
         <Actions>
-          <SecondaryBtn type="button" disabled>
-            <Icon icon={FileText} size={14} />
-            Check your email for the signed copy
-          </SecondaryBtn>
+          {sealedUrl ? (
+            <PrimaryDownloadLink
+              href={sealedUrl}
+              download={downloadName}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Icon icon={Download} size={16} />
+              Download signed PDF (.pdf)
+            </PrimaryDownloadLink>
+          ) : (
+            <PrimaryDownloadBtn type="button" disabled aria-busy={isSealing}>
+              <Icon icon={Download} size={16} />
+              {isSealing ? 'Preparing signed PDF…' : 'Download signed PDF (.pdf)'}
+            </PrimaryDownloadBtn>
+          )}
+          {isSealing ? (
+            <DownloadHint>
+              We&apos;re finalising the seal. This usually takes a few seconds.
+            </DownloadHint>
+          ) : null}
+          {verify.isError && !sealedUrl ? (
+            <DownloadError role="alert">
+              We couldn&apos;t prepare the signed PDF right now. A copy has been emailed to you; you
+              can also download it any time from{' '}
+              <a
+                href={`/verify/${snap.short_code}`}
+                style={{ color: 'inherit', textDecoration: 'underline' }}
+              >
+                /verify/{snap.short_code}
+              </a>
+              .
+            </DownloadError>
+          ) : null}
         </Actions>
 
         <RetentionCard>


### PR DESCRIPTION
## Summary
- After a recipient completes signing, the post-sign confirmation page (`/sign/:envelopeId/done`) now offers a **Download signed PDF (.pdf)** action so the signer can keep a copy of the sealed document on their own device.
- The button polls the public `GET /verify/:short_code` endpoint until the envelope reaches `completed` and `sealed_url` is populated, then flips from a disabled "Preparing signed PDF…" state to an enabled `<a download="<title>-signed.pdf" target="_blank" rel="noopener noreferrer">` backed by the 5-minute pre-signed URL the API returns.
- One screen serves both viewports: desktop and mobile share `/sign/:envelopeId/done`. A `@media (max-width: 640px)` rule snaps the action to full-width on phones; the rest of the page is already responsive.

## Where the button appears
- **Desktop** — primary CTA at the top of the Done page, immediately under the green check + recipient summary; the existing "Save my copy" upsell + retention card remain below.
- **Mobile** — same component, full-width below the summary.

## Backend touchpoints
- **None.** `GET /verify/:short_code` (`apps/api/src/verify/verify.controller.ts`) is already public and already returns a `sealed_url` (5-min signed URL) for `completed` envelopes — exactly the contract the SigningDonePage already uses to render its `/verify/<short_code>` link. No auth scope was broadened. The signer-session cookie that backs `/sign/*` is intentionally **not** used (it's cleared by `POST /sign/submit`).

## Test plan
- [x] vitest scoped — `apps/web/src/pages/SigningDonePage` + `apps/web/src/features/signing` — 77/77 passing
- [x] vitest full — 1406/1406 passing
- [x] typecheck (`pnpm --filter web typecheck`)
- [x] lint (`pnpm --filter web lint`)
- [ ] Manual verify on Cloudflare Preview after merge:
  - [ ] Desktop 1440 — sign an envelope → land on `/sign/:id/done` → button enables → click → PDF saves with `<title>-signed.pdf`
  - [ ] Mobile 375 — same flow, button is full-width
  - [ ] Disabled "Preparing signed PDF…" state visible while envelope still sealing
  - [ ] Inline alert surfaces if `/verify` errors

## TDD trail
- RED: 5 new tests added under `Download signed PDF (post-sign action)` describe block. All failed pre-fix (no UI). One iteration on `refetchInterval` to stop polling after a hard error so the alert sticks.
- GREEN: 14/14 SigningDonePage tests passing.
- REFACTOR: hook gates on `enabled: shortCode.length > 0` so deep-links with no snapshot skip the network entirely (rule 4.4 single-concern).

## Notes
- A separate parallel PR (`feature/web-download-original-pdf-on-sign`) is planned for the pre-sign "Download original PDF" action; if that lands first with a `useDownloadPdf` shared hook, this branch can be rebased to import it. Until then, `useSealedDownload` is named differently to avoid namespace collision.
- The `safeDownloadName` helper duplicates the local copy in `VerifyPage.tsx`; a NICE-TO-HAVE follow-up is to migrate VerifyPage to the shared one — out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)