### PR TITLE
fix(gdrive): revert OAuth scope to drive.file only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,10 +129,11 @@ When either picker var is unset,
 renders a friendly "Drive picker not configured on this server"
 notice.
 
-OAuth scopes are `drive.file` (per-file write access for files
-opened/created by our app) + `drive.readonly` (read-only access to all
-files — enables thumbnails, starred listing, full file enumeration in
-picker). Do not add the broad `drive` scope (full read+write).
+OAuth scope is hard-coded to `https://www.googleapis.com/auth/drive.file`
+(per-file consent only). Do not broaden — picker selections grant per-file
+access at the moment of click via Google's drive.file scope. Do NOT add
+`drive.readonly` (RESTRICTED scope requiring paid CASA audit: $4,500-$15,000+,
+4-12 week timeline, annual renewal) or the broad `drive` scope.
 
 When the feature flag `feature.gdriveIntegration` is off, all routes
 404 and the env vars are unread; the same image runs dark in dev and

--- a/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.spec.ts
@@ -178,19 +178,17 @@ describe('GDriveController', () => {
     (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
   });
 
-  it('GET /oauth/url returns a Google consent URL with drive.file + drive.readonly scopes (NOT broad drive)', async () => {
+  it('GET /oauth/url returns a Google consent URL with drive.file scope only (no restricted scopes)', async () => {
     const { ctrl } = makeController();
     const out = await ctrl.consentUrl(USER_1);
     expect(out.url).toContain('accounts.google.com/o/oauth2/v2/auth');
     expect(out.url).toContain('drive.file');
-    expect(out.url).toContain('drive.readonly');
-    // Crucially, the scope parameter must NOT contain the broad `drive`
-    // scope (which would grant full read+write). Extract just the scope
-    // value and verify it only has drive.file and drive.readonly.
+    // Must NOT contain drive.readonly (RESTRICTED scope requiring paid CASA
+    // audit) or the broad `drive` scope (full read+write).
     const scopeParam = decodeURIComponent(new URL(out.url).searchParams.get('scope') ?? '');
     const scopes = scopeParam.split(' ');
     expect(scopes).toContain('https://www.googleapis.com/auth/drive.file');
-    expect(scopes).toContain('https://www.googleapis.com/auth/drive.readonly');
+    expect(scopes).not.toContain('https://www.googleapis.com/auth/drive.readonly');
     expect(scopes).not.toContain('https://www.googleapis.com/auth/drive');
     expect(out.url).toContain('code_challenge_method=S256');
     expect(out.url).toContain('access_type=offline');

--- a/apps/api/src/integrations/gdrive/oauth-pkce.ts
+++ b/apps/api/src/integrations/gdrive/oauth-pkce.ts
@@ -61,13 +61,13 @@ function base64url(b: Buffer): string {
 /**
  * Build the Google OAuth consent URL.
  *
- * Scopes:
- * - `drive.file` — per-file write access for files opened/created by our app
- *   (needed for conversion upload). Per-file consent granted at picker click.
- * - `drive.readonly` — read-only access to all files. Enables thumbnails in
- *   GRID mode, starred file listing, and full file enumeration in the picker.
+ * Scope: `drive.file` only — per-file access for files opened/created by our
+ * app. Per-file consent is granted at picker click time. This is a
+ * non-sensitive scope requiring only free brand verification (2-3 days).
  *
- * We do NOT request the broad `drive` scope (full read+write to all files).
+ * We do NOT request `drive.readonly` (RESTRICTED scope requiring paid CASA
+ * audit: $4,500-$15,000+, 4-12 week timeline, annual renewal) or the broad
+ * `drive` scope (full read+write to all files).
  */
 export function buildConsentUrl(args: {
   clientId: string;
@@ -75,10 +75,7 @@ export function buildConsentUrl(args: {
   state: string;
   codeChallenge: string;
 }): string {
-  const scope = [
-    'https://www.googleapis.com/auth/drive.file',
-    'https://www.googleapis.com/auth/drive.readonly',
-  ].join(' ');
+  const scope = 'https://www.googleapis.com/auth/drive.file';
   const params = new URLSearchParams({
     client_id: args.clientId,
     redirect_uri: args.redirectUri,

--- a/apps/web/src/components/drive-picker/DrivePicker.test.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.test.tsx
@@ -266,65 +266,33 @@ describe('DrivePicker — happy path', () => {
     renderPicker({ mimeFilter: 'pdf' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    // One application/pdf entry per DocsView (4 views: Starred, My
-    // Drive, Shared with me, Shared drives).
-    expect(mimeCalls).toEqual([
-      'application/pdf',
-      'application/pdf',
-      'application/pdf',
-      'application/pdf',
-    ]);
+    // One application/pdf entry per DocsView (3 views: My Drive,
+    // Shared with me, Shared drives).
+    expect(mimeCalls).toEqual(['application/pdf', 'application/pdf', 'application/pdf']);
   });
 
   /*
-   * 2026-05-04 — adds a Starred tab in front of the three views that
-   * shipped in PR #149 (My Drive / Shared with me / Shared drives).
-   * Putting Starred first matches the canonical Google import-file UX
-   * (Sheets/Slides put Recent first; we don't have a Recent surface
-   * yet, so Starred leads). Each view is differentiated by
-   * ownership / shared-drives / starred flags so the picker labels
-   * every tab distinctly.
+   * Starred tab removed: with drive.file scope the token can't query
+   * starred metadata so it would always show empty. Three views remain:
+   * My Drive, Shared with me, Shared drives.
    */
-  it('configures four views in order: Starred, My Drive, Shared with me, Shared drives', async () => {
+  it('configures three views in order: My Drive, Shared with me, Shared drives', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(4);
-    expect(pickerSpy.addView).toHaveBeenCalledTimes(4);
-    expect(pickerSpy.docsViews).toHaveLength(4);
-    const [starred, myDrive, sharedWithMe, sharedDrives] = pickerSpy.docsViews;
-    // Starred — setStarred(true), no enable-drives.
-    expect(starred?.setStarredCalls).toEqual([true]);
-    expect(starred?.setEnableDrivesCalls).toEqual([]);
-    // My Drive — owned-by-me=true, no setStarred call.
+    expect(pickerSpy.docsViewCtor).toHaveBeenCalledTimes(3);
+    expect(pickerSpy.addView).toHaveBeenCalledTimes(3);
+    expect(pickerSpy.docsViews).toHaveLength(3);
+    const [myDrive, sharedWithMe, sharedDrives] = pickerSpy.docsViews;
+    // My Drive — owned-by-me=true.
     expect(myDrive?.setOwnedByMeCalls).toEqual([true]);
     expect(myDrive?.setEnableDrivesCalls).toEqual([]);
-    expect(myDrive?.setStarredCalls).toEqual([]);
     // Shared with me — owned-by-me=false.
     expect(sharedWithMe?.setOwnedByMeCalls).toEqual([false]);
     expect(sharedWithMe?.setEnableDrivesCalls).toEqual([]);
     // Shared drives — enable-drives=true (no ownership filter).
     expect(sharedDrives?.setEnableDrivesCalls).toEqual([true]);
     expect(sharedDrives?.setOwnedByMeCalls).toEqual([]);
-  });
-
-  it('Starred view applies the same MIME filter as the other tabs', async () => {
-    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
-    renderPicker({ mimeFilter: 'all' });
-    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    const expectedMimes =
-      'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
-    const [starred] = pickerSpy.docsViews;
-    expect(starred?.setMimeTypesCalls).toEqual([expectedMimes]);
-  });
-
-  it('Starred view enables folder navigation but disables folder-as-result', async () => {
-    fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
-    renderPicker({ mimeFilter: 'all' });
-    await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
-    const [starred] = pickerSpy.docsViews;
-    expect(starred?.setIncludeFoldersCalls).toEqual([true]);
-    expect(starred?.setSelectFolderEnabledCalls).toEqual([false]);
   });
 
   it('enables SUPPORT_DRIVES feature on the picker builder', async () => {
@@ -335,14 +303,14 @@ describe('DrivePicker — happy path', () => {
     expect(pickerSpy.enableFeatureCalls).toContain('sdr');
   });
 
-  it('all four views apply the comma-joined MIME-type filter for the requested mimeFilter', async () => {
+  it('all three views apply the comma-joined MIME-type filter for the requested mimeFilter', async () => {
     fetchMock.mockResolvedValue({ accessToken: 'a', developerKey: 'b', appId: 'c' });
     renderPicker({ mimeFilter: 'all' });
     await waitFor(() => expect(pickerSpy.setVisible).toHaveBeenCalled());
     const expectedMimes =
       'application/pdf,application/vnd.google-apps.document,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
     const mimeCalls = pickerSpy.setMimeTypes.mock.calls.map((c: unknown[]) => c[0]);
-    expect(mimeCalls).toEqual([expectedMimes, expectedMimes, expectedMimes, expectedMimes]);
+    expect(mimeCalls).toEqual([expectedMimes, expectedMimes, expectedMimes]);
     // And per-view: each DocsView called setMimeTypes exactly once
     // with the same comma-joined filter.
     for (const view of pickerSpy.docsViews) {

--- a/apps/web/src/components/drive-picker/DrivePicker.tsx
+++ b/apps/web/src/components/drive-picker/DrivePicker.tsx
@@ -123,33 +123,24 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
       // Google requires the builder-level feature flag too.
       .enableFeature(picker.Feature.SUPPORT_DRIVES);
 
-    // Four DocsViews with explicit labels to avoid duplicate tab names.
-    // Now using GRID mode since the `drive.readonly` scope allows
-    // Google's picker to load thumbnail images from
-    // lh3.googleusercontent.com without ORB issues. Tab order:
-    //   1. Starred        → setStarred(true), NO ownership filter
-    //   2. My Drive       → setOwnedByMe(true)
-    //   3. Shared with me → setOwnedByMe(false)
-    //   4. Shared drives  → setEnableDrives(true)
-    // All four apply the same MIME-type filter and keep
+    // Three DocsViews with explicit labels to avoid duplicate tab names.
+    // Using LIST mode since we only have the `drive.file` scope — thumbnails
+    // require `drive.readonly` which is a RESTRICTED scope needing a paid CASA
+    // audit. Tab order:
+    //   1. My Drive       → setOwnedByMe(true)
+    //   2. Shared with me → setOwnedByMe(false)
+    //   3. Shared drives  → setEnableDrives(true)
+    // Starred view is removed: with drive.file scope the token can't query
+    // starred metadata so it would always show empty.
+    // All three apply the same MIME-type filter and keep
     // setIncludeFolders(true)/setSelectFolderEnabled(false).
     const mimes = MIMES_FOR_FILTER[mimeFilter].join(',');
-    const gridMode = picker.DocsViewMode.GRID;
-
-    const starredView = new picker.DocsView(picker.ViewId.DOCS)
-      .setStarred(true)
-      // Don't filter by ownership — starred files can be shared
-      .setLabel('Starred')
-      .setMode(gridMode)
-      .setMimeTypes(mimes)
-      .setIncludeFolders(true)
-      .setSelectFolderEnabled(false);
-    builder.addView(starredView);
+    const listMode = picker.DocsViewMode.LIST;
 
     const myDriveView = new picker.DocsView(picker.ViewId.DOCS)
       .setOwnedByMe(true)
       .setLabel('My Drive')
-      .setMode(gridMode)
+      .setMode(listMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
@@ -158,7 +149,7 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const sharedWithMeView = new picker.DocsView(picker.ViewId.DOCS)
       .setOwnedByMe(false)
       .setLabel('Shared with me')
-      .setMode(gridMode)
+      .setMode(listMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);
@@ -167,7 +158,7 @@ export function DrivePicker(props: DrivePickerProps): JSX.Element | null {
     const sharedDrivesView = new picker.DocsView(picker.ViewId.DOCS)
       .setEnableDrives(true)
       .setLabel('Shared drives')
-      .setMode(gridMode)
+      .setMode(listMode)
       .setMimeTypes(mimes)
       .setIncludeFolders(true)
       .setSelectFolderEnabled(false);

--- a/apps/web/src/components/drive-picker/google-picker-types.ts
+++ b/apps/web/src/components/drive-picker/google-picker-types.ts
@@ -73,8 +73,8 @@ export interface DocsViewBuilder {
   setStarred(starred: boolean): DocsViewBuilder;
   /**
    * Switch the view between grid (thumbnails) and list mode.
-   * With `drive.readonly` scope, GRID mode works and shows thumbnails.
-   * LIST mode can be used as a fallback if thumbnails cause issues.
+   * With `drive.file` scope only, use LIST mode — GRID thumbnails require
+   * `drive.readonly` which is a RESTRICTED scope needing a paid CASA audit.
    */
   setMode(mode: unknown): DocsViewBuilder;
   /**
@@ -90,9 +90,9 @@ export interface PickerNamespace {
   readonly DocsView: new (viewId?: unknown) => DocsViewBuilder;
   readonly ViewId: { readonly DOCS: unknown };
   readonly DocsViewMode: {
-    /** Grid layout with thumbnail previews (requires drive.readonly scope). */
+    /** Grid layout with thumbnail previews (requires drive.readonly — RESTRICTED scope). */
     readonly GRID: unknown;
-    /** List layout — no thumbnails, fallback mode. */
+    /** List layout — works with drive.file scope only. */
     readonly LIST: unknown;
   };
   readonly Action: {


### PR DESCRIPTION
## Summary
- Remove `drive.readonly` from Google OAuth scope — it's a RESTRICTED scope requiring a paid CASA audit ($4,500-$15,000+, 4-12 week timeline, annual renewal)
- Keep only `drive.file` (non-sensitive, free brand verification in 2-3 days)
- Switch picker from GRID to LIST mode (thumbnails require drive.readonly)
- Remove Starred tab (can't query starred metadata with drive.file scope)
- Keep My Drive, Shared with me, Shared drives (3 tabs with .setLabel() fix)

## Test plan
- [x] `pnpm -r typecheck` passes
- [x] `pnpm -r lint` passes
- [x] `pnpm --filter web test` passes (183 suites, 1380 tests)
- [x] `pnpm --filter api test` passes (73 suites, 890 tests)
- [ ] Verify on prod after deploy: Drive picker opens with 3 tabs in list mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)