### PR TITLE
fix(web): mobile send emits width/height (not w/h) to match place-fields DTO

### DIFF
--- a/apps/web/src/pages/MobileSendPage/MobileSendPage.test.tsx
+++ b/apps/web/src/pages/MobileSendPage/MobileSendPage.test.tsx
@@ -317,6 +317,70 @@ describe('MobileSendPage', () => {
     expect(typeof arg.buildFields).toBe('function');
   });
 
+  /*
+   * Production bug (2026-05-04): every mobile send returned 400 Bad
+   * Request. Root cause — `buildFields` emitted field placements with
+   * keys `w` and `h` instead of the API DTO's required `width` /
+   * `height`. Nest's global ValidationPipe runs with `whitelist:true,
+   * forbidNonWhitelisted:true` so unknown properties throw 400. The
+   * desktop code path (DocumentRoute.tsx) used the correct keys, so
+   * desktop send was unaffected. The mismatch survived TypeScript
+   * because `FieldPlacement.width`/`height` are optional, so an
+   * extra-property literal slipped through generic inference on
+   * `flatMap<FieldPlacement>(...)`.
+   *
+   * Pin the wire shape so the rename can never silently regress.
+   */
+  it('Send-for-signature buildFields emits width/height (not w/h) for the API', async () => {
+    const user = userEvent.setup();
+    runMock.mockClear();
+    renderPage();
+
+    // Walk: file → signers → place → review → Send (mirrors the
+    // earlier orchestration test).
+    const input = screen.getByLabelText(/pdf file/i) as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [mockFile('contract.pdf')] } });
+    });
+    await user.click(screen.getByRole('button', { name: /continue/i }));
+    await user.click(screen.getByRole('button', { name: /add signer/i }));
+    const dialog = await screen.findByRole('dialog', { name: /add a signer/i });
+    await user.type(within(dialog).getByPlaceholderText(/full name/i), 'Bob Builder');
+    await user.type(within(dialog).getByPlaceholderText(/name@example\.com/i), 'bob@example.com');
+    await user.click(within(dialog).getByRole('button', { name: /^add$/i }));
+    await user.click(screen.getByRole('button', { name: /next: place fields/i }));
+    await user.click(screen.getByRole('button', { name: /^signature$/i }));
+    const canvas = await screen.findByTestId('mw-canvas');
+    await user.click(canvas);
+    await user.click(screen.getByRole('button', { name: /^review/i }));
+    await user.click(screen.getByRole('button', { name: /send for signature/i }));
+
+    expect(runMock).toHaveBeenCalledTimes(1);
+    const call = runMock.mock.calls[0];
+    if (!call) throw new Error('expected runMock to have been invoked');
+    const arg = (call as ReadonlyArray<unknown>)[0] as {
+      buildFields: (localToServer: Map<string, string>) => ReadonlyArray<Record<string, unknown>>;
+      signers: ReadonlyArray<{ localId: string; email?: string }>;
+    };
+    // Build a localToServer mapping from the signers the page passed in,
+    // so buildFields can resolve every local id to a server id.
+    const localToServer = new Map<string, string>();
+    for (const s of arg.signers) {
+      localToServer.set(s.localId, `srv-${s.localId}`);
+    }
+    const placements = arg.buildFields(localToServer);
+    expect(placements.length).toBeGreaterThan(0);
+    for (const p of placements) {
+      // Wire-shape contract: the API requires `width`/`height` and the
+      // ValidationPipe rejects any extra property — so `w`/`h` MUST
+      // not appear and `width`/`height` MUST be present numbers.
+      expect(p).not.toHaveProperty('w');
+      expect(p).not.toHaveProperty('h');
+      expect(typeof p['width']).toBe('number');
+      expect(typeof p['height']).toBe('number');
+    }
+  });
+
   it('rejects an invalid email in the add-signer sheet', async () => {
     const user = userEvent.setup();
     renderPage();

--- a/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
+++ b/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
@@ -455,8 +455,11 @@ export function MobileSendPage() {
             const yPct = canvasBounds.height > 0 ? f.y / canvasBounds.height : 0;
             // Approximate normalized field size — the API expects 0–1 box
             // coords. Mobile's fixed pixel widths scale uniformly.
-            const wPct = canvasBounds.width > 0 ? 80 / canvasBounds.width : 0.25;
-            const hPct = canvasBounds.height > 0 ? 28 / canvasBounds.height : 0.08;
+            // The DTO requires `width`/`height` keys; emitting `w`/`h`
+            // here caused every mobile send to 400 because Nest's
+            // ValidationPipe runs with `forbidNonWhitelisted: true`.
+            const widthPct = canvasBounds.width > 0 ? 80 / canvasBounds.width : 0.25;
+            const heightPct = canvasBounds.height > 0 ? 28 / canvasBounds.height : 0.08;
             return f.signerIds.flatMap((sid) => {
               const serverId = localToServer.get(sid);
               if (!serverId) return [];
@@ -465,8 +468,8 @@ export function MobileSendPage() {
                 page: p,
                 x: xPct,
                 y: yPct,
-                w: wPct,
-                h: hPct,
+                width: widthPct,
+                height: heightPct,
                 kind: FIELD_TYPE_TO_API[f.type],
                 ...(f.type === 'txt' || f.type === 'chk' ? { required: true } : {}),
               }));


### PR DESCRIPTION
## Summary

Production bug — every mobile send returned **400 Bad Request** from `PUT /envelopes/:id/fields`. Desktop send was unaffected.

## Root cause

`apps/web/src/pages/MobileSendPage/MobileSendPage.tsx` `buildFields` emitted field placements with keys `w` / `h`, but the API DTO requires `width` / `height`. Nest's global `ValidationPipe({ whitelist: true, forbidNonWhitelisted: true })` (`apps/api/src/main.ts:90`) rejected the unknown properties with HTTP 400.

The mismatch survived TypeScript because `FieldPlacement.width` / `.height` are declared optional (`apps/web/src/features/envelopes/envelopesApi.ts:83-84`), so the extra-property literal slipped through generic inference on `flatMap<FieldPlacement>(...)`.

## Fix

- Rename `wPct` / `hPct` → `widthPct` / `heightPct` (math unchanged).
- Emit `width` / `height` keys instead of `w` / `h`.
- Inline comment explains the wire-shape contract.

## Regression test (RED → GREEN trail)

`MobileSendPage.test.tsx` — exercises the `buildFields` callback through the full send flow (file → signers → place → review → Send) and asserts the wire shape:

- No `w` / `h` keys.
- `width` / `height` are present numbers.

Verified RED-first against the unchanged code (`expected ... to not have property "w"`), then GREEN by the rename. Pins the contract so a future revert can't silently re-break mobile send.

## Gates

- `pnpm typecheck` ✓
- `pnpm lint` ✓ (--max-warnings=0)
- `pnpm vitest run` ✓ — 1418/1418

## react-pr-review

0 MUST-FIX, 0 SHOULD-FIX, 0 NICE-TO-HAVE.

## Test plan

- [ ] On https://seald.nromomentum.com/m/send (mobile viewport), upload a PDF, add a signer, drop a signature, Review, Send. Verify the request succeeds (no 400) and the user lands on the sent confirmation.
- [ ] Network panel: `PUT /envelopes/<id>/fields` body shows `width` and `height` numeric keys, no `w` / `h`.
- [ ] Desktop send-flow remains unaffected.

## Out of scope

- `satisfies FieldPlacement` migration to enable excess-property checking at compile time — separate hardening PR.
- Drive-picker thumbnail issue (separate investigation in flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)