### PR TITLE
chore(api): add GDrive env vars to .env.example

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -106,6 +106,19 @@ ENVELOPE_RETENTION_YEARS=7
 # split-deploys can turn this off on API-only nodes.
 WORKER_ENABLED=false
 
+# Google Drive integration
+# Set feature.gdriveIntegration=true in feature-flags to activate.
+# All vars below are required when the feature flag is on.
+# GDRIVE_OAUTH_CLIENT_ID=<from Google Cloud Console OAuth 2.0 credentials>
+# GDRIVE_OAUTH_CLIENT_SECRET=<paired secret — NEVER commit>
+# GDRIVE_OAUTH_REDIRECT_URI=http://localhost:3000/integrations/gdrive/oauth/callback
+# GDRIVE_PICKER_DEVELOPER_KEY=<API key with Picker API enabled>
+# GDRIVE_PICKER_APP_ID=<Google Cloud project number (numeric)>
+# GDRIVE_TOKEN_KMS_KEY_ARN=<AWS KMS CMK ARN for token encryption — optional for local dev>
+# GDRIVE_TOKEN_KMS_REGION=us-east-1
+# GDRIVE_GOTENBERG_URL=http://localhost:3100
+# GDRIVE_CONVERSION_MAX_BYTES=26214400
+
 # Caddy (only read by docker-compose for ACME cert issuance)
 CADDY_DOMAIN=api.seald.example.com
 # Web SPA domain. Caddy serves `/opt/seald/apps/web/dist/` at this host


### PR DESCRIPTION
## Summary
- Documents all Google Drive integration environment variables in `.env.example` for local development setup

## Test plan
- [x] No code changes, only documentation in .env.example

🤖 Generated with [Claude Code](https://claude.com/claude-code)