### PR TITLE
fix(api): require APP_PUBLIC_URL + CORS_ORIGIN at boot

### DIFF
--- a/apps/api/src/config/__tests__/env.schema.spec.ts
+++ b/apps/api/src/config/__tests__/env.schema.spec.ts
@@ -7,6 +7,7 @@ describe('parseEnv', () => {
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_JWT_AUDIENCE: 'authenticated',
     CORS_ORIGIN: 'http://localhost:5173',
+    APP_PUBLIC_URL: 'http://localhost:5173',
     DATABASE_URL: 'postgres://u:p@host:5432/db',
   };
 
@@ -44,6 +45,7 @@ describe('env.schema — DATABASE_URL', () => {
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_JWT_AUDIENCE: 'authenticated',
     CORS_ORIGIN: 'http://localhost:5173',
+    APP_PUBLIC_URL: 'http://localhost:5173',
   };
 
   it('rejects missing DATABASE_URL', () => {
@@ -73,6 +75,7 @@ describe('env.schema — Phase 3 envelopes extensions', () => {
     SUPABASE_URL: 'https://example.supabase.co',
     SUPABASE_JWT_AUDIENCE: 'authenticated',
     CORS_ORIGIN: 'http://localhost:5173',
+    APP_PUBLIC_URL: 'http://localhost:5173',
     DATABASE_URL: 'postgres://u:p@host:5432/db?sslmode=disable',
   };
 
@@ -88,6 +91,21 @@ describe('env.schema — Phase 3 envelopes extensions', () => {
     expect(env.PDF_SIGNING_TSA_URL).toBe('https://freetsa.org/tsr');
     expect(env.EMAIL_FROM_ADDRESS).toBe('onboarding@resend.dev');
     expect(env.EMAIL_FROM_NAME).toBe('Seald');
+  });
+
+  // Regression for the 2026-05-07 prod incident where stale containers
+  // started without APP_PUBLIC_URL/CORS_ORIGIN set, fell back to the
+  // localhost default, and baked `http://localhost:5173` into audit-PDF
+  // QR codes + completed-email verify links. The defaults are gone;
+  // every container now fails fast on missing config.
+  it('throws when APP_PUBLIC_URL is missing', () => {
+    const { APP_PUBLIC_URL: _omit, ...rest } = minimalTest;
+    expect(() => parseEnv(rest)).toThrow(/APP_PUBLIC_URL/);
+  });
+
+  it('throws when CORS_ORIGIN is missing', () => {
+    const { CORS_ORIGIN: _omit, ...rest } = minimalTest;
+    expect(() => parseEnv(rest)).toThrow(/CORS_ORIGIN/);
   });
 
   it('rejects APP_PUBLIC_URL containing localhost in production', () => {

--- a/apps/api/src/config/env.schema.ts
+++ b/apps/api/src/config/env.schema.ts
@@ -9,8 +9,17 @@ export const envSchema = z
     SUPABASE_JWT_AUDIENCE: z.string().min(1).default('authenticated'),
     SUPABASE_SERVICE_ROLE_KEY: z.string().min(1).optional(),
 
-    CORS_ORIGIN: z.string().min(1).default('http://localhost:5173'),
-    APP_PUBLIC_URL: z.string().url().default('http://localhost:5173'),
+    // Required at boot. The localhost defaults that previously lived
+    // here silently masked a misconfigured prod container — when one
+    // started without these set (e.g. a stale image kept alive by
+    // `docker compose up -d --build`), it fell back to localhost and
+    // baked `http://localhost:5173` into audit-trail QR codes, verify
+    // links, and signing-invitation emails. Requiring them upfront
+    // makes every container fail-fast on missing config regardless of
+    // NODE_ENV. The production-only localhost guard below catches the
+    // remaining case where these vars are explicitly set to localhost.
+    CORS_ORIGIN: z.string().min(1),
+    APP_PUBLIC_URL: z.string().url(),
 
     DATABASE_URL: z
       .string()


### PR DESCRIPTION
## Summary

Removes the `http://localhost:5173` defaults from `APP_PUBLIC_URL` and `CORS_ORIGIN` in `apps/api/src/config/env.schema.ts`. Both vars are now required at boot, so any container that starts without them fails fast in `parseEnv` regardless of `NODE_ENV`.

### Why

Today (2026-05-07 13:33 UTC) an envelope sealed in production baked `localhost:5173/verify/...` into its audit-trail QR code. Querying `outbound_emails.payload` showed a mixed pattern across the morning:

| Time | Kind | verify_url |
|---|---|---|
| 13:30:41 | completed | **localhost:5173** |
| 13:32:34 | invite | seald.nromomentum.com ✓ |
| 13:33:43 | completed | **localhost:5173** |
| 13:40:04 | invite | seald.nromomentum.com ✓ |
| 13:41:11 | completed | seald.nromomentum.com ✓ |

Same envelope, two different URLs minutes apart — only fits a multi-container symptom. Stale containers kept alive by `docker compose up -d --build` were running with old (pre-2026-05-05) env, where `APP_PUBLIC_URL` wasn't set at all, and the schema's `.default('http://localhost:5173')` silently filled it in. Today's operator-workflow `--force-recreate` killed the stale instances; this PR closes the silent-fallback path so the same situation cannot recur.

The existing production-only localhost-rejection guard (PR #193) remains — it now catches the orthogonal case where these vars are *explicitly* set to localhost in production.

### Changes

- `apps/api/src/config/env.schema.ts`: drop `.default(...)` from both vars; add comment explaining the rationale.
- `apps/api/src/config/__tests__/env.schema.spec.ts`: test fixtures (`valid`, `base`, `minimalTest`) now set `APP_PUBLIC_URL=http://localhost:5173` explicitly. New regressions assert `parseEnv` throws when either var is missing.

`apps/api/.env.example` already pins both vars, so local-dev workflows that copy the example to `.env` are unaffected.

## Test plan

- [x] `pnpm --filter api typecheck` — green
- [x] `pnpm --filter api lint` — green
- [x] `pnpm --filter api exec jest` — 900/900 pass (incl. 2 new regressions)
- [ ] CI green
- [ ] After merge + deploy, seal a fresh test envelope and confirm `verify_url` in `outbound_emails.payload` uses `https://seald.nromomentum.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)