### PR TITLE
refactor(web): hierarchical envelope query-key factory

### DIFF
--- a/apps/web/src/features/envelopes/index.ts
+++ b/apps/web/src/features/envelopes/index.ts
@@ -1,4 +1,5 @@
 export {
+  envelopeKeys,
   ENVELOPES_KEY,
   ENVELOPE_KEY,
   ENVELOPE_EVENTS_KEY,

--- a/apps/web/src/features/envelopes/useEnvelopes.ts
+++ b/apps/web/src/features/envelopes/useEnvelopes.ts
@@ -25,10 +25,27 @@ import {
   uploadEnvelopeFile,
 } from './envelopesApi';
 
-export const ENVELOPES_KEY = ['envelopes'] as const;
-export const ENVELOPE_KEY = (id: string): readonly [string, string] => ['envelope', id] as const;
-export const ENVELOPE_EVENTS_KEY = (id: string): readonly [string, string, string] =>
-  ['envelope', id, 'events'] as const;
+/**
+ * Hierarchical query-key factory for envelope queries (RQ-1.1, RQ-1.4).
+ * All keys share the `['envelopes']` root so a single
+ * `invalidateQueries({ queryKey: envelopeKeys.all })` sweeps the entire
+ * family — lists, details, and events alike.
+ */
+export const envelopeKeys = {
+  all: ['envelopes'] as const,
+  lists: () => [...envelopeKeys.all, 'list'] as const,
+  list: (params: ListEnvelopesParams) => [...envelopeKeys.lists(), params] as const,
+  details: () => [...envelopeKeys.all, 'detail'] as const,
+  detail: (id: string) => [...envelopeKeys.details(), id] as const,
+  events: (id: string) => [...envelopeKeys.all, 'detail', id, 'events'] as const,
+} as const;
+
+/** @deprecated Use `envelopeKeys.all` — kept for backward compat with tests. */
+export const ENVELOPES_KEY = envelopeKeys.all;
+/** @deprecated Use `envelopeKeys.detail(id)` — kept for backward compat. */
+export const ENVELOPE_KEY = (id: string) => envelopeKeys.detail(id);
+/** @deprecated Use `envelopeKeys.events(id)` — kept for backward compat. */
+export const ENVELOPE_EVENTS_KEY = (id: string) => envelopeKeys.events(id);
 
 /**
  * Lists the signed-in user's envelopes. Pass `enabled: false` for guests
@@ -36,7 +53,7 @@ export const ENVELOPE_EVENTS_KEY = (id: string): readonly [string, string, strin
  */
 export function useEnvelopesQuery(enabled: boolean, params: ListEnvelopesParams = {}) {
   return useQuery<EnvelopeListResponse>({
-    queryKey: [...ENVELOPES_KEY, params],
+    queryKey: envelopeKeys.list(params),
     queryFn: ({ signal }) => listEnvelopes(params, signal),
     enabled,
   });
@@ -44,7 +61,7 @@ export function useEnvelopesQuery(enabled: boolean, params: ListEnvelopesParams 
 
 export function useEnvelopeQuery(id: string, enabled: boolean) {
   return useQuery<Envelope>({
-    queryKey: ENVELOPE_KEY(id),
+    queryKey: envelopeKeys.detail(id),
     queryFn: ({ signal }) => getEnvelope(id, signal),
     enabled: enabled && Boolean(id),
   });
@@ -57,7 +74,7 @@ export function useEnvelopeQuery(id: string, enabled: boolean) {
  */
 export function useEnvelopeEventsQuery(id: string, enabled: boolean) {
   return useQuery<EnvelopeEventsResponse>({
-    queryKey: ENVELOPE_EVENTS_KEY(id),
+    queryKey: envelopeKeys.events(id),
     queryFn: ({ signal }) => listEnvelopeEvents(id, signal),
     enabled: enabled && Boolean(id),
   });
@@ -68,8 +85,8 @@ export function useCreateEnvelopeMutation() {
   return useMutation<Envelope, Error, { readonly title: string }>({
     mutationFn: (input) => createEnvelope(input),
     onSuccess: (envelope) => {
-      qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
-      qc.setQueryData(ENVELOPE_KEY(envelope.id), envelope);
+      qc.invalidateQueries({ queryKey: envelopeKeys.lists() });
+      qc.setQueryData(envelopeKeys.detail(envelope.id), envelope);
     },
   });
 }
@@ -84,7 +101,7 @@ export function useUploadEnvelopeFileMutation() {
   return useMutation<{ readonly pages: number; readonly sha256: string }, Error, UploadFileArgs>({
     mutationFn: ({ envelopeId, file }) => uploadEnvelopeFile(envelopeId, file),
     onSuccess: (_result, args) => {
-      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(args.envelopeId) });
+      qc.invalidateQueries({ queryKey: envelopeKeys.detail(args.envelopeId) });
     },
   });
 }
@@ -98,7 +115,7 @@ export function useAddEnvelopeSignerMutation() {
   return useMutation<EnvelopeSigner, Error, AddSignerArgs>({
     mutationFn: ({ envelopeId, ...input }) => addEnvelopeSigner(envelopeId, input),
     onSuccess: (_signer, args) => {
-      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(args.envelopeId) });
+      qc.invalidateQueries({ queryKey: envelopeKeys.detail(args.envelopeId) });
     },
   });
 }
@@ -113,7 +130,7 @@ export function useRemoveEnvelopeSignerMutation() {
   return useMutation<void, Error, RemoveSignerArgs>({
     mutationFn: ({ envelopeId, signerId }) => removeEnvelopeSigner(envelopeId, signerId),
     onSuccess: (_void, args) => {
-      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(args.envelopeId) });
+      qc.invalidateQueries({ queryKey: envelopeKeys.detail(args.envelopeId) });
     },
   });
 }
@@ -128,7 +145,7 @@ export function usePlaceEnvelopeFieldsMutation() {
   return useMutation<ReadonlyArray<EnvelopeField>, Error, PlaceFieldsArgs>({
     mutationFn: ({ envelopeId, fields }) => placeEnvelopeFields(envelopeId, fields),
     onSuccess: (_fields, args) => {
-      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(args.envelopeId) });
+      qc.invalidateQueries({ queryKey: envelopeKeys.detail(args.envelopeId) });
     },
   });
 }
@@ -138,8 +155,8 @@ export function useSendEnvelopeMutation() {
   return useMutation<Envelope, Error, string>({
     mutationFn: (id) => sendEnvelope(id),
     onSuccess: (envelope) => {
-      qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
-      qc.setQueryData(ENVELOPE_KEY(envelope.id), envelope);
+      qc.invalidateQueries({ queryKey: envelopeKeys.lists() });
+      qc.setQueryData(envelopeKeys.detail(envelope.id), envelope);
     },
   });
 }
@@ -149,7 +166,7 @@ export function useDeleteEnvelopeMutation() {
   return useMutation<void, Error, string>({
     mutationFn: (id) => deleteEnvelope(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
+      qc.invalidateQueries({ queryKey: envelopeKeys.lists() });
     },
   });
 }
@@ -165,13 +182,16 @@ export function useCancelEnvelopeMutation() {
   return useMutation<CancelEnvelopeResponse, Error, string>({
     mutationFn: (id) => cancelEnvelope(id),
     onSuccess: (_res, id) => {
-      // Invalidate both the list and the detail query so the UI re-pulls
-      // the canonical `canceled` status. Don't optimistically setQueryData
-      // — the API also recomputes signers.access_token_hash side-effects
-      // and we want the next read to round-trip.
-      qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
-      qc.invalidateQueries({ queryKey: ENVELOPE_KEY(id) });
-      qc.invalidateQueries({ queryKey: ENVELOPE_EVENTS_KEY(id) });
+      // Invalidate the entire envelope family (lists + this detail + events)
+      // so the UI re-pulls the canonical `canceled` status. Don't
+      // optimistically setQueryData — the API also recomputes
+      // signers.access_token_hash side-effects and we want the next read
+      // to round-trip. With hierarchical keys a single `envelopeKeys.all`
+      // invalidation would catch everything, but we scope narrowly to
+      // avoid unnecessary refetches on unrelated detail queries.
+      qc.invalidateQueries({ queryKey: envelopeKeys.lists() });
+      qc.invalidateQueries({ queryKey: envelopeKeys.detail(id) });
+      qc.invalidateQueries({ queryKey: envelopeKeys.events(id) });
     },
   });
 }

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
@@ -30,9 +30,7 @@ import type { DownloadMenuItem } from '@/components/DownloadMenu';
 import { ExitConfirmDialog } from '@/components/ExitConfirmDialog';
 import { Skeleton } from '@/components/Skeleton';
 import {
-  ENVELOPES_KEY,
-  ENVELOPE_EVENTS_KEY,
-  ENVELOPE_KEY,
+  envelopeKeys,
   getEnvelopeDownloadUrl,
   remindEnvelopeSigner,
   useEnvelopeEventsQuery,
@@ -490,8 +488,8 @@ export function EnvelopeDetailPage() {
     const sent = results.filter((r) => r.status === 'fulfilled').length;
     const failed = results.length - sent;
     setRemindInFlight(false);
-    qc.invalidateQueries({ queryKey: ENVELOPE_EVENTS_KEY(envelope.id) });
-    qc.invalidateQueries({ queryKey: ENVELOPE_KEY(envelope.id) });
+    qc.invalidateQueries({ queryKey: envelopeKeys.events(envelope.id) });
+    qc.invalidateQueries({ queryKey: envelopeKeys.detail(envelope.id) });
     if (failed === 0) {
       setToast({
         kind: 'success',
@@ -523,7 +521,7 @@ export function EnvelopeDetailPage() {
     if (envelope.status === 'draft') {
       deleteEnvelope.mutate(envelope.id, {
         onSuccess: () => {
-          qc.invalidateQueries({ queryKey: ENVELOPES_KEY });
+          qc.invalidateQueries({ queryKey: envelopeKeys.lists() });
           navigate('/documents');
         },
         onError: (err) => {


### PR DESCRIPTION
## Summary

- Introduced `envelopeKeys` factory object following TanStack Query best practices (RQ-1.1, RQ-1.4)
- All envelope query keys now share a common `['envelopes']` root enabling granular prefix-based invalidation
- Migrated all mutations and the EnvelopeDetailPage to use the new factory
- Deprecated old `ENVELOPES_KEY` / `ENVELOPE_KEY` / `ENVELOPE_EVENTS_KEY` constants (kept as re-exports for test backward compat)

## Rules addressed

| File | Rule | Fix |
|------|------|-----|
| `features/envelopes/useEnvelopes.ts` | RQ-1.1 (query key factories) | Introduced `envelopeKeys` factory object |
| `features/envelopes/useEnvelopes.ts` | RQ-1.4 (hierarchical keys) | All keys now nest under `['envelopes']` root |
| `pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx` | RQ-1.1 | Migrated inline key refs to factory |

## Review findings (no-fix, documented)

| File | Rule | Reason skipped |
|------|------|----------------|
| `pages/TemplatesListPage/TemplatesListPage.tsx` | RQ-9.2 / 4.4 (useEffect fetch) | Deliberate pub/sub store pattern, not React Query; changing would alter behavior |
| `components/PageThumbRail/PageThumbRail.tsx` | 4.3 (index key) | Static decorative skeletons, never reordered |
| `components/PasswordStrengthMeter/PasswordStrengthMeter.tsx` | 4.3 (index key) | Fixed-count bars, never reordered |
| `routes/UploadRoute.tsx` | RQ-3.1 (mutation error handling) | `connectDrive.mutate()` opens a popup; failure is self-evident |

## Test plan

- [x] `pnpm --filter shared build` passes
- [x] `pnpm --filter web typecheck` passes
- [x] `pnpm --filter web lint` passes
- [x] `pnpm --filter web test` — all 1377 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)