### PR TITLE
fix(api): reject localhost in APP_PUBLIC_URL/CORS_ORIGIN for production

### DIFF
--- a/apps/api/src/config/env.schema.spec.ts
+++ b/apps/api/src/config/env.schema.spec.ts
@@ -90,11 +90,34 @@ describe('env.schema — Phase 3 envelopes extensions', () => {
     expect(env.EMAIL_FROM_NAME).toBe('Seald');
   });
 
+  it('rejects APP_PUBLIC_URL containing localhost in production', () => {
+    expect(() =>
+      parseEnv({
+        ...minimalTest,
+        NODE_ENV: 'production',
+        APP_PUBLIC_URL: 'http://localhost:5173',
+      }),
+    ).toThrow(/APP_PUBLIC_URL.*must not contain localhost/);
+  });
+
+  it('rejects CORS_ORIGIN containing localhost in production', () => {
+    expect(() =>
+      parseEnv({
+        ...minimalTest,
+        NODE_ENV: 'production',
+        APP_PUBLIC_URL: 'https://seald.app',
+        CORS_ORIGIN: 'http://localhost:5173',
+      }),
+    ).toThrow(/CORS_ORIGIN.*must not contain localhost/);
+  });
+
   it('requires signer session + cron + metrics secrets in production', () => {
     expect(() =>
       parseEnv({
         ...minimalTest,
         NODE_ENV: 'production',
+        APP_PUBLIC_URL: 'https://seald.app',
+        CORS_ORIGIN: 'https://seald.app',
       }),
     ).toThrow(/SIGNER_SESSION_SECRET/);
   });
@@ -104,6 +127,8 @@ describe('env.schema — Phase 3 envelopes extensions', () => {
       parseEnv({
         ...minimalTest,
         NODE_ENV: 'production',
+        APP_PUBLIC_URL: 'https://seald.app',
+        CORS_ORIGIN: 'https://seald.app',
         SIGNER_SESSION_SECRET: '0'.repeat(64),
         CRON_SECRET: '1'.repeat(64),
         METRICS_SECRET: '2'.repeat(64),

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -156,6 +156,25 @@ export const envSchema = z
     GDRIVE_CONVERSION_MAX_BYTES: z.coerce.number().int().positive().default(26_214_400),
   })
   .superRefine((env, ctx) => {
+    if (env.NODE_ENV === 'production') {
+      if (/localhost|127\.0\.0\.1/.test(env.APP_PUBLIC_URL)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['APP_PUBLIC_URL'],
+          message:
+            'APP_PUBLIC_URL must not contain localhost in production — set it to the public web origin (e.g. https://seald.nromomentum.com)',
+        });
+      }
+      if (/localhost|127\.0\.0\.1/.test(env.CORS_ORIGIN)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['CORS_ORIGIN'],
+          message:
+            'CORS_ORIGIN must not contain localhost in production — set it to the public web origin (e.g. https://seald.nromomentum.com)',
+        });
+      }
+    }
+
     if (env.NODE_ENV !== 'test') {
       for (const key of ['SIGNER_SESSION_SECRET', 'CRON_SECRET', 'METRICS_SECRET'] as const) {
         const value = env[key];


### PR DESCRIPTION
## Summary
- Adds a `superRefine` guard in `apps/api/src/config/env.schema.ts` that rejects `APP_PUBLIC_URL` and `CORS_ORIGIN` values containing `localhost` or `127.0.0.1` when `NODE_ENV=production`
- The API container will now fail fast at startup instead of silently generating audit trail PDFs with `localhost:5173/verify/...` links
- Adds 2 unit tests covering the new validation

## Manual step required on production
After merging, SSH into the EC2 host and add to `/opt/seald/apps/api/.env`:
```
APP_PUBLIC_URL=https://seald.nromomentum.com
CORS_ORIGIN=https://seald.nromomentum.com
```
Then restart: `sudo docker compose up -d --build`

(CORS_ORIGIN may already be set — verify. APP_PUBLIC_URL is the one confirmed missing.)

## Test plan
- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r lint` passes
- [x] `pnpm --filter api test` — 890 tests pass (including 2 new)
- [ ] After deploy: verify audit trail PDF shows `https://seald.nromomentum.com/verify/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)