### PR TITLE
fix(deploy): hard-reset host before build so stale local edits can't freeze prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,10 +86,30 @@ jobs:
             echo "Deploying ref=$REF"
 
             git fetch --all --tags --prune
+
+            # Self-heal: any local edits or untracked files block
+            # `git pull --ff-only`. The previous version of this script
+            # used `git pull --ff-only || true`, which silently ignored
+            # the failure — leaving the host frozen ~70 commits behind
+            # main while every `docker compose up -d --build` rebuilt
+            # the same stale image. Discovered 2026-05-07 chasing a
+            # localhost-in-audit-PDF bug that turned out to be 65+
+            # un-deployed commits.
+            #
+            # Stash anything dirty (preserves it under refs/stash if
+            # an operator is mid-fixup), then hard-reset to origin/$REF
+            # and clean any untracked leftovers. After this, the
+            # working tree is exactly $REF.
+            echo "=== git status before reset ==="
+            git status --porcelain | head -20 || true
+            git stash push --include-untracked -m "auto-stash-pre-deploy-$(date +%Y%m%d-%H%M%S)" 2>&1 | head -3 || true
             git checkout "$REF"
-            git pull --ff-only || true
+            git reset --hard "origin/$REF"
+            git clean -fd
+            echo "deployed SHA: $(git rev-parse HEAD)"
+
             sudo docker compose pull || true
-            sudo docker compose up -d --build
+            sudo docker compose up -d --build --force-recreate api
 
             # Health probe: api:3000 is exposed only on the docker
             # network. Probe via the caddy container so we exercise


### PR DESCRIPTION
## Summary

Replaces the silent `git pull --ff-only || true` in the API deploy script with a deterministic stash + hard-reset + clean. After this PR, the host's `/opt/seald` checkout always exactly matches the requested ref before `docker compose up -d --build`.

## Why

Today's incident — `localhost:5173` URLs in production audit-trail PDFs and completed emails — turned out to be **65+ commits worth of merges that never deployed**, including PR #212 (the strict-env-required hardening). Tracing the deploy log:

```
$ git pull --ff-only
Updating 62e4a73..6bd3321
error: Your local changes to the following files would be overwritten by merge:
   apps/api/src/sealing/audit-pdf.tsx
   apps/api/src/email/templates/withdrawn_after_sign/body.html
   ... (22 tracked files + 4 untracked) ...
Aborting
```

`|| true` swallowed the failure. Every subsequent `docker compose up -d --build` rebuilt the same stale image. Operators couldn't tell the deploy was broken because the workflow exited 0 and `/health` came back OK on the unchanged container.

## Changes

- `git pull --ff-only` → `git stash --include-untracked` + `git reset --hard origin/$REF` + `git clean -fd`. Stash is recoverable (`git stash list` on host).
- Logs `git status --porcelain` (truncated to 20 lines) before the reset, so future ops can see what was on the host straight from the run log.
- Logs the deployed SHA after the reset.
- Adds `--force-recreate api` to the compose `up` so the container always reloads env even when docker thinks the image hash is identical.

## Test plan
- [x] YAML parses (`actionlint`-style, via existing CI workflow lint job)
- [ ] Merge → first deploy reset host + rebuilds with current main
- [ ] Post-deploy: confirm `outbound_emails.payload.verify_url` for a fresh envelope is `https://seald.nromomentum.com/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)