### PR TITLE
feat(mobile): mobile Google Drive picker on /m/send (Phase 5)

### DIFF
--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -18,6 +18,7 @@ import { ForgotPasswordPage } from './pages/ForgotPasswordPage';
 import { CheckEmailPage } from './pages/CheckEmailPage';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { GDriveOAuthCallbackPage } from './pages/GDriveOAuthCallbackPage';
+import { MobileGdriveReturnPage } from './pages/MobileGdriveReturnPage';
 import { RequireSignerSession } from './features/signing/RequireSignerSession';
 import { SigningErrorBoundary } from './features/signing/SigningErrorBoundary';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -187,6 +188,11 @@ export function AppRoutes() {
             </ErrorBoundary>
           }
         />
+        {/* Bounce-back from Google's OAuth consent for the mobile flow.
+            Forwards into /m/send?gdrive_connected=1 so the picker auto-
+            opens once the new account row is in the React-Query cache.
+            Lives outside <AppShell /> for the same reason as /m/send. */}
+        <Route path="/m/send/drive" element={<MobileGdriveReturnPage />} />
       </Route>
 
       <Route element={<RequireAuth />}>

--- a/apps/web/src/components/mobile/MobileDrivePicker/MobileDrivePicker.test.tsx
+++ b/apps/web/src/components/mobile/MobileDrivePicker/MobileDrivePicker.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '@/test/renderWithProviders';
+import { MobileDrivePicker } from './MobileDrivePicker';
+import { setSignerReporter, type SignerEvent } from '@/features/signing/telemetry';
+
+import type * as ApiClientModule from '@/lib/api/apiClient';
+import type * as GDriveImportModule from '@/features/gdriveImport';
+
+// Mock the apiClient at the module boundary so the picker's React-Query
+// call resolves with whatever each test wants — no real network.
+vi.mock('@/lib/api/apiClient', async () => {
+  const actual = await vi.importActual<typeof ApiClientModule>('@/lib/api/apiClient');
+  return {
+    ...actual,
+    apiClient: {
+      get: vi.fn(),
+      post: vi.fn(),
+      delete: vi.fn(),
+    },
+  };
+});
+
+// Stub useDriveImport so the conversion side-effect is a deterministic
+// callback into the test, not the real polling loop.
+vi.mock('@/features/gdriveImport', async () => {
+  const actual = await vi.importActual<typeof GDriveImportModule>('@/features/gdriveImport');
+  return {
+    ...actual,
+    useDriveImport: ({ onReady }: { onReady: (file: File) => void }) => ({
+      state: { kind: 'idle' as const },
+      beginImport: vi.fn((file: { name: string }) => {
+        onReady(new File(['hi'], `${file.name}.pdf`, { type: 'application/pdf' }));
+      }),
+      cancelImport: vi.fn(async () => undefined),
+      reset: vi.fn(),
+    }),
+  };
+});
+
+import { apiClient } from '@/lib/api/apiClient';
+
+const apiGetMock = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  apiGetMock.mockReset();
+});
+
+function renderPicker(overrides: Partial<React.ComponentProps<typeof MobileDrivePicker>> = {}) {
+  return renderWithProviders(
+    <MobileDrivePicker
+      open
+      accountId="acct-1"
+      onClose={overrides.onClose ?? vi.fn()}
+      onPick={overrides.onPick ?? vi.fn()}
+      onReconnect={overrides.onReconnect ?? vi.fn()}
+    />,
+  );
+}
+
+describe('MobileDrivePicker', () => {
+  it('renders the empty state when the API returns zero files', async () => {
+    apiGetMock.mockResolvedValueOnce({ data: { files: [] } });
+    renderPicker();
+    expect(await screen.findByText(/no files in this folder/i)).toBeInTheDocument();
+  });
+
+  it('emits file_selected telemetry and hands the converted file to onPick', async () => {
+    const events: SignerEvent[] = [];
+    setSignerReporter((e) => events.push(e));
+    apiGetMock.mockResolvedValueOnce({
+      data: {
+        files: [
+          {
+            id: 'file-1',
+            name: 'MSA',
+            mimeType: 'application/pdf',
+            modifiedTime: '2026-04-24T00:00:00Z',
+          },
+        ],
+      },
+    });
+    const onPick = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({ onPick });
+    const row = await screen.findByRole('button', { name: /import file msa/i });
+    await user.click(row);
+    await waitFor(() => expect(onPick).toHaveBeenCalledTimes(1));
+    const firstCall = onPick.mock.calls[0];
+    if (!firstCall) throw new Error('onPick was not called');
+    const file: File = firstCall[0];
+    expect(file.name).toBe('MSA.pdf');
+    const types = events.map((e) => e.type);
+    expect(types).toContain('mobile.gdrive.file_selected');
+    expect(types).toContain('mobile.gdrive.converted');
+    setSignerReporter(() => {
+      /* reset */
+    });
+  });
+
+  it('renders the re-authorize state when the list endpoint returns 401', async () => {
+    const err = Object.assign(new Error('Unauthorized'), { status: 401 });
+    apiGetMock.mockRejectedValueOnce(err);
+    const onReconnect = vi.fn();
+    const user = userEvent.setup();
+    renderPicker({ onReconnect });
+    const cta = await screen.findByRole('button', { name: /re-authorize/i });
+    await user.click(cta);
+    expect(onReconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits picker_open telemetry exactly once on first mount', async () => {
+    const events: SignerEvent[] = [];
+    setSignerReporter((e) => events.push(e));
+    apiGetMock.mockResolvedValueOnce({ data: { files: [] } });
+    renderPicker();
+    await screen.findByText(/no files in this folder/i);
+    const opens = events.filter((e) => e.type === 'mobile.gdrive.picker_open');
+    expect(opens).toHaveLength(1);
+    setSignerReporter(() => {
+      /* reset */
+    });
+  });
+});

--- a/apps/web/src/components/mobile/MobileDrivePicker/MobileDrivePicker.tsx
+++ b/apps/web/src/components/mobile/MobileDrivePicker/MobileDrivePicker.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useRef, useState } from 'react';
+import type { JSX } from 'react';
+import { createPortal } from 'react-dom';
+import { useQuery } from '@tanstack/react-query';
+import { File as FileIcon, Folder, X } from 'lucide-react';
+import { apiClient, type ApiError } from '@/lib/api/apiClient';
+import { reportSignerEvent } from '@/features/signing/telemetry';
+import { useDriveImport } from '@/features/gdriveImport';
+import type { DriveFile } from '@/components/drive-picker';
+import {
+  Backdrop,
+  Empty,
+  Header,
+  HeaderTitle,
+  IconButton,
+  ImportingOverlay,
+  PrimaryAction,
+  Row,
+  RowIcon,
+  RowSub,
+  RowText,
+  RowTitle,
+  ScrollList,
+  Skeleton,
+  Spinner,
+  StateText,
+  StateTitle,
+  Surface,
+} from './styles';
+
+/**
+ * Mobile-only Google Drive picker. Opens as a full-screen sheet (slides
+ * up from the bottom) on the /m/send flow when the sender taps "Import
+ * from Google Drive". Custom UI is justified mobile-only carve-out
+ * (Q1 in clarifications-mobile.md): Google's own Picker iframe ships
+ * with a >=768 px minimum viewport which breaks the 320–414 px contract
+ * of /m/send.
+ *
+ * Reuses the WT-A-2 list-files proxy (`GET /integrations/gdrive/files`)
+ * and the WT-D conversion orchestrator (`useDriveImport`) — no backend
+ * changes. The component itself emits three telemetry events:
+ *  - `mobile.gdrive.picker_open` once when the sheet first mounts
+ *  - `mobile.gdrive.file_selected` on row tap
+ *  - `mobile.gdrive.converted` once the converted PDF is in hand
+ */
+
+export interface MobileDrivePickerProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly onPick: (file: File) => void;
+  readonly accountId: string;
+  /** Tapping "Re-authorize" or "Connect Google Drive" calls this. */
+  readonly onReconnect?: () => void;
+}
+
+interface DriveFilesResponse {
+  readonly files: ReadonlyArray<DriveFile>;
+}
+
+function formatModified(iso: string | undefined): string {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function statusOf(err: unknown): number | undefined {
+  if (err && typeof err === 'object' && 'status' in err) {
+    const s = (err as ApiError).status;
+    return typeof s === 'number' ? s : undefined;
+  }
+  return undefined;
+}
+
+export function MobileDrivePicker(props: MobileDrivePickerProps): JSX.Element | null {
+  const { open, onClose, onPick, accountId, onReconnect } = props;
+  const [importing, setImporting] = useState<DriveFile | null>(null);
+  // Mirror `importing` in a ref so the `onReady` callback registered
+  // with `useDriveImport` (captured at hook-init time) can see the file
+  // it's converting even when state updates haven't flushed yet (rule
+  // 4.4 — keep one effect, one responsibility; the ref short-circuits
+  // a stale-closure read without coupling the conversion side-effect to
+  // a re-render).
+  const importingRef = useRef<DriveFile | null>(null);
+
+  // Single-flight: emit picker_open telemetry exactly once per sheet
+  // mount (rule 4.4 — one effect, one responsibility). Re-opens fire
+  // again because the parent unmounts/remounts via `open`.
+  const reportedOpenRef = useRef(false);
+  useEffect(() => {
+    if (!open) {
+      reportedOpenRef.current = false;
+      return;
+    }
+    if (reportedOpenRef.current) return;
+    reportedOpenRef.current = true;
+    reportSignerEvent({ type: 'mobile.gdrive.picker_open', account_id: accountId });
+  }, [open, accountId]);
+
+  const filesQuery = useQuery<DriveFilesResponse, ApiError>({
+    queryKey: ['gdrive', 'files', accountId],
+    enabled: open && Boolean(accountId),
+    queryFn: async () => {
+      const res = await apiClient.get<DriveFilesResponse>('/integrations/gdrive/files', {
+        params: { accountId, mimeFilter: 'all' },
+      });
+      return res.data;
+    },
+    retry: false,
+  });
+
+  const importer = useDriveImport({
+    accountId,
+    onReady: (file) => {
+      const m = importingRef.current;
+      importingRef.current = null;
+      setImporting(null);
+      if (m) {
+        reportSignerEvent({
+          type: 'mobile.gdrive.converted',
+          account_id: accountId,
+          mime_type: m.mimeType,
+        });
+      }
+      onPick(file);
+    },
+  });
+
+  // Lock body scroll while open — same pattern as MWBottomSheet.
+  useEffect(() => {
+    if (!open) return undefined;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [open]);
+
+  // ESC-to-close keyboard hook (web). Android back-button is handled by
+  // the route stack — when this picker is rendered as part of /m/send
+  // the navigation back-button collapses the dialog naturally.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  if (typeof document === 'undefined') return null;
+
+  const handleRowTap = (f: DriveFile): void => {
+    reportSignerEvent({
+      type: 'mobile.gdrive.file_selected',
+      account_id: accountId,
+      mime_type: f.mimeType,
+    });
+    importingRef.current = f;
+    setImporting(f);
+    importer.beginImport(f);
+  };
+
+  const status = statusOf(filesQuery.error);
+  const isAuthError = status === 401;
+  const isLoading = filesQuery.isLoading || filesQuery.isPending;
+  const files = filesQuery.data?.files ?? [];
+
+  let body: JSX.Element;
+  if (isAuthError) {
+    body = (
+      <Empty>
+        <StateTitle>Authorization expired</StateTitle>
+        <StateText>Your Google connection needs to be re-authorized to continue.</StateText>
+        <PrimaryAction
+          type="button"
+          onClick={() => {
+            onReconnect?.();
+          }}
+        >
+          Re-authorize
+        </PrimaryAction>
+      </Empty>
+    );
+  } else if (filesQuery.isError) {
+    body = (
+      <Empty>
+        <StateTitle>Couldn&apos;t load Drive</StateTitle>
+        <StateText>Something went wrong listing your files. Please try again.</StateText>
+        <PrimaryAction type="button" onClick={() => filesQuery.refetch()}>
+          Retry
+        </PrimaryAction>
+      </Empty>
+    );
+  } else if (isLoading) {
+    body = (
+      <ScrollList>
+        <Skeleton aria-hidden />
+        <Skeleton aria-hidden />
+        <Skeleton aria-hidden />
+      </ScrollList>
+    );
+  } else if (files.length === 0) {
+    body = (
+      <Empty>
+        <StateTitle>No files in this folder</StateTitle>
+        <StateText>You can pick a different account or upload from your phone instead.</StateText>
+      </Empty>
+    );
+  } else {
+    body = (
+      <ScrollList>
+        {files.map((f) => {
+          const isFolder = f.mimeType === 'application/vnd.google-apps.folder';
+          const label = isFolder ? `Open folder ${f.name}` : `Import file ${f.name}`;
+          return (
+            <Row key={f.id} type="button" aria-label={label} onClick={() => handleRowTap(f)}>
+              <RowIcon aria-hidden>
+                {isFolder ? <Folder size={20} /> : <FileIcon size={20} />}
+              </RowIcon>
+              <RowText>
+                <RowTitle>{f.name}</RowTitle>
+                {f.modifiedTime && <RowSub>Modified {formatModified(f.modifiedTime)}</RowSub>}
+              </RowText>
+            </Row>
+          );
+        })}
+      </ScrollList>
+    );
+  }
+
+  return createPortal(
+    <Backdrop role="dialog" aria-modal="true" aria-labelledby="mobile-drive-picker-title">
+      <Surface>
+        <Header>
+          <IconButton type="button" onClick={onClose} aria-label="Close Drive picker">
+            <X size={20} aria-hidden />
+          </IconButton>
+          <HeaderTitle id="mobile-drive-picker-title">My Drive</HeaderTitle>
+          <span style={{ width: 44, flexShrink: 0 }} aria-hidden />
+        </Header>
+        {body}
+        {importing && (
+          <ImportingOverlay role="status" aria-live="polite">
+            <Spinner aria-hidden />
+            <StateTitle>Importing &lsquo;{importing.name}&rsquo;…</StateTitle>
+            <StateText>Converting your file to PDF.</StateText>
+          </ImportingOverlay>
+        )}
+      </Surface>
+    </Backdrop>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/mobile/MobileDrivePicker/index.ts
+++ b/apps/web/src/components/mobile/MobileDrivePicker/index.ts
@@ -1,0 +1,2 @@
+export { MobileDrivePicker } from './MobileDrivePicker';
+export type { MobileDrivePickerProps } from './MobileDrivePicker';

--- a/apps/web/src/components/mobile/MobileDrivePicker/styles.ts
+++ b/apps/web/src/components/mobile/MobileDrivePicker/styles.ts
@@ -1,0 +1,245 @@
+import styled, { keyframes } from 'styled-components';
+
+// Bottom-up sheet entry — mirrors the existing slide-up feel of the
+// MWBottomSheet but for a full-viewport picker. No new tokens.
+const slideUp = keyframes`
+  from { transform: translateY(100%); }
+  to   { transform: translateY(0); }
+`;
+
+export const Backdrop = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: rgba(11, 18, 32, 0.45);
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+`;
+
+export const Surface = styled.div`
+  background: #fff;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  animation: ${slideUp} 220ms ease-out;
+  /* Use 100dvh to honour iOS Safari's URL bar; fall back to vh on older
+     browsers via the supplemental rule below. */
+  height: 100vh;
+  height: 100dvh;
+`;
+
+export const Header = styled.div`
+  display: flex;
+  align-items: center;
+  height: 56px;
+  padding: 0 8px;
+  border-bottom: 1px solid var(--border-1);
+  flex-shrink: 0;
+`;
+
+export const HeaderTitle = styled.h1`
+  flex: 1;
+  text-align: center;
+  font: inherit;
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--fg-1);
+  margin: 0;
+  /* Truncate long folder names (mobile is <414 px viewport) so the
+     title can never push the close-button off-screen. */
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: 0 8px;
+`;
+
+export const IconButton = styled.button`
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  color: var(--fg-2);
+  flex-shrink: 0;
+
+  &:active {
+    background: var(--ink-100);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--indigo-600);
+    outline-offset: 2px;
+  }
+`;
+
+export const ScrollList = styled.div`
+  flex: 1;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+`;
+
+export const Row = styled.button`
+  width: 100%;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 16px;
+  min-height: 56px;
+  background: transparent;
+  border: 0;
+  border-bottom: 1px solid var(--border-1);
+  cursor: pointer;
+  font: inherit;
+  color: var(--fg-1);
+
+  &:active {
+    background: var(--ink-100);
+  }
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+  &:focus-visible {
+    outline: 2px solid var(--indigo-600);
+    outline-offset: -2px;
+  }
+`;
+
+export const RowIcon = styled.span`
+  width: 44px;
+  height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  background: var(--ink-100);
+  color: var(--indigo-600);
+  flex-shrink: 0;
+`;
+
+export const RowText = styled.span`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+`;
+
+export const RowTitle = styled.span`
+  font-size: 15px;
+  font-weight: 500;
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const RowSub = styled.span`
+  font-size: 12px;
+  color: var(--fg-3);
+  margin-top: 2px;
+`;
+
+export const Empty = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  color: var(--fg-3);
+  font-size: 14px;
+  gap: 12px;
+  text-align: center;
+`;
+
+export const StateText = styled.div`
+  color: var(--fg-2);
+  font-size: 14px;
+  line-height: 1.45;
+`;
+
+export const StateTitle = styled.div`
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: 18px;
+  color: var(--fg-1);
+`;
+
+export const PrimaryAction = styled.button`
+  margin-top: 8px;
+  min-height: 44px;
+  padding: 0 18px;
+  border-radius: 12px;
+  background: var(--indigo-600);
+  color: #fff;
+  border: 0;
+  font: inherit;
+  font-weight: 500;
+  cursor: pointer;
+
+  &:active {
+    background: var(--indigo-700, #4338ca);
+  }
+  &:focus-visible {
+    outline: 2px solid var(--indigo-600);
+    outline-offset: 2px;
+  }
+`;
+
+export const Skeleton = styled.div`
+  height: 56px;
+  margin: 0 16px;
+  border-bottom: 1px solid var(--border-1);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  &::before {
+    content: '';
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    background: var(--ink-100);
+  }
+  &::after {
+    content: '';
+    flex: 1;
+    height: 12px;
+    border-radius: 6px;
+    background: var(--ink-100);
+    margin-right: 24%;
+  }
+`;
+
+export const ImportingOverlay = styled.div`
+  position: absolute;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.96);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+  z-index: 1;
+`;
+
+export const Spinner = styled.div`
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 3px solid var(--ink-200);
+  border-top-color: var(--indigo-600);
+  animation: spin 0.8s linear infinite;
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+`;

--- a/apps/web/src/features/signing/telemetry.ts
+++ b/apps/web/src/features/signing/telemetry.ts
@@ -37,6 +37,22 @@ export type SignerEvent =
       readonly envelope_id: string | null;
       readonly status: number | null;
       readonly message: string;
+    }
+  // Mobile Google Drive integration (Phase 5). Three additive variants
+  // emitted from `<MobileDrivePicker />` when the sender on /m/send taps
+  // the "Import from Google Drive" tile, picks a file from the sheet,
+  // and the conversion completes. Uses the same reporter seam so a host
+  // build can swap the no-op for PostHog/Datadog without forking.
+  | { readonly type: 'mobile.gdrive.picker_open'; readonly account_id: string }
+  | {
+      readonly type: 'mobile.gdrive.file_selected';
+      readonly account_id: string;
+      readonly mime_type: string;
+    }
+  | {
+      readonly type: 'mobile.gdrive.converted';
+      readonly account_id: string;
+      readonly mime_type: string;
     };
 
 export type SignerReporter = (event: SignerEvent) => void;

--- a/apps/web/src/pages/MobileGdriveReturnPage.tsx
+++ b/apps/web/src/pages/MobileGdriveReturnPage.tsx
@@ -1,0 +1,20 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+/**
+ * Landing page for the Google Drive OAuth return on mobile. The mobile
+ * flow uses a full-page redirect (Q2 in clarifications-mobile.md) — iOS
+ * Safari blocks popup-based OAuth — so the API's callback bounces the
+ * user to `/m/send/drive` after a successful token exchange. This route
+ * is a near-zero-LOC bounce: it forwards back into `/m/send` with
+ * `?gdrive_connected=1` so MobileSendPage's auto-open effect re-opens
+ * the picker sheet on landing. Replace=true so the back-button skips
+ * the hop.
+ */
+export function MobileGdriveReturnPage() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    navigate('/m/send?gdrive_connected=1', { replace: true });
+  }, [navigate]);
+  return null;
+}

--- a/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
+++ b/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
@@ -1,6 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { ArrowRight, Send } from 'lucide-react';
+import { isFeatureEnabled } from 'shared';
+import { MobileDrivePicker } from '@/components/mobile/MobileDrivePicker';
+import { useGDriveAccounts } from '@/routes/settings/integrations/useGDriveAccounts';
 import {
   Shell,
   Scroller,
@@ -84,8 +87,15 @@ const FIELD_TYPE_TO_API: Readonly<Record<MobileFieldType, FieldPlacement['kind']
  * desktop nav bar would dominate a 375 px viewport); the mobile flow has
  * its own stepper + sticky CTA.
  */
+// API base URL for full-page OAuth redirect. iOS Safari's popup blocker
+// silently swallows `window.open()` outside a synchronous user gesture
+// chain, so the mobile flow uses a top-level navigation. Pulled at
+// module-init from Vite's env (rule 3.2: no `any`).
+const GDRIVE_API_BASE = import.meta.env.VITE_API_BASE_URL as string | undefined;
+
 export function MobileSendPage() {
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   // QA-2026-05-02 (Bug 2): pull `session` so the "Add me as signer" toggle
   // also works for anonymous Supabase sessions. `useAuth().user` is `null`
   // for anon sessions on purpose (NavBar, AppState gate on it), but the
@@ -133,6 +143,52 @@ export function MobileSendPage() {
          onClick doesn't see an unhandled rejection (rule 4.4). */
     });
   }, [downloadPdfFile, pdfFile]);
+
+  // ---- Google Drive integration (Phase 5, mobile-only) ----
+  // The picker is fully gated behind `feature.gdriveIntegration` AND a
+  // connected account; the dark build never mounts it. The OAuth flow
+  // is full-page redirect (Q2 in clarifications-mobile.md): iOS Safari
+  // silently blocks popup-based auth, and the redirect target carries a
+  // `return=/m/send/drive` so we can re-open the picker on come-back.
+  const gdriveOn = isFeatureEnabled('gdriveIntegration');
+  const accountsQuery = useGDriveAccounts();
+  const driveAccounts = gdriveOn ? (accountsQuery.data ?? []) : [];
+  const driveAccountId = driveAccounts[0]?.id ?? null;
+  const [drivePickerOpen, setDrivePickerOpen] = useState(false);
+
+  const beginDriveOAuth = useCallback((): void => {
+    if (!GDRIVE_API_BASE) return;
+    const ret = encodeURIComponent('/m/send/drive');
+    window.location.href = `${GDRIVE_API_BASE}/integrations/gdrive/oauth/start?return=${ret}`;
+  }, []);
+
+  const handlePickFromDrive = useCallback((): void => {
+    if (driveAccountId) {
+      setDrivePickerOpen(true);
+      return;
+    }
+    beginDriveOAuth();
+  }, [driveAccountId, beginDriveOAuth]);
+
+  const reauthorizeDrive = useCallback((): void => {
+    if (!GDRIVE_API_BASE) return;
+    const ret = encodeURIComponent('/m/send/drive');
+    window.location.href = `${GDRIVE_API_BASE}/integrations/gdrive/oauth/start?return=${ret}&prompt=consent`;
+  }, []);
+
+  // Auto-open the picker when the OAuth callback returned us to
+  // /m/send?gdrive_connected=1. Strip the param after consuming so a
+  // back-then-forward doesn't re-open the sheet uninvited (rule 4.4 —
+  // one effect, one responsibility).
+  useEffect(() => {
+    if (!gdriveOn) return;
+    if (searchParams.get('gdrive_connected') !== '1') return;
+    if (!driveAccountId) return;
+    setDrivePickerOpen(true);
+    const next = new URLSearchParams(searchParams);
+    next.delete('gdrive_connected');
+    setSearchParams(next, { replace: true });
+  }, [gdriveOn, searchParams, driveAccountId, setSearchParams]);
 
   const [signers, setSigners] = useState<ReadonlyArray<MobileSigner>>([]);
   const [meIncluded, setMeIncluded] = useState(false);
@@ -563,7 +619,10 @@ export function MobileSendPage() {
         {step === 'start' && (
           <>
             {fileError && <ErrorBanner role="alert">{fileError}</ErrorBanner>}
-            <MWStart onPickFile={handlePickFile} />
+            <MWStart
+              onPickFile={handlePickFile}
+              {...(gdriveOn ? { onPickFromDrive: handlePickFromDrive } : {})}
+            />
           </>
         )}
         {step === 'file' && pdfFile && (
@@ -684,6 +743,24 @@ export function MobileSendPage() {
         onAdd={addSignerLocal}
         existingEmails={existingSignerEmails}
       />
+
+      {/* Mobile Drive picker (Phase 5). Fully gated by the feature
+          flag + a connected account — the dark build never mounts it.
+          On pick, the imported PDF goes through the same handlePickFile
+          boundary as the upload and camera tiles so file-type / size
+          rejection stays consistent. */}
+      {gdriveOn && driveAccountId && (
+        <MobileDrivePicker
+          open={drivePickerOpen}
+          accountId={driveAccountId}
+          onClose={() => setDrivePickerOpen(false)}
+          onReconnect={reauthorizeDrive}
+          onPick={(file) => {
+            setDrivePickerOpen(false);
+            handlePickFile(file);
+          }}
+        />
+      )}
     </Shell>
   );
 }

--- a/apps/web/src/pages/MobileSendPage/screens/MWStart.tsx
+++ b/apps/web/src/pages/MobileSendPage/screens/MWStart.tsx
@@ -1,6 +1,8 @@
 import { ChevronRight, Camera, Upload } from 'lucide-react';
 import styled from 'styled-components';
 import { useRef } from 'react';
+import { isFeatureEnabled } from 'shared';
+import { GDriveLogo } from '@/features/gdriveImport/GDriveLogo';
 
 const Wrap = styled.div`
   padding: 8px 16px 24px;
@@ -91,6 +93,12 @@ const HiddenFileInput = styled.input`
 
 export interface MWStartProps {
   readonly onPickFile: (file: File) => void;
+  /**
+   * Tapping the "Import from Google Drive" tile. When undefined, the
+   * tile hides — feature flag off, or the parent page hasn't wired the
+   * Drive picker yet.
+   */
+  readonly onPickFromDrive?: () => void;
 }
 
 // 2026-05-03 (per user): the "From a template" tile was removed. The
@@ -101,9 +109,13 @@ export interface MWStartProps {
 // for now mobile users start from a phone-side PDF (Upload PDF) or a
 // camera capture (Take photo).
 export function MWStart(props: MWStartProps) {
-  const { onPickFile } = props;
+  const { onPickFile, onPickFromDrive } = props;
   const inputRef = useRef<HTMLInputElement | null>(null);
   const cameraRef = useRef<HTMLInputElement | null>(null);
+  // The Drive tile only renders when (a) the feature flag is on and (b)
+  // the parent has wired a handler. Both gates must hold so the dark
+  // build still tree-shakes the picker via the parent's flag check.
+  const showDriveTile = isFeatureEnabled('gdriveIntegration') && Boolean(onPickFromDrive);
 
   const handleFile = (e: React.ChangeEvent<HTMLInputElement>): void => {
     const f = e.target.files?.[0];
@@ -137,6 +149,18 @@ export function MWStart(props: MWStartProps) {
           </TileText>
           <ChevronRight size={18} aria-hidden style={{ color: 'var(--fg-4)' }} />
         </Tile>
+        {showDriveTile && (
+          <Tile type="button" onClick={onPickFromDrive} aria-label="Import from Google Drive">
+            <TileIcon $accent="var(--indigo-600)" aria-hidden>
+              <GDriveLogo size={22} />
+            </TileIcon>
+            <TileText>
+              <TileTitle>Import from Google Drive</TileTitle>
+              <TileSub>Pick a file from your Drive</TileSub>
+            </TileText>
+            <ChevronRight size={18} aria-hidden style={{ color: 'var(--fg-4)' }} />
+          </Tile>
+        )}
       </Tiles>
       <HiddenFileInput
         ref={inputRef}


### PR DESCRIPTION
## Summary

Phase 5 of the mobile Google Drive integration. Adds a custom full-screen
picker sheet on `/m/send` (mobile-only carve-out — Google's own Picker
iframe enforces a >=768px viewport which breaks the 320–414px mobile
contract). Wires the existing WT-A-2 list-files proxy and the WT-D
conversion endpoint through the same `handlePickFile` boundary the
upload + camera tiles already use, so the rest of the flow is identical.

- New `MobileDrivePicker` (~255 LOC component, ~245 LOC styles) with
  loading skeleton / list / empty / 401-reauthorize / error states
- Full-page OAuth redirect (Q2 in clarifications-mobile.md) — iOS Safari
  silently swallows popup-based auth, so the mobile flow uses
  `window.location.href = ${API_BASE}/integrations/gdrive/oauth/start?return=/m/send/drive`
- `/m/send/drive` route bounces back into `/m/send?gdrive_connected=1`,
  whose auto-open effect in `MobileSendPage` re-opens the picker once the
  new account row hydrates from the React-Query cache
- Three additive telemetry variants on `SignerEvent`:
  `mobile.gdrive.picker_open`, `mobile.gdrive.file_selected`,
  `mobile.gdrive.converted`
- Tile + picker mount only when `feature.gdriveIntegration` is on AND a
  Drive account is connected — dark builds tree-shake everything

No backend changes. No new dependencies. The picker reuses
`useDriveImport` (WT-D conversion polling), the apiClient, and the
existing `useGDriveAccounts` hook from settings/integrations.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web test` — 1422/1422 pass (4 new in `MobileDrivePicker.test.tsx`)
- [x] `pnpm audit --prod --audit-level=high` — no vulnerabilities
- [x] `seald-react-pr-review` — verdict CLEAN; no MUST-FIX
- [ ] Phase 6 manual QA (separate run): iPhone SE / 14 Plus / 13 Pro,
      OAuth round-trip, no-account → connect → return → auto-open,
      token-expired re-auth path, search/folder navigation
- [ ] Chromatic visual diff for new MobileDrivePicker stories — deferred
      to follow-up (no Storybook story added in this PR; SHOULD-FIX)

## Files

- NEW `apps/web/src/components/mobile/MobileDrivePicker/{MobileDrivePicker.tsx,styles.ts,index.ts,MobileDrivePicker.test.tsx}`
- NEW `apps/web/src/pages/MobileGdriveReturnPage.tsx`
- MOD `apps/web/src/pages/MobileSendPage/{MobileSendPage.tsx,screens/MWStart.tsx}`
- MOD `apps/web/src/AppRoutes.tsx` (register `/m/send/drive`)
- MOD `apps/web/src/features/signing/telemetry.ts` (3 additive events)

LOC: 773 net new (within the ≤800 hard cap; soft 700 budget exceeded by
the picker's 5 explicit UX states + accessible labels — kept under 800
per the design's hard rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)