### PR TITLE
fix(web): wrap SigningDonePage story in QueryClientProvider

### DIFF
--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.stories.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.stories.tsx
@@ -1,10 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { writeDoneSnapshot } from '../../features/signing';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SEALED_DOWNLOAD_KEY, writeDoneSnapshot } from '../../features/signing';
+import type { VerifyResponse } from '../../features/verify';
 import { SigningDonePage } from './SigningDonePage';
 
 const ENVELOPE_ID = 'env-storybook-001';
+const SHORT_CODE = 'STORYBOOKDONE';
 
 // Seed at module load so the first render of the page already sees the
 // snapshot in sessionStorage (the page redirects away if it's missing).
@@ -12,7 +16,7 @@ if (typeof window !== 'undefined') {
   writeDoneSnapshot({
     kind: 'submitted',
     envelope_id: ENVELOPE_ID,
-    short_code: 'STORYBOOKDONE',
+    short_code: SHORT_CODE,
     title: 'Master Services Agreement',
     sender_name: 'Eliran Azulay',
     recipient_email: 'maya@example.com',
@@ -20,13 +24,59 @@ if (typeof window !== 'undefined') {
   });
 }
 
+// Pre-rendered VerifyResponse used to seed the React Query cache. PR #166
+// added `useSealedDownload` to SigningDonePage, which calls `useQuery`
+// against `GET /verify/:short_code`. Without a QueryClientProvider in the
+// story tree, React Query throws "No QueryClient set" at first render and
+// Chromatic captures the throw as a component error (build 422+ on main).
+// Seeding the cache up-front also short-circuits the polling: the hook's
+// refetchInterval returns `false` once `status === 'completed'` and a
+// `sealed_url` is present, so the network is never touched in Storybook.
+const COMPLETED_VERIFY: VerifyResponse = {
+  envelope: {
+    id: ENVELOPE_ID,
+    title: 'Master Services Agreement',
+    short_code: SHORT_CODE,
+    status: 'completed',
+    original_pages: 2,
+    original_sha256: null,
+    sealed_sha256: null,
+    tc_version: '1',
+    privacy_version: '1',
+    sent_at: '2026-04-24T00:00:00Z',
+    completed_at: '2026-04-24T00:00:08Z',
+    expires_at: '2026-05-24T00:00:00Z',
+  },
+  signers: [],
+  events: [],
+  chain_intact: true,
+  sealed_url: 'https://signed.example/sealed.pdf?sig=storybook',
+  audit_url: 'https://signed.example/audit.pdf?sig=storybook',
+};
+
 function Wrap({ children }: { readonly children: ReactNode }) {
+  // Lazy-init keeps render pure (rule 2.1) — without it, every re-render
+  // would mint a new QueryClient and discard the seeded cache. retry:
+  // false matches `renderSigningRoute` so a misconfigured story fails
+  // loudly instead of silently retrying.
+  const [qc] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, gcTime: 0, staleTime: Infinity },
+        mutations: { retry: false },
+      },
+    });
+    client.setQueryData(SEALED_DOWNLOAD_KEY(SHORT_CODE), COMPLETED_VERIFY);
+    return client;
+  });
   return (
-    <MemoryRouter initialEntries={[`/sign/${ENVELOPE_ID}/done`]}>
-      <Routes>
-        <Route path="/sign/:envelopeId/done" element={children} />
-      </Routes>
-    </MemoryRouter>
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={[`/sign/${ENVELOPE_ID}/done`]}>
+        <Routes>
+          <Route path="/sign/:envelopeId/done" element={children} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>
   );
 }
 


### PR DESCRIPTION
## Summary

Restores Chromatic CI on `main`. PR #166 added `useSealedDownload` (a React Query hook) to `SigningDonePage` but did not update its existing Storybook story. Without a `QueryClientProvider`, React Query throws "No QueryClient set" at first render → Chromatic captures the throw as a component error. Build 422+ red on every push since 06aef8e.

## Fix

- Add a story-local `QueryClientProvider` with a fresh `QueryClient` (lazy-init via `useState` per rule 2.1).
- Pre-seed `SEALED_DOWNLOAD_KEY('STORYBOOKDONE')` with a `completed` `VerifyResponse`. The hook's `refetchInterval` returns `false` for `status === 'completed' && sealed_url` present, so the network is never touched in Storybook.
- Story renders the post-sign "Sealed terminal screen" with the download CTA enabled (which is the intent of `Default: Sealed terminal screen`).

## Why story-local, not global

The global `apps/web/.storybook/preview.tsx` should remain side-effect-free so stories that explicitly want to test loading/error states can supply their own `QueryClient` with the desired pre-seeded shape. The `SigningDonePage.test.tsx` test harness (`renderSigningRoute`) already wraps tests in a fresh `QueryClient` — this story now mirrors that pattern.

## Test plan

- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint --max-warnings=0` ✓
- [x] `pnpm --filter web build-storybook` ✓
- [x] `pnpm --filter web exec vitest run src/pages/SigningDonePage` ✓ (14/14 — story import verified to not break the test file's barrel surface)
- [ ] Chromatic visual regression — green expected on this PR (will adopt the new baseline on merge to main).

## Rules respected

- 2.1 (purity): `QueryClient` created in lazy `useState` initialiser; `setQueryData` lives inside the initialiser, not in render.
- 3.1/3.2: `VerifyResponse` imported as type; no `any`.
- 3.7: `children` prop is `readonly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)