### PR TITLE
chore(deps): bump eslint-config-prettier 9→10 (root + apps/api)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -78,7 +78,7 @@
     "@typescript-eslint/parser": "7.18.0",
     "canvas": "^3.2.3",
     "eslint": "8.57.1",
-    "eslint-config-prettier": "9.1.0",
+    "eslint-config-prettier": "10.1.8",
     "jest": "^30.3.0",
     "pdfjs-dist": "^4.2.67",
     "pg-mem": "^3.0.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,8 +218,8 @@ importers:
         specifier: 8.57.1
         version: 8.57.1
       eslint-config-prettier:
-        specifier: 9.1.0
-        version: 9.1.0(eslint@8.57.1)
+        specifier: 10.1.8
+        version: 10.1.8(eslint@8.57.1)
       jest:
         specifier: ^30.3.0
         version: 30.3.0(@types/node@20.16.10)(ts-node@10.9.2(@swc/core@1.15.30(@swc/helpers@0.5.21))(@types/node@20.16.10)(typescript@5.6.3))
@@ -4945,8 +4945,8 @@ packages:
     engines: {node: '>=6.0'}
     hasBin: true
 
-  eslint-config-prettier@9.1.0:
-    resolution: {integrity: sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==}
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
@@ -14526,7 +14526,7 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-config-prettier@9.1.0(eslint@8.57.1):
+  eslint-config-prettier@10.1.8(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
 


### PR DESCRIPTION
Closes #170, #162.

Consolidated bump for the paired eslint-config-prettier major across root + apps/api so lockfiles and flat-config imports stay aligned in a single review.

Note: only `apps/api/package.json` declares `eslint-config-prettier` (root + `apps/web` do not), so both upstream Dependabot PRs (#170 and #162) targeted the same single file and were effectively duplicates. This consolidated PR carries the bump once.

`apps/api/.eslintrc.cjs` extends `'prettier'` (the legacy config name preserved in v10). The deprecated `prettier/prettier` ruleset removed in v10 was not in use, so no config edit was required.

## Test plan
- [x] pnpm -r lint
- [x] pnpm -r typecheck
- [x] pnpm --filter web test (1429 pass)
- [x] pnpm --filter api test (888 pass)