### PR TITLE
fix(web): allow blob: in CSP img-src for signature preview

### DIFF
--- a/apps/landing/public/_headers
+++ b/apps/landing/public/_headers
@@ -7,7 +7,7 @@
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self' mailto:; frame-ancestors 'self'; img-src 'self' data: https://static.cloudflareinsights.com https://*.googleusercontent.com https://*.gstatic.com https://*.supabase.co; script-src 'self' https://static.cloudflareinsights.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com https://*.supabase.co https://api.seald.nromomentum.com https://www.googleapis.com https://content.googleapis.com; frame-src 'self' https://docs.google.com https://accounts.google.com; object-src 'none'; upgrade-insecure-requests
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; form-action 'self' mailto:; frame-ancestors 'self'; img-src 'self' data: blob: https://static.cloudflareinsights.com https://*.googleusercontent.com https://*.gstatic.com https://*.supabase.co; script-src 'self' https://static.cloudflareinsights.com https://apis.google.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://cloudflareinsights.com https://*.supabase.co https://api.seald.nromomentum.com https://www.googleapis.com https://content.googleapis.com; frame-src 'self' https://docs.google.com https://accounts.google.com; object-src 'none'; upgrade-insecure-requests
 
 # Long-cache hashed build assets
 /assets/*

--- a/apps/web/src/test/csp-headers.contract.test.ts
+++ b/apps/web/src/test/csp-headers.contract.test.ts
@@ -71,6 +71,24 @@ describe('CSP contract — apps/landing/public/_headers', () => {
   });
 
   /**
+   * Production bug (2026-05-04): after a user signed, the optimistic
+   * signature preview rendered through `URL.createObjectURL(blob)` in
+   * `useSigning.ts` was blocked by CSP — the network panel showed
+   * `blob:https://seald.nromomentum.com/...` as `(blocked:csp)`. Our
+   * `img-src` allowed `data:` but not `blob:`. Pin the allowance so a
+   * future tightening that drops `blob:` re-breaks the signature
+   * preview at unit-test time, not on prod.
+   *
+   * blob: URLs are same-origin object URLs — they cannot leak data
+   * cross-origin and are widely accepted as safe for img-src.
+   */
+  it('img-src allows blob: so optimistic signature previews render', () => {
+    const csp = loadCsp();
+    const sources = directive(csp, 'img-src');
+    expect(sources).toContain('blob:');
+  });
+
+  /**
    * Production bug (2026-05-04): with the Drive picker backend wired
    * up and `GDRIVE_PICKER_DEVELOPER_KEY`/`GDRIVE_PICKER_APP_ID` loaded
    * on the API host, end users still saw "Couldn't load Google's


### PR DESCRIPTION
## Summary
- After signing, the optimistic signature preview (rendered via `URL.createObjectURL(blob)` in [useSigning.ts:141](apps/web/src/features/signing/useSigning.ts:141)) was blocked by CSP — Network panel showed `blob:https://seald.nromomentum.com/...` as `(blocked:csp)`.
- Existing `img-src 'self' data: ...` allowed `data:` but not `blob:`.
- Fix: add `blob:` to the existing `img-src` directive (one token).
- Why we keep CSP: closes pentest finding **F-002** (Medium, CWE-1021/CWE-693) and underpins CCPA "reasonable security" (commit `1afa56e`). Removing CSP would re-open F-002.
- `lh3.googleusercontent.com` is already covered by the existing `https://*.googleusercontent.com` wildcard — no separate entry needed for Drive picker thumbnails.

## Test plan
- [x] RED: new contract test in [csp-headers.contract.test.ts](apps/web/src/test/csp-headers.contract.test.ts) asserts `img-src` contains `blob:` (failed on pre-fix `_headers`).
- [x] GREEN: passes after the fix.
- [x] Full web vitest: 1417/1417 passing
- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint` ✓
- [ ] Post-deploy: re-sign on prod and confirm signature preview renders without CSP block in Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)