### PR TITLE
fix(security): remediate SAST/dependency findings

### DIFF
--- a/.github/workflows/prod-diagnose.yml
+++ b/.github/workflows/prod-diagnose.yml
@@ -20,12 +20,15 @@ jobs:
     steps:
       - name: SSH read-only diagnostic
         uses: appleboy/ssh-action@v1.2.5
+        env:
+          SSH_USER: ${{ secrets.DEPLOY_SSH_USER }}
         with:
           host: ${{ secrets.DEPLOY_SSH_HOST }}
           username: ${{ secrets.DEPLOY_SSH_USER }}
           key: ${{ secrets.DEPLOY_SSH_KEY }}
           port: 22
           command_timeout: 4m
+          envs: SSH_USER
           script: |
             set -uo pipefail
             echo '=== whoami / pwd ==='
@@ -77,4 +80,4 @@ jobs:
 
             echo '=== bash history hint (last 30 from root if any) ==='
             sudo bash -c 'tail -n 30 ~/.bash_history 2>/dev/null || true'
-            sudo bash -c 'tail -n 30 /home/${{ secrets.DEPLOY_SSH_USER }}/.bash_history 2>/dev/null || true'
+            sudo bash -c "tail -n 30 /home/${SSH_USER}/.bash_history 2>/dev/null || true"

--- a/apps/api/src/cron/cron.controller.ts
+++ b/apps/api/src/cron/cron.controller.ts
@@ -7,7 +7,7 @@ import {
   Post,
   UnauthorizedException,
 } from '@nestjs/common';
-import { timingSafeEqual } from 'node:crypto';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 import { Public } from '../auth/public.decorator';
 import { APP_ENV } from '../config/config.module';
 import type { AppEnv } from '../config/env.schema';
@@ -93,10 +93,16 @@ export class CronController {
  * Constant-time string compare for shared secrets. Avoids the early-exit
  * leak in `===` that lets an attacker probe a secret one character at a
  * time with timing measurements.
+ *
+ * Defence in depth: HMAC-compare both values so the comparison is always
+ * the same length (32 bytes) regardless of input. This eliminates the
+ * length-oracle that a naive `if (a.length !== b.length) return false`
+ * would leak. The HMAC key is ephemeral — it only needs to be consistent
+ * within a single comparison, not across requests.
  */
 function safeCompare(a: string, b: string): boolean {
-  const aBuf = Buffer.from(a);
-  const bBuf = Buffer.from(b);
-  if (aBuf.length !== bBuf.length) return false;
-  return timingSafeEqual(aBuf, bBuf);
+  const key = randomBytes(32);
+  const hmacA = createHmac('sha256', key).update(a).digest();
+  const hmacB = createHmac('sha256', key).update(b).digest();
+  return timingSafeEqual(hmacA, hmacB);
 }


### PR DESCRIPTION
## Summary

Security penetration test and static analysis of the Seald monorepo. Two actionable findings were fixed; the remainder are informational.

## Findings

| Severity | Location | Issue | Fix |
|----------|----------|-------|-----|
| **MEDIUM** | `apps/api/src/cron/cron.controller.ts` | `safeCompare` timing oracle — early `return false` on mismatched buffer lengths leaks whether the attacker's guess has the correct length | Replaced with HMAC-based comparison: both inputs are HMAC'd with an ephemeral key, producing fixed 32-byte digests for `timingSafeEqual`, eliminating the length oracle |
| **LOW** | `.github/workflows/prod-diagnose.yml` | `${{ secrets.DEPLOY_SSH_USER }}` interpolated directly into shell script body (potential script injection if secret contained metacharacters) | Moved to `envs` passthrough via appleboy/ssh-action so the value is injected as an environment variable, not shell-expanded |
| **INFO** | Dependency audit | `pnpm audit --prod` reports zero known vulnerabilities | No action needed |
| **INFO** | Secrets scan | No hardcoded secrets found; `.env` files are gitignored; only `.env.example` with placeholders committed | No action needed |
| **INFO** | SQL injection | All DB queries use Kysely's parameterized query builder; no raw SQL with user input | No action needed |
| **INFO** | XSS | No `dangerouslySetInnerHTML` usage; no unsanitized user input in DOM | No action needed |
| **INFO** | Auth | Global APP_GUARD with default-deny; signer session uses HttpOnly/SameSite cookies with HS256 JWT; PKCE+state for OAuth | No action needed |
| **INFO** | CORS | Origin allowlist from env var; credentials mode explicit | No action needed |
| **INFO** | Crypto | 256-bit tokens, SHA-256 hash-then-lookup pattern, jose for JWT, constant-time equalities | No action needed |
| **INFO** | CI workflows | No `${{ github.event.* }}` in `run:` blocks; actions use version tags; permissions scoped to `contents: read` | No action needed |

## Test plan

- [x] `pnpm --filter api test` — 888 tests pass
- [x] `pnpm --filter web test` — 1429 tests pass
- [x] `pnpm -r typecheck` — clean
- [x] `pnpm --filter api lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)