### PR TITLE
fix(api): add GET /oauth/start for mobile full-page OAuth redirect

### DIFF
--- a/apps/api/src/integrations/gdrive/__tests__/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/__tests__/gdrive.controller.spec.ts
@@ -311,6 +311,102 @@ describe('GDriveController', () => {
     expect(meta).toBe(true);
   });
 
+  // BUG 1 fix: GET /oauth/start — full-page redirect for mobile browsers
+  // that block popups (iOS Safari). Same consent URL generation as
+  // /oauth/url but issues a 302 redirect instead of returning JSON.
+  describe('GET /oauth/start (mobile full-page OAuth redirect)', () => {
+    it('redirects to Google consent URL with drive.file scope', async () => {
+      const { ctrl } = makeController();
+      const res = fakeRes();
+      await ctrl.oauthStart(USER_1, '/m/send/drive', res);
+      expect(res.redirectedTo).toContain('accounts.google.com/o/oauth2/v2/auth');
+      expect(res.redirectedTo).toContain('drive.file');
+      expect(res.redirectedTo).toContain('code_challenge_method=S256');
+    });
+
+    it('stores returnPath in state so callback redirects to it', async () => {
+      const { ctrl, state } = makeController();
+      const res = fakeRes();
+      await ctrl.oauthStart(USER_1, '/m/send/drive', res);
+      // Extract state param from the redirect URL
+      const url = new URL(res.redirectedTo!);
+      const stateParam = url.searchParams.get('state');
+      expect(stateParam).toBeTruthy();
+      const entry = state.consume(stateParam!);
+      expect(entry).not.toBeNull();
+      expect(entry!.returnPath).toBe('/m/send/drive');
+      expect(entry!.userId).toBe('user-1');
+    });
+
+    it('sanitizes return param: rejects absolute URLs (open-redirect prevention)', async () => {
+      const { ctrl, state } = makeController();
+      const res = fakeRes();
+      await ctrl.oauthStart(USER_1, 'https://evil.com/steal', res);
+      // Should still redirect to Google (the route works) but returnPath
+      // should be undefined in the state (rejected by sanitization).
+      expect(res.redirectedTo).toContain('accounts.google.com');
+      const url = new URL(res.redirectedTo!);
+      const stateParam = url.searchParams.get('state');
+      const entry = state.consume(stateParam!);
+      expect(entry!.returnPath).toBeUndefined();
+    });
+
+    it('sanitizes return param: rejects protocol-relative URLs (//evil.com)', async () => {
+      const { ctrl, state } = makeController();
+      const res = fakeRes();
+      await ctrl.oauthStart(USER_1, '//evil.com/steal', res);
+      const url = new URL(res.redirectedTo!);
+      const stateParam = url.searchParams.get('state');
+      const entry = state.consume(stateParam!);
+      expect(entry!.returnPath).toBeUndefined();
+    });
+
+    it('works without return param (returnPath is undefined in state)', async () => {
+      const { ctrl, state } = makeController();
+      const res = fakeRes();
+      await ctrl.oauthStart(USER_1, undefined, res);
+      expect(res.redirectedTo).toContain('accounts.google.com');
+      const url = new URL(res.redirectedTo!);
+      const stateParam = url.searchParams.get('state');
+      const entry = state.consume(stateParam!);
+      expect(entry!.returnPath).toBeUndefined();
+    });
+
+    it('throws 503 when OAuth client id is unset', async () => {
+      const repo = new FakeRepo();
+      const kms = new GDriveKmsService(
+        new StubKmsClient(),
+        'arn:aws:kms:us-east-1:000000000000:key/k',
+      );
+      const google = new StubGoogleClient();
+      const svc = new GDriveService(repo, kms, google);
+      const stateStore = new OAuthStateStore();
+      const limiter = new GDriveRateLimiter({ capacity: 30, windowMs: 60_000 });
+      const proxy: FilesProxy = async () => ({ files: [] });
+      const ctrl = new GDriveController(svc, stateStore, { ...CFG, clientId: '' }, limiter, proxy);
+      await expect(ctrl.oauthStart(USER_1, '/m/send', fakeRes())).rejects.toMatchObject({
+        status: HttpStatus.SERVICE_UNAVAILABLE,
+      });
+    });
+  });
+
+  // BUG 1 fix: callback redirects to returnPath when present in state
+  it('GET /oauth/callback redirects to returnPath (mobile flow) instead of popup-bridge when state carries returnPath', async () => {
+    const { ctrl, state } = makeController();
+    const started = state.start('user-1', { returnPath: '/m/send/drive' });
+    const res = fakeRes();
+    await ctrl.oauthCallback('the-code', started.state, undefined, res);
+    expect(res.redirectedTo).toBe('http://localhost:5173/m/send/drive?connected=1');
+  });
+
+  it('GET /oauth/callback falls back to popup-bridge when state has no returnPath', async () => {
+    const { ctrl, state } = makeController();
+    const started = state.start('user-1');
+    const res = fakeRes();
+    await ctrl.oauthCallback('the-code', started.state, undefined, res);
+    expect(res.redirectedTo).toBe('http://localhost:5173/oauth/gdrive/callback?connected=1');
+  });
+
   it('feature flag off → every route 404s', async () => {
     (FEATURE_FLAGS as Record<string, boolean>).gdriveIntegration = false;
     const { ctrl } = makeController();
@@ -323,6 +419,9 @@ describe('GDriveController', () => {
       ctrl.listFiles(USER_1, '00000000-0000-0000-0000-000000000aaa', 'all'),
     ).rejects.toBeInstanceOf(NotFoundException);
     await expect(ctrl.oauthCallback('c', 's', undefined, fakeRes())).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    await expect(ctrl.oauthStart(USER_1, '/m/send', fakeRes())).rejects.toBeInstanceOf(
       NotFoundException,
     );
   });

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -146,6 +146,42 @@ export class GDriveController {
     };
   }
 
+  /**
+   * Full-page OAuth redirect for mobile browsers (iOS Safari blocks
+   * popups). Accepts `?return=<path>` — the SPA path to redirect the
+   * user to after the OAuth callback completes. Generates the consent
+   * URL server-side and issues a 302 redirect so the browser navigates
+   * straight to Google without a round-trip JSON fetch.
+   *
+   * The `return` path is stored in the OAuth state entry so the callback
+   * handler can redirect back to the correct SPA route once the flow
+   * completes (instead of the default popup-bridge page).
+   */
+  @Get('oauth/start')
+  async oauthStart(
+    @CurrentUser() user: AuthUser,
+    @Query('return') returnPath: string | undefined,
+    @Res({ passthrough: true }) res: { redirect(url: string): void },
+  ): Promise<void> {
+    this.requireFlag();
+    this.requireOAuthConfigured();
+    // Validate the return path: must be a relative SPA path (starts with /)
+    // to prevent open-redirect attacks. Strip anything that looks like a
+    // protocol or double-slash prefix.
+    const opts: { returnPath?: string } = {};
+    if (returnPath && /^\/[^/]/.test(returnPath)) {
+      opts.returnPath = returnPath;
+    }
+    const { state, codeChallenge } = this.stateStore.start(user.id, opts);
+    const url = buildConsentUrl({
+      clientId: this.config.clientId,
+      redirectUri: this.config.redirectUri,
+      state,
+      codeChallenge,
+    });
+    res.redirect(url);
+  }
+
   @Get('oauth/callback')
   @Public()
   // The callback is reached via Google's redirect — the user's browser, not
@@ -182,7 +218,18 @@ export class GDriveController {
     // never closed. The new bridge page handles popup mode (postMessage
     // back to the opener + window.close()) and same-tab fallback
     // (redirects back to /settings/integrations?connected=1).
-    res.redirect(`${this.config.appPublicUrl}/oauth/gdrive/callback?connected=1`);
+    //
+    // Mobile full-page flow: when the state carries a `returnPath` (set
+    // by the `oauth/start` endpoint), redirect directly to that SPA path
+    // with `?connected=1` appended. This avoids the popup-bridge page
+    // entirely — mobile Safari never opened a popup, so there's nothing
+    // to close.
+    if (entry.returnPath) {
+      const sep = entry.returnPath.includes('?') ? '&' : '?';
+      res.redirect(`${this.config.appPublicUrl}${entry.returnPath}${sep}connected=1`);
+    } else {
+      res.redirect(`${this.config.appPublicUrl}/oauth/gdrive/callback?connected=1`);
+    }
   }
 
   @Get('accounts')

--- a/apps/api/src/integrations/gdrive/oauth-pkce.ts
+++ b/apps/api/src/integrations/gdrive/oauth-pkce.ts
@@ -16,6 +16,8 @@ export interface OAuthStateEntry {
   codeVerifier: string;
   userId: string;
   expiresAt: number;
+  /** SPA path to redirect to after the OAuth callback completes (mobile full-page flow). */
+  returnPath?: string;
 }
 
 export class OAuthStateStore {
@@ -25,16 +27,23 @@ export class OAuthStateStore {
     private readonly clock: () => number = Date.now,
   ) {}
 
-  start(userId: string): { state: string; codeVerifier: string; codeChallenge: string } {
+  start(
+    userId: string,
+    opts?: { returnPath?: string },
+  ): { state: string; codeVerifier: string; codeChallenge: string } {
     const codeVerifier = base64url(randomBytes(64));
     const codeChallenge = base64url(createHash('sha256').update(codeVerifier).digest());
     const state = base64url(randomBytes(32));
     this.gc();
-    this.store.set(state, {
+    const entry: OAuthStateEntry = {
       codeVerifier,
       userId,
       expiresAt: this.clock() + this.ttlMs,
-    });
+    };
+    if (opts?.returnPath !== undefined) {
+      entry.returnPath = opts.returnPath;
+    }
+    this.store.set(state, entry);
     return { state, codeVerifier, codeChallenge };
   }
 


### PR DESCRIPTION
## Summary
- **BUG 1**: Mobile code navigates to `GET /integrations/gdrive/oauth/start?return=/m/send/drive` for full-page OAuth (iOS Safari blocks popups), but this route did not exist on the API (404 error).
- Adds `GET /oauth/start` endpoint that generates the OAuth consent URL and issues a 302 redirect (server-side), accepting `?return=<path>` to redirect the user back to the correct SPA route after OAuth completes.
- Updates `oauth/callback` to redirect to the `returnPath` stored in OAuth state (mobile flow) instead of always redirecting to the popup-bridge page (desktop flow).
- Open-redirect prevention: `?return=` param is validated to be a relative path starting with `/` (rejects absolute URLs and protocol-relative `//` prefixes).

## Changes
- `apps/api/src/integrations/gdrive/oauth-pkce.ts` — added optional `returnPath` field to `OAuthStateEntry`; `start()` accepts `opts.returnPath`
- `apps/api/src/integrations/gdrive/gdrive.controller.ts` — new `GET oauth/start` endpoint; updated `oauthCallback` to conditionally redirect to `returnPath`
- `apps/api/src/integrations/gdrive/__tests__/gdrive.controller.spec.ts` — 7 new tests covering the new endpoint, return-path sanitization, callback redirect behavior, and feature-flag gating

## Test plan
- [x] `pnpm --filter shared build` — green
- [x] `pnpm -r typecheck` — green
- [x] `pnpm -r lint` — green
- [x] `pnpm --filter api test` — 898 passed
- [x] `pnpm --filter web test` — 1384 passed
- [ ] Deploy and verify on mobile: navigate to `/m/send`, tap Connect Google Drive, complete OAuth, verify redirect lands on `/m/send/drive?connected=1`

## Note on BUG 2 (Picker 403)
The Picker code in `DrivePicker.tsx` already correctly calls `.setOrigin(window.location.origin)`. The 403 is most likely caused by the `GDRIVE_PICKER_DEVELOPER_KEY` API key not having `seald.nromomentum.com` in its HTTP referrer restrictions in Google Cloud Console, or the Picker API not being enabled in the project. This is a Google Cloud Console configuration issue, not a code bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)