### PR TITLE
fix(api): enable noFallthroughCasesInSwitch in tsconfig

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -14,7 +14,7 @@
     "incremental": true,
     "tsBuildInfoFile": "./dist/.tsbuildinfo",
     "strictNullChecks": true,
-    "noFallthroughCasesInSwitch": false,
+    "noFallthroughCasesInSwitch": true,
     "target": "ES2022",
     "lib": ["ES2022"],
     "jsx": "react"


### PR DESCRIPTION
## Summary
- Enables `noFallthroughCasesInSwitch: true` in `apps/api/tsconfig.json`, aligning with TS-1.1 (strict mode best practices) and the base tsconfig which already sets this flag.
- The API tsconfig was the only one explicitly disabling it. All existing switch/case code uses grouped cases (not actual fallthrough), so zero code changes were needed.

## TypeScript Strict Review Findings

| Rule | Severity | Status | Notes |
|------|----------|--------|-------|
| TS-1.1 strict: true | MUST-FIX | PASS | All tsconfigs have `strict: true` |
| TS-1.1 noFallthroughCasesInSwitch | MUST-FIX | **FIXED** | API had it disabled |
| TS-1.2 noUncheckedIndexedAccess | MUST-FIX | PASS | Set in base + web |
| TS-1.3 exactOptionalPropertyTypes | SHOULD-FIX | PASS | Set in base + web |
| TS-1.1 noPropertyAccessFromIndexSignature | SHOULD-FIX | DEFERRED | Would require 50+ changes to index-signature accesses (node-forge, Supabase metadata) |
| TS-9.x no-any | MUST-FIX | PASS | Zero `any` in production code; 4 instances in test files with eslint-disable (legitimate mocking) |
| TS-9.4 no Function/Object | MUST-FIX | PASS | No usage found |
| TS-2.x discriminated unions | MUST-FIX | PASS | No violations found |
| TS-4.x satisfies/as const | MUST-FIX | N/A | No obvious missed opportunities |

## Test plan
- [x] `pnpm --filter shared build` passes
- [x] `pnpm -r typecheck` passes (all 4 projects)
- [x] `pnpm -r lint` passes
- [x] `pnpm --filter web test` — 182 suites, 1377 tests pass
- [x] `pnpm --filter api test` — 73 suites, 890 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)