### PR TITLE
fix(web): contain route render errors in AppShell + align nav-active mock

### DIFF
--- a/apps/web/e2e/steps/nav-active.steps.ts
+++ b/apps/web/e2e/steps/nav-active.steps.ts
@@ -18,18 +18,28 @@ Given('the user is signed in as {string}', async ({ seededUser, mockedApi }, ema
     fullName: 'Alice Example',
   });
   // Stub the dashboard + envelope APIs so each route renders without a
-  // live backend.
+  // live backend. Shape matches the `Envelope` contract from
+  // `envelopesApi.ts` — both EnvelopeDetailPage and SentConfirmationPage
+  // read `signers` + `short_code`, so a stale `recipients`-shaped payload
+  // tears the tree down on render (no top-level ErrorBoundary above NavBar).
   mockedApi.on('GET', /\/api\/envelopes(\?|$)/, { json: { items: [] } });
   mockedApi.on('GET', /\/api\/envelopes\/[^/]+$/, {
     json: {
       id: 'abc-123',
+      owner_id: '00000000-0000-4000-8000-000000000a11',
       title: 'Test envelope',
+      short_code: 'ABC-123',
       status: 'sent',
-      createdAt: '2026-04-25T10:00:00Z',
-      updatedAt: '2026-04-25T10:00:00Z',
-      recipients: [],
-      events: [],
-      documents: [],
+      original_pages: 1,
+      expires_at: '2026-05-25T10:00:00Z',
+      tc_version: '1.0',
+      privacy_version: '1.0',
+      sent_at: '2026-04-25T10:00:00Z',
+      completed_at: null,
+      signers: [],
+      fields: [],
+      created_at: '2026-04-25T10:00:00Z',
+      updated_at: '2026-04-25T10:00:00Z',
     },
   });
 });

--- a/apps/web/src/layout/AppShell.error-boundary.test.tsx
+++ b/apps/web/src/layout/AppShell.error-boundary.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { JSX } from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../test/renderWithProviders';
+import { AppShell } from './AppShell';
+
+vi.mock('@/features/account', () => ({
+  useAccountActions: () => ({
+    exportData: vi.fn(),
+    deleteAccount: vi.fn(),
+    isExporting: false,
+    isDeleting: false,
+  }),
+}));
+
+vi.mock('../lib/observability', () => ({
+  reportError: vi.fn(),
+  initSentry: vi.fn(),
+}));
+
+function Boom(): JSX.Element {
+  throw new Error('Kaboom');
+}
+
+function renderShellAt(path: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<AppShell />}>
+          <Route path="/documents" element={<div>doc list</div>} />
+          <Route path="/document/:id/sent" element={<Boom />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// React intentionally logs caught errors to console.error in dev. Silence
+// the noise so the suite output stays clean — same pattern the
+// ErrorBoundary unit tests use.
+let consoleSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+describe('AppShell error boundary (route-crash containment)', () => {
+  it('renders the routed content normally when nothing throws', () => {
+    const { getByText, queryByRole } = renderShellAt('/documents');
+    expect(getByText('doc list')).toBeInTheDocument();
+    expect(queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('keeps the NavBar + legal footer mounted when the routed page throws', () => {
+    const { getByRole } = renderShellAt('/document/abc-123/sent');
+
+    // Boundary surfaces the recoverable fallback inside <Content>.
+    expect(getByRole('alert')).toBeInTheDocument();
+    expect(getByRole('heading', { name: /something went wrong/i })).toBeInTheDocument();
+    expect(getByRole('button', { name: /try again/i })).toBeInTheDocument();
+
+    // NavBar still rendered above the boundary — the user can still click
+    // away to a working route. This is the regression: pre-fix, an
+    // uncaught render error in any route blanked the entire tree.
+    expect(getByRole('navigation')).toBeInTheDocument();
+    expect(getByRole('button', { name: /^Documents$/i })).toBeInTheDocument();
+
+    // Legal footer (issue #39) is below the boundary in the same Shell —
+    // it must also survive a route crash so consent withdrawal stays as
+    // easy as giving consent (EDPB 03/2022 + CCPA §7026(a)(4)).
+    expect(getByRole('contentinfo', { name: /legal and cookie preferences/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 import { isFeatureEnabled } from 'shared';
 import styled from 'styled-components';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import { NavBar } from '../components/NavBar';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
@@ -210,7 +211,13 @@ export function AppShell() {
         isDeleting={account.isDeleting}
       />
       <Content>
-        <Outlet />
+        {/* Keyed by pathname so navigating to a different route remounts
+            the boundary and clears any prior caught error — otherwise a
+            crashed page would persist its fallback after the user navigates
+            away via the NavBar. */}
+        <ErrorBoundary key={location.pathname}>
+          <Outlet />
+        </ErrorBoundary>
       </Content>
       <ShellLegalFooter />
     </Shell>


### PR DESCRIPTION
## Summary

- Fix the failing `nav-active.feature` BDD scenario "Documents tab stays active on the post-send confirmation" by aligning the test mock with the real `Envelope` API contract (`signers` + `short_code`, not the stale `recipients`/`events`/`documents` shape).
- Wrap `<Outlet />` in `AppShell` with `<ErrorBoundary key={location.pathname}>` (rule 4.5) so a render-time exception in any routed page surfaces the recoverable "Something went wrong" panel inside `<Content>` instead of tearing the whole tree down — NavBar + legal footer survive, the user can still navigate away.
- New regression test (`AppShell.error-boundary.test.tsx`) renders a route whose element throws and asserts NavBar (`role="navigation"`, "Documents" tab) and the legal footer remain mounted.

## Why

The post-send scenario was crashing inside `SentConfirmationPage.tsx:86` (`signers.map(...)` on undefined) because the mock returned a stale shape. Without an `ErrorBoundary` above the `Outlet`, the uncaught render error unmounted the whole tree, blanking the page and making the active-nav assertion impossible. The sibling envelope-detail scenario was masked by a render/probe race.

## Test plan

- [x] `pnpm --filter web typecheck` — clean
- [x] `pnpm --filter web lint` — clean
- [x] `pnpm --filter web test` — 1400/1400 passed
- [x] `pnpm --filter web exec playwright test --project=chromium-bdd e2e/.bdd/e2e/features/nav-active.feature.spec.js` — 4/4 passed
- [x] React PR review (rules §1–§4) — no MUST-FIX, no SHOULD-FIX

## Rules cited

- **rule 4.5** — wrap async/routed UI in an error boundary; recoverable fallback inside Content.
- **rule 4.3** — `key={location.pathname}` is a stable string (not an array index).
- **rule 4.6** — regression test queries by accessible role/name (`alert`, `navigation`, `heading`, `button`, `contentinfo`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)