### PR TITLE
ops: run parseEnv in container + dump file mtimes

### DIFF
--- a/.github/workflows/inspect-prod-containers.yml
+++ b/.github/workflows/inspect-prod-containers.yml
@@ -99,10 +99,19 @@ jobs:
                   console.log("APP_PUBLIC_URL pre-load:", process.env.APP_PUBLIC_URL);
                   try { process.loadEnvFile(r); } catch (e) { console.log("loadEnvFile threw:", e.message); }
                   console.log("APP_PUBLIC_URL post-load:", process.env.APP_PUBLIC_URL);
+                  const { parseEnv } = require("/app/apps/api/dist/src/config/env.schema.js");
+                  const parsed = parseEnv(process.env);
+                  console.log("parseEnv APP_PUBLIC_URL:", parsed.APP_PUBLIC_URL);
+                  console.log("parseEnv CORS_ORIGIN:", parsed.CORS_ORIGIN);
+                  console.log("parseEnv NODE_ENV:", parsed.NODE_ENV);
                 } catch (e) {
                   console.log("probe error:", e.message);
                 }
               ' 2>&1 || true
+              echo '--- audit-pdf.js verifyUrl construction ---'
+              sudo docker exec "$CID" grep -n "verify\|publicUrl" /app/apps/api/dist/src/sealing/audit-pdf.js 2>&1 | head -10 || true
+              echo '--- file mtime (image build timestamp signal) ---'
+              sudo docker exec "$CID" stat -c '%y %n' /app/apps/api/dist/src/config/env.schema.js /app/apps/api/dist/src/sealing/audit-pdf.js /app/apps/api/dist/src/sealing/sealing.service.js 2>&1 | head -5 || true
             else
               echo "(api container not running)"
             fi

--- a/.github/workflows/inspect-prod-containers.yml
+++ b/.github/workflows/inspect-prod-containers.yml
@@ -76,3 +76,33 @@ jobs:
             echo
             echo '=== /opt/seald listing ==='
             ls -la /opt/seald | head -20
+
+            echo
+            echo '=== INSIDE seald-api-1 container: filesystem & code probe ==='
+            CID=$(sudo docker compose ps -q api)
+            if [ -n "$CID" ]; then
+              echo '--- ls /app/apps/api/ (looking for stray .env) ---'
+              sudo docker exec "$CID" ls -la /app/apps/api/ 2>&1 | head -30 || true
+              echo '--- /app/apps/api/.env existence check ---'
+              sudo docker exec "$CID" sh -c 'if [ -f /app/apps/api/.env ]; then echo "PRESENT ($(wc -l < /app/apps/api/.env) lines)"; head -3 /app/apps/api/.env | sed "s/=.*/=<redacted>/"; else echo "ABSENT"; fi' 2>&1 || true
+              echo '--- env.schema.js: does it still have the localhost default? ---'
+              sudo docker exec "$CID" grep -n "localhost:5173\|APP_PUBLIC_URL" /app/apps/api/dist/src/config/env.schema.js 2>&1 | head -20 || true
+              echo '--- node process: actual APP_PUBLIC_URL after loadDotenv() ---'
+              sudo docker exec "$CID" node -e 'console.log("printenv-style:", process.env.APP_PUBLIC_URL)' 2>&1 || true
+              echo '--- node process: simulate boot to see what parseEnv resolves ---'
+              sudo docker exec "$CID" node -e '
+                try {
+                  const r = require("path").resolve(process.cwd(), ".env");
+                  console.log("cwd:", process.cwd());
+                  console.log("dotenv path:", r);
+                  console.log("dotenv exists:", require("fs").existsSync(r));
+                  console.log("APP_PUBLIC_URL pre-load:", process.env.APP_PUBLIC_URL);
+                  try { process.loadEnvFile(r); } catch (e) { console.log("loadEnvFile threw:", e.message); }
+                  console.log("APP_PUBLIC_URL post-load:", process.env.APP_PUBLIC_URL);
+                } catch (e) {
+                  console.log("probe error:", e.message);
+                }
+              ' 2>&1 || true
+            else
+              echo "(api container not running)"
+            fi


### PR DESCRIPTION
Compiled env.schema.js in the running image still has the localhost default → the image is pre-PR-#212. This patch runs parseEnv inside the container to see what SealingService actually gets, and dumps file mtimes to date the image.