### PR TITLE
fix(deploy): chown whole /opt/seald tree, not just .git

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,13 +71,19 @@ jobs:
             set -euo pipefail
             cd /opt/seald
 
-            # Self-heal: break-glass restores (`prod-restore.yml`) run
-            # `sudo git fetch` and leave some `.git/objects` owned by
-            # root, which makes the next `git fetch` here fail with
-            # "insufficient permission for adding an object". Reclaim
-            # ownership for the SSH user before any git op. Idempotent
-            # — no-op when ownership is already correct.
-            sudo chown -R "$(id -u):$(id -g)" .git
+            # Self-heal: prior break-glass workflows
+            # (`prod-restore.yml`, `set-app-public-url.yml`) write files
+            # under /opt/seald via `sudo` — leaving root-owned objects
+            # in `.git/objects/`, root-owned `.env.bak.<ts>` snapshots
+            # in `apps/api/`, and even root-owned tracked files when
+            # they did sudo edits. Any of those breaks the SSH user's
+            # subsequent `git fetch / stash / reset / clean`.
+            #
+            # Reclaim ownership for the SSH user across the WHOLE
+            # checkout (not just .git) before any git op. Idempotent.
+            # /opt/seald is small enough (~repo size) that the recursive
+            # chown is a no-op-fast path on warm runs.
+            sudo chown -R "$(id -u):$(id -g)" .
 
             # For workflow_run (push to main), inputs.ref is unset →
             # fall through to 'main'. For dispatch, honour the provided


### PR DESCRIPTION
## Summary

Widens the deploy script's pre-pull \`chown\` from \`.git\` to the entire \`/opt/seald\` tree. Required to make the self-healing logic added in #218 actually work — without it, root-owned \`.env.bak.<ts>\` files (created by \`set-app-public-url.yml\`'s \`sudo cp\`) block \`git stash --include-untracked\`, and root-owned tracked files block \`git reset --hard\`.

## Why

First run of the new logic on PR #218's merge failed:

\`\`\`
error: open(\"apps/api/.env.bak.1777832472\"): Permission denied
fatal: Unable to process path apps/api/.env.bak.1777832472
Cannot save the untracked files
...
error: unable to unlink old 'apps/web/.../TemplatePickerDialog.tsx': Permission denied
fatal: Could not reset index file to revision 'origin/main'.
\`\`\`

The host accumulated root-owned files outside \`.git/\` from various \`sudo\` operations across recovery workflows. The existing chown only fixed \`.git\`. After this PR, the chown covers the whole tree, so the stash / reset / clean sequence works.

Idempotent and fast on warm runs (no-op when ownership is already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)