### PR TITLE
fix(web,api): mobile OAuth uses /oauth/url with auth header

### DIFF
--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -138,7 +138,7 @@ export class GDriveController {
   ): Promise<{ url: string }> {
     this.requireFlag();
     this.requireOAuthConfigured();
-    // Sanitise returnPath: must start with '/' (relative) to prevent open-redirect.
+    // Sanitize returnPath: must start with '/' (relative) to prevent open-redirect.
     const safePath =
       returnPath && returnPath.startsWith('/') && !returnPath.startsWith('//')
         ? returnPath

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -132,10 +132,21 @@ export class GDriveController {
   }
 
   @Get('oauth/url')
-  async consentUrl(@CurrentUser() user: AuthUser): Promise<{ url: string }> {
+  async consentUrl(
+    @CurrentUser() user: AuthUser,
+    @Query('return') returnPath?: string,
+  ): Promise<{ url: string }> {
     this.requireFlag();
     this.requireOAuthConfigured();
-    const { state, codeChallenge } = this.stateStore.start(user.id);
+    // Sanitise returnPath: must start with '/' (relative) to prevent open-redirect.
+    const safePath =
+      returnPath && returnPath.startsWith('/') && !returnPath.startsWith('//')
+        ? returnPath
+        : undefined;
+    const { state, codeChallenge } = this.stateStore.start(
+      user.id,
+      safePath ? { returnPath: safePath } : undefined,
+    );
     return {
       url: buildConsentUrl({
         clientId: this.config.clientId,

--- a/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
+++ b/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
@@ -6,6 +6,7 @@ import { DrivePicker } from '@/components/drive-picker';
 import type { DriveFile } from '@/components/drive-picker';
 import { useDriveImport } from '@/features/gdriveImport';
 import { useGDriveAccounts } from '@/routes/settings/integrations/useGDriveAccounts';
+import { apiClient } from '@/lib/api/apiClient';
 import {
   Shell,
   Scroller,
@@ -94,7 +95,8 @@ const FIELD_TYPE_TO_API: Readonly<Record<MobileFieldType, FieldPlacement['kind']
 // silently swallows `window.open()` outside a synchronous user gesture
 // chain, so the mobile flow uses a top-level navigation. Pulled at
 // module-init from Vite's env (rule 3.2: no `any`).
-const GDRIVE_API_BASE = import.meta.env.VITE_API_BASE_URL as string | undefined;
+// Removed GDRIVE_API_BASE — mobile OAuth now uses apiClient.get('/oauth/url')
+// which carries the JWT auth header automatically.
 
 export function MobileSendPage() {
   const navigate = useNavigate();
@@ -159,10 +161,19 @@ export function MobileSendPage() {
   const driveAccountId = driveAccounts[0]?.id ?? null;
   const [drivePickerOpen, setDrivePickerOpen] = useState(false);
 
-  const beginDriveOAuth = useCallback((): void => {
-    if (!GDRIVE_API_BASE) return;
-    const ret = encodeURIComponent('/m/send/drive');
-    window.location.href = `${GDRIVE_API_BASE}/integrations/gdrive/oauth/start?return=${ret}`;
+  const beginDriveOAuth = useCallback(async (): Promise<void> => {
+    try {
+      const ret = encodeURIComponent('/m/send/drive');
+      const res = await apiClient.get<{ url: string }>(
+        `/integrations/gdrive/oauth/url?return=${ret}`,
+      );
+      // Full-page redirect (not popup) — iOS Safari blocks window.open.
+      // The return path is stored in OAuth state so the callback redirects
+      // to /m/send/drive → /m/send?gdrive_connected=1.
+      window.location.href = res.data.url;
+    } catch {
+      // Silently fail — the user can retry by tapping the tile again.
+    }
   }, []);
 
   const handlePickFromDrive = useCallback((): void => {
@@ -173,10 +184,17 @@ export function MobileSendPage() {
     beginDriveOAuth();
   }, [driveAccountId, beginDriveOAuth]);
 
-  const reauthorizeDrive = useCallback((): void => {
-    if (!GDRIVE_API_BASE) return;
-    const ret = encodeURIComponent('/m/send/drive');
-    window.location.href = `${GDRIVE_API_BASE}/integrations/gdrive/oauth/start?return=${ret}&prompt=consent`;
+  const reauthorizeDrive = useCallback(async (): Promise<void> => {
+    try {
+      // Re-consent forces the user to re-approve scopes (e.g. after scope change).
+      const res = await apiClient.get<{ url: string }>('/integrations/gdrive/oauth/url');
+      // Append prompt=consent to force re-approval.
+      const url = new URL(res.data.url);
+      url.searchParams.set('prompt', 'consent');
+      window.location.href = url.toString();
+    } catch {
+      // Silently fail.
+    }
   }, []);
 
   // Auto-open the picker when the OAuth callback returned us to

--- a/apps/web/src/pages/MobileSendPage/screens/MWIntegrations.tsx
+++ b/apps/web/src/pages/MobileSendPage/screens/MWIntegrations.tsx
@@ -8,6 +8,7 @@ import {
   useGDriveAccounts,
   useDisconnectGDrive,
 } from '@/routes/settings/integrations/useGDriveAccounts';
+import { apiClient } from '@/lib/api/apiClient';
 import { DisconnectModal } from '@/routes/settings/integrations/DisconnectModal';
 
 const Page = styled.div`
@@ -181,9 +182,16 @@ export function MWIntegrations(): ReactNode {
     navigate('/m/send');
   }, [navigate]);
 
-  const handleConnect = useCallback((): void => {
-    const apiBase = import.meta.env.VITE_API_BASE_URL as string;
-    window.location.href = `${apiBase}/integrations/gdrive/oauth/start?return=/m/send/drive`;
+  const handleConnect = useCallback(async (): Promise<void> => {
+    try {
+      const ret = encodeURIComponent('/m/send/drive');
+      const res = await apiClient.get<{ url: string }>(
+        `/integrations/gdrive/oauth/url?return=${ret}`,
+      );
+      window.location.href = res.data.url;
+    } catch {
+      // Silently fail — user can retry.
+    }
   }, []);
 
   const handleDisconnectClick = useCallback((id: string, email: string): void => {


### PR DESCRIPTION
## Summary
- Mobile GDrive OAuth was broken — navigated to `/oauth/start` as a raw browser redirect without JWT auth header → 404
- Fix: use `apiClient.get('/oauth/url?return=/m/send/drive')` which carries the JWT automatically, then redirect to the consent URL
- Added optional `?return` param to existing `/oauth/url` endpoint so the callback knows where to redirect mobile users
- Open-redirect protection: return path must be relative (starts with `/`, not `//`)

## Root cause
`window.location.href = API_URL/oauth/start` is a browser navigation — no auth headers sent. The endpoint requires JWT auth. Desktop uses popup + `window.open()` which also doesn't carry auth, but desktop calls `/oauth/url` via fetch first (with auth header) then opens the returned URL.

## Test plan
- [x] Typecheck clean
- [x] Lint clean
- [x] 1384 web tests pass
- [x] 898 API tests pass
- [ ] Manual: on mobile, tap GDrive tile → should redirect to Google consent → return to /m/send

🤖 Generated with [Claude Code](https://claude.com/claude-code)