### PR TITLE
fix(api,web): broaden GDrive OAuth scope to drive.readonly for thumbnails + starred

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,9 +129,10 @@ When either picker var is unset,
 renders a friendly "Drive picker not configured on this server"
 notice.
 
-OAuth scope is hard-coded to `https://www.googleapis.com/auth/drive.file`
-(per-file consent only). Do not broaden — picker selections grant per-file
-access at the moment of click via Google's drive.file scope.
+OAuth scopes are `drive.file` (per-file write access for files
+opened/created by our app) + `drive.readonly` (read-only access to all
+files — enables thumbnails, starred listing, full file enumeration in
+picker). Do not add the broad `drive` scope (full read+write).
 
 When the feature flag `feature.gdriveIntegration` is off, all routes
 404 and the env vars are unread; the same image runs dark in dev and

--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -177,15 +177,20 @@ describe('GDriveController', () => {
     (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
   });
 
-  it('GET /oauth/url returns a Google consent URL with drive.file scope (NOT drive)', async () => {
+  it('GET /oauth/url returns a Google consent URL with drive.file + drive.readonly scopes (NOT broad drive)', async () => {
     const { ctrl } = makeController();
     const out = await ctrl.consentUrl(USER_1);
     expect(out.url).toContain('accounts.google.com/o/oauth2/v2/auth');
-    expect(out.url).toContain('scope=https%3A%2F%2Fwww.googleapis.com%2Fauth%2Fdrive.file');
-    // Crucially, it must NOT include the broad `drive` scope or
-    // `drive.readonly`. Negative assertion is the contract guard.
-    expect(out.url).not.toMatch(/scope=https%3A%2F%2Fwww\.googleapis\.com%2Fauth%2Fdrive(&|$)/);
-    expect(out.url).not.toContain('drive.readonly');
+    expect(out.url).toContain('drive.file');
+    expect(out.url).toContain('drive.readonly');
+    // Crucially, the scope parameter must NOT contain the broad `drive`
+    // scope (which would grant full read+write). Extract just the scope
+    // value and verify it only has drive.file and drive.readonly.
+    const scopeParam = decodeURIComponent(new URL(out.url).searchParams.get('scope') ?? '');
+    const scopes = scopeParam.split(' ');
+    expect(scopes).toContain('https://www.googleapis.com/auth/drive.file');
+    expect(scopes).toContain('https://www.googleapis.com/auth/drive.readonly');
+    expect(scopes).not.toContain('https://www.googleapis.com/auth/drive');
     expect(out.url).toContain('code_challenge_method=S256');
     expect(out.url).toContain('access_type=offline');
   });

--- a/apps/api/src/integrations/gdrive/oauth-pkce.ts
+++ b/apps/api/src/integrations/gdrive/oauth-pkce.ts
@@ -59,9 +59,15 @@ function base64url(b: Buffer): string {
 }
 
 /**
- * Build the Google OAuth consent URL. Scope is `drive.file` (per-file
- * authorization) NOT `drive` (full account) — Phase 4 red-flag row 12,
- * Phase 1 Q5. Test asserts the literal string.
+ * Build the Google OAuth consent URL.
+ *
+ * Scopes:
+ * - `drive.file` — per-file write access for files opened/created by our app
+ *   (needed for conversion upload). Per-file consent granted at picker click.
+ * - `drive.readonly` — read-only access to all files. Enables thumbnails in
+ *   GRID mode, starred file listing, and full file enumeration in the picker.
+ *
+ * We do NOT request the broad `drive` scope (full read+write to all files).
  */
 export function buildConsentUrl(args: {
   clientId: string;
@@ -69,11 +75,15 @@ export function buildConsentUrl(args: {
   state: string;
   codeChallenge: string;
 }): string {
+  const scope = [
+    'https://www.googleapis.com/auth/drive.file',
+    'https://www.googleapis.com/auth/drive.readonly',
+  ].join(' ');
   const params = new URLSearchParams({
     client_id: args.clientId,
     redirect_uri: args.redirectUri,
     response_type: 'code',
-    scope: 'https://www.googleapis.com/auth/drive.file',
+    scope,
     access_type: 'offline',
     prompt: 'consent',
     state: args.state,

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -124,29 +124,23 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
       .enableFeature(picker.Feature.SUPPORT_DRIVES);
 
     // Four DocsViews with explicit labels to avoid duplicate tab names.
-    // Each view uses LIST mode (not GRID) to work around the thumbnail
-    // ORB issue with drive.file scope. Tab order:
-    //   1. Starred        → setStarred(true) + setOwnedByMe(true)
+    // Now using GRID mode (default) since the `drive.readonly` scope
+    // allows Google's picker to load thumbnail images from
+    // lh3.googleusercontent.com without ORB issues. Tab order:
+    //   1. Starred        → setStarred(true), NO ownership filter
     //   2. My Drive       → setOwnedByMe(true)
     //   3. Shared with me → setOwnedByMe(false)
     //   4. Shared drives  → setEnableDrives(true)
     // All four apply the same MIME-type filter and keep
-    // setIncludeFolders(true)/setSelectFolderEnabled(false). OAuth
-    // scope remains drive.file — per-file access granted at click time.
-    // FIX: Use LIST mode instead of GRID (default). With the
-    // drive.file scope, Google's picker can't load thumbnail images
-    // from lh3.googleusercontent.com — Chrome's ORB blocks them
-    // because the response lacks Cross-Origin-Resource-Policy. LIST
-    // mode avoids thumbnails entirely while keeping full functionality.
-    // See: https://issuetracker.google.com/issues/311256289
+    // setIncludeFolders(true)/setSelectFolderEnabled(false).
     const mimes = MIMES_FOR_FILTER[mimeFilter].join(',');
-    const listMode = picker.DocsViewMode.LIST;
+    const gridMode = picker.DocsViewMode.GRID;
 
     const starredView = new picker.DocsView(picker.ViewId.DOCS)
       .setStarred(true)
-      .setOwnedByMe(true)
+      // Don't filter by ownership — starred files can be shared
       .setLabel('Starred')
-      .setMode(listMode)
+      .setMode(gridMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
@@ -155,7 +149,7 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const myDriveView = new picker.DocsView(picker.ViewId.DOCS)
       .setOwnedByMe(true)
       .setLabel('My Drive')
-      .setMode(listMode)
+      .setMode(gridMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
@@ -164,7 +158,7 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const sharedWithMeView = new picker.DocsView(picker.ViewId.DOCS)
       .setOwnedByMe(false)
       .setLabel('Shared with me')
-      .setMode(listMode)
+      .setMode(gridMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
@@ -173,7 +167,7 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const sharedDrivesView = new picker.DocsView(picker.ViewId.DOCS)
       .setEnableDrives(true)
       .setLabel('Shared drives')
-      .setMode(listMode)
+      .setMode(gridMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);

--- a/apps/web/src/components/drive-picker/google-picker-types.ts
+++ b/apps/web/src/components/drive-picker/google-picker-types.ts
@@ -73,10 +73,8 @@ export interface DocsViewBuilder {
   setStarred(starred: boolean): DocsViewBuilder;
   /**
    * Switch the view between grid (thumbnails) and list mode.
-   * With `drive.file` scope, thumbnails are blocked by Chrome's ORB
-   * because the picker can't access lh3.googleusercontent.com without
-   * broader permissions. Use `DocsViewMode.LIST` to avoid grey
-   * thumbnails while keeping full file-selection functionality.
+   * With `drive.readonly` scope, GRID mode works and shows thumbnails.
+   * LIST mode can be used as a fallback if thumbnails cause issues.
    */
   setMode(mode: unknown): DocsViewBuilder;
   /**
@@ -92,9 +90,9 @@ export interface PickerNamespace {
   readonly DocsView: new (viewId?: unknown) => DocsViewBuilder;
   readonly ViewId: { readonly DOCS: unknown };
   readonly DocsViewMode: {
-    /** Grid layout with thumbnail previews. */
+    /** Grid layout with thumbnail previews (requires drive.readonly scope). */
     readonly GRID: unknown;
-    /** List layout — no thumbnails, works with drive.file scope. */
+    /** List layout — no thumbnails, fallback mode. */
     readonly LIST: unknown;
   };
   readonly Action: {


### PR DESCRIPTION
## Summary
- Adds `drive.readonly` scope alongside `drive.file` in the GDrive OAuth consent URL
- Switches the Google Drive picker from LIST mode to GRID mode (thumbnails now load correctly since drive.readonly avoids the ORB cross-origin block)
- Removes `.setOwnedByMe(true)` from the starred view so shared starred files are visible
- Updates test assertions and CLAUDE.md documentation to reflect the new scope pair

## Why
The previous `drive.file`-only scope could not enumerate files or load thumbnails from `lh3.googleusercontent.com` (Chrome ORB blocks cross-origin images without CORP headers). `drive.readonly` grants read-only access to all files, enabling thumbnails, starred file listing, and full file enumeration — without granting write access to any file the user hasn't explicitly opened via the picker.

## Test plan
- [x] `gdrive.controller.spec.ts` — scope assertion updated and passing
- [x] `DrivePicker.test.tsx` — all 16 tests passing
- [x] Full API suite (888 tests) green
- [x] Full web suite (1375 tests) green
- [x] typecheck + lint green
- [ ] Manual: sign in → connect GDrive → open picker → verify thumbnails show in GRID mode
- [ ] Manual: verify starred tab shows ALL starred files (owned + shared)
- [ ] Manual: pick a file → verify conversion works
- [ ] Production: re-verify after deploy

## Note on re-consent
Users who previously connected their GDrive account will need to **disconnect and reconnect** because the OAuth token was issued with the narrower `drive.file` scope only. The new `drive.readonly` scope requires fresh consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)