### PR TITLE
fix(copy): correct mailto links, terminology, and broken references

### DIFF
--- a/apps/api/src/email/templates/withdrawn_after_sign/body.html
+++ b/apps/api/src/email/templates/withdrawn_after_sign/body.html
@@ -53,7 +53,7 @@
       <h1>Heads up — <em>{{envelope_title}}</em> was withdrawn after you signed.</h1>
       <p>
         <a
-          href="mailto:{{sender_name}}"
+          href="mailto:{{sender_email}}"
           style="
             display: inline-block;
             color: inherit;

--- a/apps/api/src/email/templates/withdrawn_to_signer/body.html
+++ b/apps/api/src/email/templates/withdrawn_to_signer/body.html
@@ -79,7 +79,7 @@
           Any signing link from a previous Seald email for this envelope is no longer active. If you
           expected to sign this and believe this is an error, please contact
           <a
-            href="mailto:{{sender_name}}"
+            href="mailto:{{sender_email}}"
             style="
               display: inline-block;
               color: inherit;
@@ -175,7 +175,7 @@
       <p class="muted">
         If you expect a new version,
         <a
-          href="mailto:{{sender_name}}"
+          href="mailto:{{sender_email}}"
           style="
             display: inline-block;
             color: inherit;

--- a/apps/api/src/sealing/audit-pdf.tsx
+++ b/apps/api/src/sealing/audit-pdf.tsx
@@ -1614,9 +1614,12 @@ function TermsGrid({ terms }: { terms: ReadonlyArray<TermDef> }): React.ReactEle
 
 function ReferenceLinks(): React.ReactElement {
   const links = [
-    { label: 'Seald signature user guide', url: 'seald.nromomentum.com/help/guides' },
-    { label: 'Seald terms and conditions', url: 'seald.nromomentum.com/help/terms' },
-    { label: 'Seald signature privacy notice', url: 'seald.nromomentum.com/help/privacy' },
+    { label: 'Seald terms of service', url: 'seald.nromomentum.com/legal/terms' },
+    { label: 'Seald privacy policy', url: 'seald.nromomentum.com/legal/privacy' },
+    {
+      label: 'Seald ESIGN consumer disclosure',
+      url: 'seald.nromomentum.com/legal/esign-disclosure',
+    },
   ];
   return (
     <View style={styles.refsCard}>

--- a/apps/landing/src/pages/index.astro
+++ b/apps/landing/src/pages/index.astro
@@ -361,7 +361,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
                 </span>
               </li>
             </ul>
-            <a href="#" class="btn btn-secondary btn-lg">See a sample audit <span class="btn-arrow">→</span></a>
+            <a href="/verify" class="btn btn-secondary btn-lg">Verify a document <span class="btn-arrow">→</span></a>
           </div>
 
           <div class="audit-paper reveal">
@@ -398,7 +398,7 @@ import BaseLayout from '@/layouts/BaseLayout.astro';
         <p>Start with a free account during the beta. No credit card required.</p>
         <div class="hero-cta">
           <a href="/signup" class="btn btn-primary btn-lg">Start free <span class="btn-arrow">→</span></a>
-          <a href="#" class="btn btn-secondary btn-lg">Talk to sales</a>
+          <a href="/contact" class="btn btn-secondary btn-lg">Talk to us</a>
         </div>
       </div>
       <div class="cta-line" id="ctaLine">

--- a/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
+++ b/apps/web/src/pages/SigningDonePage/SigningDonePage.tsx
@@ -323,7 +323,7 @@ export function SigningDonePage() {
           )}
           {isSealing ? (
             <DownloadHint>
-              We&apos;re finalising the seal. This usually takes a few seconds.
+              We&apos;re finalizing the seal. This usually takes a few seconds.
             </DownloadHint>
           ) : null}
           {verify.isError && !sealedUrl ? (

--- a/apps/web/src/pages/VerifyPage/VerifyPage.test.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.test.tsx
@@ -439,7 +439,7 @@ describe('VerifyPage', () => {
   // explicitly handle (only 'sender'/'signer'/'system' are valid today,
   // but the union may grow), the function returns the literal "Signer".
   // Covering the fallback protects against silent label drift.
-  it('labels a system event with no signer_id as "Sealed system" in the timeline', async () => {
+  it('labels a system event with no signer_id as "Seald system" in the timeline', async () => {
     const payload: VerifyResponse = {
       ...SIGNED_PAYLOAD,
       events: [
@@ -456,7 +456,7 @@ describe('VerifyPage', () => {
     const Wrapper = wrap('/verify/u82ZmvdxwG3CU');
     render(<VerifyPage />, { wrapper: Wrapper });
     await waitFor(() => {
-      expect(screen.getByText(/sealed system/i)).toBeInTheDocument();
+      expect(screen.getByText(/seald system/i)).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/VerifyPage/VerifyPage.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.tsx
@@ -154,9 +154,9 @@ const EVENT_LABEL: Record<VerifyEvent['event_type'], string> = {
   sent: 'Envelope sent',
   viewed: 'Document viewed',
   tc_accepted: 'Terms accepted',
-  esign_disclosure_acknowledged: 'E-sign disclosure acknowledged',
+  esign_disclosure_acknowledged: 'ESIGN disclosure acknowledged',
   intent_to_sign_confirmed: 'Intent to sign confirmed',
-  consent_withdrawn: 'E-sign consent withdrawn',
+  consent_withdrawn: 'ESIGN consent withdrawn',
   field_filled: 'Field filled',
   signed: 'Signature captured',
   all_signed: 'All signers complete',
@@ -337,7 +337,7 @@ function actorLabel(ev: VerifyEvent, signers: ReadonlyArray<VerifySigner>): stri
     if (s) return s.name;
   }
   if (ev.actor_kind === 'sender') return 'Sender';
-  if (ev.actor_kind === 'system') return 'Sealed system';
+  if (ev.actor_kind === 'system') return 'Seald system';
   return 'Signer';
 }
 


### PR DESCRIPTION
## Summary

- **Email templates**: Fixed `mailto:{{sender_name}}` → `mailto:{{sender_email}}` in `withdrawn_to_signer` and `withdrawn_after_sign` templates (3 occurrences) — links were pointing to names instead of email addresses
- **VerifyPage**: Normalized "E-sign" → "ESIGN" in event labels to match the audit PDF and the ESIGN Act's proper name; fixed "Sealed system" → "Seald system" actor label (confused past-tense verb with product name)
- **Audit PDF**: Updated reference URLs from non-existent `/help/*` paths to the real landing page routes (`/legal/terms`, `/legal/privacy`, `/legal/esign-disclosure`)
- **Landing page**: Replaced placeholder `#` hrefs with real destinations (`/verify`, `/contact`)
- **SigningDonePage**: Fixed British "finalising" → American "finalizing" for consistent US English

## Test plan

- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r lint` passes
- [x] `pnpm --filter web test` — 1377 tests pass (including updated VerifyPage test)
- [x] `pnpm --filter api test` — 888 tests pass
- [ ] Visually confirm email templates render correctly in preview
- [ ] Verify landing page CTA links route to correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)