### PR TITLE
feat(web): remember signer's typed name and initials per email

### DIFF
--- a/apps/web/src/components/SignatureCapture/SignatureCapture.test.tsx
+++ b/apps/web/src/components/SignatureCapture/SignatureCapture.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { axe } from 'vitest-axe';
 import { renderWithTheme } from '../../test/renderWithTheme';
 import { SignatureCapture, computeScaledFontSize, CAPTURE_WIDTH } from './SignatureCapture';
+import * as typedPreferences from './typedPreferences';
 
 beforeEach(() => {
   // jsdom does not implement HTMLCanvasElement.prototype.toBlob; stub it.
@@ -120,6 +121,125 @@ describe('SignatureCapture', () => {
       />,
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  describe('typed preference persistence', () => {
+    beforeEach(() => {
+      window.localStorage.clear();
+    });
+
+    it('prefills the typed input with the saved signature for the email', () => {
+      window.localStorage.setItem(
+        'seald:signing:typed:v1',
+        JSON.stringify({ 'maya@example.com': { signature: 'Maya Custom Name' } }),
+      );
+      const { getByLabelText } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="signature"
+          defaultName="Maya Raskin"
+          email="maya@example.com"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      const input = getByLabelText(/your full name/i) as HTMLInputElement;
+      expect(input.value).toBe('Maya Custom Name');
+    });
+
+    it('prefills the typed input with the saved initials for the email', () => {
+      window.localStorage.setItem(
+        'seald:signing:typed:v1',
+        JSON.stringify({ 'maya@example.com': { initials: 'mlr' } }),
+      );
+      const { getByRole } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="initials"
+          defaultName="Maya Raskin"
+          email="maya@example.com"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      const input = getByRole('textbox', { name: 'Initials' }) as HTMLInputElement;
+      expect(input.value).toBe('mlr');
+    });
+
+    it('falls back to the default-derived value when nothing is saved', () => {
+      const { getByRole } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="initials"
+          defaultName="Maya Raskin"
+          email="maya@example.com"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      const input = getByRole('textbox', { name: 'Initials' }) as HTMLInputElement;
+      expect(input.value).toBe('MR');
+    });
+
+    it('persists the typed value to localStorage on Apply (typed tab)', async () => {
+      const onApply = vi.fn();
+      const { getByLabelText, getByRole } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="signature"
+          defaultName="Maya Raskin"
+          email="maya@example.com"
+          onCancel={() => {}}
+          onApply={onApply}
+        />,
+      );
+      const input = getByLabelText(/your full name/i);
+      await userEvent.clear(input);
+      await userEvent.type(input, 'Maya Q. Raskin');
+      await userEvent.click(getByRole('button', { name: /apply/i }));
+      await vi.waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+      const raw = window.localStorage.getItem('seald:signing:typed:v1');
+      expect(raw).not.toBeNull();
+      const parsed = JSON.parse(raw ?? '{}') as Record<string, { signature?: string }>;
+      expect(parsed['maya@example.com']?.signature).toBe('Maya Q. Raskin');
+    });
+
+    it('does NOT call saveTypedPreference when the user switches to the draw tab', async () => {
+      const saveSpy = vi.spyOn(typedPreferences, 'saveTypedPreference');
+      const { getByRole } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="signature"
+          defaultName="Maya Raskin"
+          email="maya@example.com"
+          onCancel={() => {}}
+          onApply={() => {}}
+        />,
+      );
+      await userEvent.click(getByRole('tab', { name: /draw/i }));
+      // Apply is disabled until a stroke is drawn; jsdom can't render canvas
+      // strokes, so the user can't actually Apply via draw here. The contract
+      // we care about is: save is never called from the draw or upload paths.
+      expect(saveSpy).not.toHaveBeenCalled();
+      saveSpy.mockRestore();
+    });
+
+    it('skips persistence entirely when email is empty', async () => {
+      const onApply = vi.fn();
+      const { getByRole } = renderWithTheme(
+        <SignatureCapture
+          open
+          kind="signature"
+          defaultName="Maya Raskin"
+          email=""
+          onCancel={() => {}}
+          onApply={onApply}
+        />,
+      );
+      await userEvent.click(getByRole('button', { name: /apply/i }));
+      await vi.waitFor(() => expect(onApply).toHaveBeenCalledTimes(1));
+      expect(window.localStorage.getItem('seald:signing:typed:v1')).toBeNull();
+    });
   });
 });
 

--- a/apps/web/src/components/SignatureCapture/SignatureCapture.tsx
+++ b/apps/web/src/components/SignatureCapture/SignatureCapture.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../Icon';
 import { SignatureMark } from '../SignatureMark';
 import type {
   SignatureCaptureFormat,
+  SignatureCaptureKind,
   SignatureCaptureProps,
   SignatureCaptureResult,
 } from './SignatureCapture.types';
@@ -28,6 +29,26 @@ import {
   Title,
   UploadArea,
 } from './SignatureCapture.styles';
+import { getTypedPreference, saveTypedPreference } from './typedPreferences';
+
+function deriveInitialsFromName(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((p) => p[0] ?? '')
+    .join('')
+    .slice(0, 3)
+    .toUpperCase();
+}
+
+function computeInitialTyped(args: {
+  readonly kind: SignatureCaptureKind;
+  readonly defaultName: string;
+  readonly email: string;
+}): string {
+  const saved = getTypedPreference({ email: args.email, kind: args.kind });
+  if (saved !== null) return saved;
+  return args.kind === 'initials' ? deriveInitialsFromName(args.defaultName) : args.defaultName;
+}
 
 export const CAPTURE_WIDTH = 600;
 export const CAPTURE_HEIGHT = 200;
@@ -102,18 +123,11 @@ function renderTypedToCanvas(text: string, kind: 'signature' | 'initials'): HTML
  * tab order (Cancel / Apply are the last focusable elements).
  */
 export const SignatureCapture = forwardRef<HTMLDivElement, SignatureCaptureProps>((props, ref) => {
-  const { open, kind, defaultName, onCancel, onApply, ...rest } = props;
+  const { open, kind, defaultName, email = '', onCancel, onApply, ...rest } = props;
 
   const [tab, setTab] = useState<SignatureCaptureFormat>('typed');
   const [typed, setTyped] = useState<string>(() =>
-    kind === 'initials'
-      ? defaultName
-          .split(/\s+/)
-          .map((p) => p[0] ?? '')
-          .join('')
-          .slice(0, 3)
-          .toUpperCase()
-      : defaultName,
+    computeInitialTyped({ kind, defaultName, email }),
   );
   const [strokeCount, setStrokeCount] = useState(0);
   const [uploadFile, setUploadFile] = useState<File | null>(null);
@@ -125,16 +139,7 @@ export const SignatureCapture = forwardRef<HTMLDivElement, SignatureCaptureProps
 
   const reset = useCallback(() => {
     setTab('typed');
-    setTyped(
-      kind === 'initials'
-        ? defaultName
-            .split(/\s+/)
-            .map((p) => p[0] ?? '')
-            .join('')
-            .slice(0, 3)
-            .toUpperCase()
-        : defaultName,
-    );
+    setTyped(computeInitialTyped({ kind, defaultName, email }));
     setStrokeCount(0);
     setUploadFile(null);
     setUploadName('');
@@ -143,7 +148,7 @@ export const SignatureCapture = forwardRef<HTMLDivElement, SignatureCaptureProps
       const ctx = canvas.getContext('2d');
       if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
     }
-  }, [defaultName, kind]);
+  }, [defaultName, email, kind]);
 
   useEffect(() => {
     if (!open) return undefined;
@@ -232,6 +237,7 @@ export const SignatureCapture = forwardRef<HTMLDivElement, SignatureCaptureProps
     if (tab === 'typed') {
       const canvas = renderTypedToCanvas(typed, kind);
       const blob = await canvasToPngBlob(canvas);
+      saveTypedPreference({ email, kind, value: typed });
       const result: SignatureCaptureResult = {
         blob,
         format: 'typed',

--- a/apps/web/src/components/SignatureCapture/SignatureCapture.types.ts
+++ b/apps/web/src/components/SignatureCapture/SignatureCapture.types.ts
@@ -15,6 +15,12 @@ export interface SignatureCaptureProps extends HTMLAttributes<HTMLDivElement> {
   readonly open: boolean;
   readonly kind: SignatureCaptureKind;
   readonly defaultName: string;
+  /**
+   * Signer's email — used to key per-user typed-name/initials preference in
+   * localStorage so the user's customized typed value persists across opens.
+   * Empty string disables persistence (useful in stories/tests).
+   */
+  readonly email?: string;
   readonly onCancel: () => void;
   readonly onApply: (result: SignatureCaptureResult) => void;
 }

--- a/apps/web/src/components/SignatureCapture/typedPreferences.test.ts
+++ b/apps/web/src/components/SignatureCapture/typedPreferences.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { getTypedPreference, saveTypedPreference } from './typedPreferences';
+
+const STORAGE_KEY = 'seald:signing:typed:v1';
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('typedPreferences', () => {
+  it('returns null when nothing is saved', () => {
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBeNull();
+  });
+
+  it('round-trips a signature value', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'Eliran Azulay' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBe('Eliran Azulay');
+  });
+
+  it('keeps signature and initials independent for the same user', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'Eliran Azulay' });
+    saveTypedPreference({ email: 'a@b.com', kind: 'initials', value: 'eaz' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBe('Eliran Azulay');
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'initials' })).toBe('eaz');
+  });
+
+  it('isolates preferences across different emails', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'A B' });
+    saveTypedPreference({ email: 'c@d.com', kind: 'signature', value: 'C D' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBe('A B');
+    expect(getTypedPreference({ email: 'c@d.com', kind: 'signature' })).toBe('C D');
+  });
+
+  it('treats email case-insensitively', () => {
+    saveTypedPreference({ email: 'Eliran@Example.com', kind: 'signature', value: 'EA' });
+    expect(getTypedPreference({ email: 'eliran@example.com', kind: 'signature' })).toBe('EA');
+    expect(getTypedPreference({ email: '  ELIRAN@EXAMPLE.COM ', kind: 'signature' })).toBe('EA');
+  });
+
+  it('is a noop when email is empty', () => {
+    saveTypedPreference({ email: '', kind: 'signature', value: 'X' });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(getTypedPreference({ email: '', kind: 'signature' })).toBeNull();
+  });
+
+  it('clears the per-kind entry when value is empty', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'A B' });
+    saveTypedPreference({ email: 'a@b.com', kind: 'initials', value: 'AB' });
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: '' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBeNull();
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'initials' })).toBe('AB');
+  });
+
+  it('removes the user entry entirely when both kinds are cleared', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'A B' });
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: '' });
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw ?? '{}') as Record<string, unknown>;
+    expect(parsed['a@b.com']).toBeUndefined();
+  });
+
+  it('tolerates corrupt JSON in storage', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not valid json');
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBeNull();
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: 'A B' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBe('A B');
+  });
+
+  it('trims whitespace before saving', () => {
+    saveTypedPreference({ email: 'a@b.com', kind: 'signature', value: '   Eliran   ' });
+    expect(getTypedPreference({ email: 'a@b.com', kind: 'signature' })).toBe('Eliran');
+  });
+});

--- a/apps/web/src/components/SignatureCapture/typedPreferences.ts
+++ b/apps/web/src/components/SignatureCapture/typedPreferences.ts
@@ -1,0 +1,69 @@
+import type { SignatureCaptureKind } from './SignatureCapture.types';
+
+const STORAGE_KEY = 'seald:signing:typed:v1';
+
+type StoredEntry = Partial<Record<SignatureCaptureKind, string>>;
+type StoredMap = Record<string, StoredEntry>;
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function readMap(): StoredMap {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as StoredMap;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function writeMap(map: StoredMap): void {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(map));
+  } catch {
+    // localStorage may be unavailable (private mode, quota, SSR) — silently noop.
+  }
+}
+
+export function getTypedPreference(input: {
+  readonly email: string;
+  readonly kind: SignatureCaptureKind;
+}): string | null {
+  const key = normalizeEmail(input.email);
+  if (!key) return null;
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  const map = readMap();
+  const entry = map[key];
+  const value = entry?.[input.kind];
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function saveTypedPreference(input: {
+  readonly email: string;
+  readonly kind: SignatureCaptureKind;
+  readonly value: string;
+}): void {
+  const key = normalizeEmail(input.email);
+  if (!key) return;
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  const trimmed = input.value.trim();
+  const map = readMap();
+  const existing: StoredEntry = map[key] ?? {};
+  if (trimmed.length === 0) {
+    delete existing[input.kind];
+  } else {
+    existing[input.kind] = trimmed;
+  }
+  if (Object.keys(existing).length === 0) {
+    delete map[key];
+  } else {
+    map[key] = existing;
+  }
+  writeMap(map);
+}

--- a/apps/web/src/pages/SigningFillPage/SigningFillPage.tsx
+++ b/apps/web/src/pages/SigningFillPage/SigningFillPage.tsx
@@ -272,6 +272,7 @@ function Content() {
         open={sigDrawer !== null}
         kind={sigDrawer?.kind ?? 'signature'}
         defaultName={session.signer?.name ?? ''}
+        email={session.signer?.email ?? ''}
         onCancel={closeSigDrawer}
         onApply={(r) => {
           handleSignatureApply(r).catch(() => {


### PR DESCRIPTION
## Summary
- Persist the signer's customized typed name (signature fields) and typed initials (initials fields) to `localStorage`, keyed by lower-cased signer email, so reopening the capture sheet restores their last applied value instead of falling back to `session.signer.name`.
- Saves only when the user clicks **Apply** on the **type** tab — the draw and upload paths never write to storage.
- Storage shape: single key `seald:signing:typed:v1` → `{ [email]: { signature?: string, initials?: string } }`. Tolerates corrupt JSON, missing/empty email (silently no-ops), and quota/SSR failures.

## Changes
- New helper `apps/web/src/components/SignatureCapture/typedPreferences.ts` — `getTypedPreference` / `saveTypedPreference`.
- `SignatureCapture` accepts a new optional `email` prop and uses a single `computeInitialTyped` helper for both initial state and `reset()`. Calls `saveTypedPreference` in `handleApply` only when `tab === 'typed'`.
- `SigningFillPage` plumbs `session.signer.email` to `<SignatureCapture>`.

## Test plan
- [x] `pnpm --filter web typecheck` ✓
- [x] `pnpm --filter web lint` ✓
- [x] `pnpm --filter web test` — 185 files / 1414 tests ✓
- [x] New unit tests: `typedPreferences.test.ts` (round-trip, per-kind isolation, per-email isolation, case-insensitive email key, corrupt-JSON tolerance, empty-email no-op, clear behavior, whitespace trim).
- [x] New component tests: prefill from storage (signature + initials), fallback to default when storage empty, save on Apply (typed), no save when email is empty, no save when user switches to draw tab.
- [ ] Manual: open the signing screen, type a custom name in signature, Apply, close and reopen the field — typed value should match the previously applied value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)