### PR TITLE
fix(web): unique signer colors + stable placement binding when replacing template signers

### DIFF
--- a/apps/api/src/templates/dto/create-template.dto.ts
+++ b/apps/api/src/templates/dto/create-template.dto.ts
@@ -86,6 +86,18 @@ export class TemplateFieldDto {
   @IsInt()
   @Min(0)
   readonly signerIndex?: number;
+
+  /**
+   * Stable per-signer id (matches `TemplateLastSignerDto.id`) of the
+   * signer this field was assigned to at template-save time. New SPA
+   * builds populate this alongside `signerIndex` so the use-template
+   * wizard can rebind by stable id and avoid the mid-list-removal
+   * shift bug. Capped to the same MaxLength as the signer id field.
+   */
+  @IsOptional()
+  @IsString()
+  @MaxLength(64)
+  readonly signerRoleId?: string;
 }
 
 /**

--- a/apps/web/src/features/signers/pickAvailableColor.test.ts
+++ b/apps/web/src/features/signers/pickAvailableColor.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { pickAvailableColor } from './pickAvailableColor';
+
+const PALETTE = ['#A', '#B', '#C', '#D', '#E', '#F'] as const;
+
+describe('pickAvailableColor', () => {
+  it('returns the first palette color when nothing is in use', () => {
+    expect(pickAvailableColor(PALETTE, [])).toBe('#A');
+  });
+
+  it('returns the first unused color when some are in use', () => {
+    expect(pickAvailableColor(PALETTE, ['#A', '#B'])).toBe('#C');
+  });
+
+  it('skips holes — picks the lowest-index unused color, not the next-after-largest', () => {
+    // Mid-list signer was removed: in-use set is {#A, #C}; expect #B,
+    // not #D (which `prev.length % palette.length = 2 = #C` would return).
+    expect(pickAvailableColor(PALETTE, ['#A', '#C'])).toBe('#B');
+  });
+
+  it('compares case-insensitively so #abcdef and #ABCDEF are treated as the same color', () => {
+    expect(pickAvailableColor(PALETTE, ['#a', '#B'])).toBe('#C');
+  });
+
+  it('handles duplicate colors in `used` without skipping more palette slots than needed', () => {
+    expect(pickAvailableColor(PALETTE, ['#A', '#A', '#B'])).toBe('#C');
+  });
+
+  it('falls back to a deterministic modulo when every palette slot is taken', () => {
+    // 6 palette colors all in use plus one extra → wraps via `used.length % palette.length`.
+    expect(pickAvailableColor(PALETTE, ['#A', '#B', '#C', '#D', '#E', '#F'])).toBe('#A');
+    expect(pickAvailableColor(PALETTE, ['#A', '#B', '#C', '#D', '#E', '#F', '#A'])).toBe('#B');
+  });
+});

--- a/apps/web/src/features/signers/pickAvailableColor.ts
+++ b/apps/web/src/features/signers/pickAvailableColor.ts
@@ -1,0 +1,29 @@
+/**
+ * Pick the first color from `palette` that is not already in `used`.
+ *
+ * Used for assigning a unique color to each signer in an envelope's
+ * roster. The naive `prev.length % palette.length` pattern collides
+ * after a mid-list removal — e.g. removing index 1 from
+ * `[A(#0), B(#1), C(#2)]` and adding D gives D the same color as C.
+ * Walking the palette and picking the lowest-index unused entry avoids
+ * that without requiring callers to track a separate "next free slot"
+ * counter.
+ *
+ * Comparisons are case-insensitive so `#abcdef` and `#ABCDEF` are
+ * treated as the same color (both Tailwind's hex casing and our seed
+ * fixtures are lower-case, but contact data sourced from elsewhere may
+ * not be).
+ *
+ * When every palette slot is already taken, falls back to a
+ * deterministic `used.length % palette.length` so two callers with the
+ * same input produce the same output (predictable for tests).
+ */
+export function pickAvailableColor(
+  palette: ReadonlyArray<string>,
+  used: ReadonlyArray<string>,
+): string {
+  const usedSet = new Set(used.map((c) => c.toLowerCase()));
+  const free = palette.find((c) => !usedSet.has(c.toLowerCase()));
+  if (free !== undefined) return free;
+  return palette[used.length % palette.length] ?? palette[0]!;
+}

--- a/apps/web/src/features/templates/__tests__/deriveFieldLayout.test.ts
+++ b/apps/web/src/features/templates/__tests__/deriveFieldLayout.test.ts
@@ -157,20 +157,39 @@ describe('deriveTemplateFieldLayout', () => {
     ];
     const out = deriveTemplateFieldLayout(fields, 4, [{ id: 's1' }, { id: 's2' }]);
     expect(out).toEqual([
-      { type: 'signature', pageRule: 2, x: 50, y: 100, signerIndex: 1 },
-      { type: 'signature', pageRule: 3, x: 60, y: 110, signerIndex: 0 },
+      // signerRoleId is the canonical binding (drives stable rebind
+      // when the wizard removes a mid-list signer); signerIndex is
+      // kept alongside for legacy rebinder back-compat.
+      { type: 'signature', pageRule: 2, x: 50, y: 100, signerIndex: 1, signerRoleId: 's2' },
+      { type: 'signature', pageRule: 3, x: 60, y: 110, signerIndex: 0, signerRoleId: 's1' },
     ]);
   });
 
-  it('propagates signerIndex onto every fan-out entry of a non-contiguous group', () => {
+  it('propagates signerIndex + signerRoleId onto every fan-out entry of a non-contiguous group', () => {
     const fields: ReadonlyArray<PlacedFieldValue> = [
       field({ id: 'f1', page: 1, type: 'date', x: 200, y: 50, linkId: 'L3', signerIds: ['s2'] }),
       field({ id: 'f3', page: 3, type: 'date', x: 200, y: 50, linkId: 'L3', signerIds: ['s2'] }),
     ];
     const out = deriveTemplateFieldLayout(fields, 5, [{ id: 's1' }, { id: 's2' }]);
     expect(out).toEqual([
-      { type: 'date', pageRule: 1, x: 200, y: 50, label: 'L3', signerIndex: 1 },
-      { type: 'date', pageRule: 3, x: 200, y: 50, label: 'L3', signerIndex: 1 },
+      {
+        type: 'date',
+        pageRule: 1,
+        x: 200,
+        y: 50,
+        label: 'L3',
+        signerIndex: 1,
+        signerRoleId: 's2',
+      },
+      {
+        type: 'date',
+        pageRule: 3,
+        x: 200,
+        y: 50,
+        label: 'L3',
+        signerIndex: 1,
+        signerRoleId: 's2',
+      },
     ]);
   });
 

--- a/apps/web/src/features/templates/__tests__/rebindFieldsToSigners.test.ts
+++ b/apps/web/src/features/templates/__tests__/rebindFieldsToSigners.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { rebindFieldsToSigners } from '../rebindFieldsToSigners';
 import type { ResolvedField } from '../templates';
 
-// Minimal helper — keeps the assertions focused on the signer-count rules.
+// Minimal helper — keeps the assertions focused on the signer-rebind rules.
 function field(
   partial: Partial<ResolvedField> & Pick<ResolvedField, 'page' | 'type'>,
 ): ResolvedField {
@@ -11,6 +11,7 @@ function field(
     x: partial.x ?? 100,
     y: partial.y ?? 200,
     ...(partial.signerIndex !== undefined ? { signerIndex: partial.signerIndex } : {}),
+    ...(partial.signerRoleId !== undefined ? { signerRoleId: partial.signerRoleId } : {}),
     ...partial,
   };
 }
@@ -103,6 +104,70 @@ describe('rebindFieldsToSigners', () => {
     ];
     const out = rebindFieldsToSigners(resolved, [{ id: 's1' }]);
     expect(out.map((f) => f.linkId)).toEqual(['L-1', 'L-1']);
+  });
+
+  // Bug 2 spec, the user-reported scenario (2026-05-10): user opens a
+  // template with prefilled signers [alice, bob], removes alice in the
+  // wizard, adds carol → roster becomes [bob, carol]. Bob's placement
+  // must stay pinned to bob; alice's placement is dropped; carol gets
+  // no preset fields. Pre-fix this re-bound by ordinal — bob shifted to
+  // index 0 and inherited alice's placement, the literal "placement
+  // moved" symptom.
+  it('binds by signerRoleId so removing a mid-list signer keeps remaining placements pinned', () => {
+    const resolved: ReadonlyArray<ResolvedField> = [
+      field({
+        id: 'alice-field',
+        page: 1,
+        type: 'signature',
+        signerIndex: 0,
+        signerRoleId: 'alice',
+      }),
+      field({
+        id: 'bob-field',
+        page: 2,
+        type: 'signature',
+        signerIndex: 1,
+        signerRoleId: 'bob',
+      }),
+    ];
+    const out = rebindFieldsToSigners(resolved, [{ id: 'bob' }, { id: 'carol' }]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: 'bob-field', signerIds: ['bob'] });
+  });
+
+  it('drops a field whose signerRoleId does not match any roster member, even when an ordinal would', () => {
+    // The legacy ordinal path would have bound this field to signers[0]
+    // (rachel) — we explicitly assert that the role-id check wins so
+    // the kept signer doesn't pick up an orphaned placement.
+    const resolved: ReadonlyArray<ResolvedField> = [
+      field({
+        id: 'a',
+        page: 1,
+        type: 'signature',
+        signerIndex: 0,
+        signerRoleId: 'alice',
+      }),
+    ];
+    const out = rebindFieldsToSigners(resolved, [{ id: 'rachel' }]);
+    expect(out).toEqual([]);
+  });
+
+  it('signerRoleId match wins over signerIndex when both are present', () => {
+    // Same id at a different ordinal → the field follows the id, not
+    // the position. Confirms the new rule ignores `signerIndex` once
+    // `signerRoleId` is supplied.
+    const resolved: ReadonlyArray<ResolvedField> = [
+      field({
+        id: 'a',
+        page: 1,
+        type: 'signature',
+        signerIndex: 0,
+        signerRoleId: 'bob',
+      }),
+    ];
+    const out = rebindFieldsToSigners(resolved, [{ id: 'alice' }, { id: 'bob' }]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.signerIds).toEqual(['bob']);
   });
 
   it('maps template field types to their editor counterparts', () => {

--- a/apps/web/src/features/templates/deriveFieldLayout.ts
+++ b/apps/web/src/features/templates/deriveFieldLayout.ts
@@ -127,19 +127,22 @@ export function deriveTemplateFieldLayout(
       // The user can re-place it on the resolved document.
       continue;
     }
-    // Derive signerIndex from the head field's first assigned signer.
-    // Linked copies share an assignment in the editor today (the group
-    // toolbar applies the picker to every member), so the head's
-    // signerIds[0] is representative of the bucket. Drop the field
-    // entirely from the layout if we can't resolve an index when one
-    // was requested via `signers` — better to lose the field than to
-    // misbind it to signers[0] silently.
+    // Derive signerIndex AND signerRoleId from the head field's first
+    // assigned signer. Linked copies share an assignment in the editor
+    // today (the group toolbar applies the picker to every member), so
+    // the head's signerIds[0] is representative of the bucket. Both
+    // fields are populated when `signers` is supplied — the ordinal
+    // for legacy back-compat, the role-id as the canonical binder.
     let signerIndex: number | undefined;
+    let signerRoleId: string | undefined;
     if (signers) {
       const headSignerId = head.signerIds[0];
       if (headSignerId !== undefined) {
         const idx = signerOrdinalById.get(headSignerId);
-        if (idx !== undefined) signerIndex = idx;
+        if (idx !== undefined) {
+          signerIndex = idx;
+          signerRoleId = headSignerId;
+        }
       }
     }
     const rule = inferPageRule(pages, totalPages);
@@ -151,6 +154,7 @@ export function deriveTemplateFieldLayout(
         y: head.y,
         ...(head.linkId ? { label: head.linkId } : {}),
         ...(signerIndex !== undefined ? { signerIndex } : {}),
+        ...(signerRoleId !== undefined ? { signerRoleId } : {}),
       });
       continue;
     }
@@ -166,6 +170,7 @@ export function deriveTemplateFieldLayout(
         y: head.y,
         ...(head.linkId ? { label: head.linkId } : {}),
         ...(signerIndex !== undefined ? { signerIndex } : {}),
+        ...(signerRoleId !== undefined ? { signerRoleId } : {}),
       });
     }
   }

--- a/apps/web/src/features/templates/mergeFieldLayoutOnReducedRoster.ts
+++ b/apps/web/src/features/templates/mergeFieldLayoutOnReducedRoster.ts
@@ -42,9 +42,17 @@ export function mergeFieldLayoutOnReducedRoster(
   if (draftLastSigners.length >= sourceLastSigners.length) {
     return { fieldLayout: derivedLayout, lastSigners: draftLastSigners };
   }
-  const preservedFromSource = sourceFields.filter(
-    (f) => f.signerIndex !== undefined && f.signerIndex >= draftLastSigners.length,
-  );
+  // Preserve every source-template field whose owner isn't in the
+  // shrunken draft roster. Match by stable role id when present (so
+  // the user removing a mid-list signer in the editor doesn't drag
+  // the next signer's fields with it), falling back to
+  // `signerIndex >= draftLastSigners.length` for legacy templates
+  // that haven't been re-saved yet with `signerRoleId`.
+  const draftSignerIds = new Set(draftLastSigners.map((s) => s.id));
+  const preservedFromSource = sourceFields.filter((f) => {
+    if (f.signerRoleId !== undefined) return !draftSignerIds.has(f.signerRoleId);
+    return f.signerIndex !== undefined && f.signerIndex >= draftLastSigners.length;
+  });
   return {
     fieldLayout: [...derivedLayout, ...preservedFromSource],
     lastSigners: sourceLastSigners,

--- a/apps/web/src/features/templates/rebindFieldsToSigners.ts
+++ b/apps/web/src/features/templates/rebindFieldsToSigners.ts
@@ -28,46 +28,59 @@ export interface RebindSigner {
 }
 
 /**
- * Apply the user-spec signer-count rules to a resolved-template field
+ * Apply the user-spec signer-rebind rules to a resolved-template field
  * set, projecting each field onto the active envelope roster.
  *
- * Three cases (driven by each field's saved `signerIndex` ordinal):
+ * Binding precedence (per field):
  *
- *   1. `signerIndex` defined AND `< signers.length` — bind to
- *      `signers[signerIndex]` so per-signer colors & assignments
- *      survive the round-trip even when the user replaced the signers.
- *      Identity doesn't matter; the ordinal does.
+ *   1. `signerRoleId` matches a signer's `id` in the roster — bind
+ *      there. This is the canonical path for new templates AND for
+ *      legacy templates after `resolveTemplateFields` backfills
+ *      `signerRoleId` from `last_signers[signerIndex]`. Surviving the
+ *      mid-list-removal shift bug (where removing signer A from
+ *      [A, B] used to re-assign A's placements to B) depends on this
+ *      step running before the ordinal fallback.
  *
- *   2. `signerIndex` defined AND `>= signers.length` — DROP the field.
- *      The user removed a signer, so their fields go with them. This
- *      replaces the previous fallback-to-signers[0], which collapsed
- *      every "extra" field onto signer #0 and looked like duplicate
- *      signatures (the original bug).
+ *   2. `signerRoleId` defined but no roster member matches — DROP.
+ *      The signer that owned this field was removed from the active
+ *      envelope; their placements go with them.
  *
- *   3. `signerIndex` undefined (legacy templates saved before signer
- *      indexing was added) — fall back to `signers[0]` for back-compat.
- *      If the roster is empty, drop. The user can still rebind in the
- *      editor.
+ *   3. `signerIndex` defined AND `< signers.length` (legacy ordinal
+ *      path, no `signerRoleId`) — bind by ordinal. Survives only on
+ *      pre-fix templates that haven't been re-resolved with
+ *      `lastSigners` yet.
  *
- * Extra signers (those at indexes the original template never used)
- * automatically get no preset fields — the per-field loop only emits
- * fields the template originally placed, so "more signers than the
- * template" naturally produces empty assignments for the new signers
- * (the user adds those fields manually in the editor).
+ *   4. `signerIndex` defined AND `>= signers.length` — DROP, same
+ *      reasoning as case 2.
+ *
+ *   5. Neither defined (truly ancient templates) — best-effort
+ *      fallback to `signers[0]`; if the roster is empty, drop.
+ *
+ * Extra signers (those past every saved binding) get no preset fields;
+ * the per-field loop only emits what the template originally placed.
  */
 export function rebindFieldsToSigners(
   resolved: ReadonlyArray<ResolvedField>,
   signers: ReadonlyArray<RebindSigner>,
 ): ReadonlyArray<PlacedFieldValue> {
+  const signerById = new Map(signers.map((s) => [s.id, s]));
   const out: PlacedFieldValue[] = [];
   for (const rf of resolved) {
     let targetSignerId: string | undefined;
-    if (rf.signerIndex !== undefined) {
-      // Saved-with-index path: bind by ordinal, drop on out-of-range.
+    if (rf.signerRoleId !== undefined) {
+      // Stable-id path: drop when the role's owner is no longer in
+      // the roster. Do NOT fall through to `signerIndex` — that
+      // re-introduces the shift bug for legacy templates the
+      // backfill already covered.
+      const target = signerById.get(rf.signerRoleId);
+      if (!target) continue;
+      targetSignerId = target.id;
+    } else if (rf.signerIndex !== undefined) {
+      // Legacy ordinal path: bind by ordinal, drop on out-of-range.
       if (rf.signerIndex >= signers.length) continue;
       targetSignerId = signers[rf.signerIndex]?.id;
     } else {
-      // Legacy path: best-effort fallback to signers[0].
+      // Pre-signerIndex legacy: best-effort fallback to signers[0].
       targetSignerId = signers[0]?.id;
     }
     out.push({

--- a/apps/web/src/features/templates/templates.ts
+++ b/apps/web/src/features/templates/templates.ts
@@ -163,12 +163,18 @@ export interface ResolvedField {
   readonly y: number;
   readonly label?: string;
   /**
-   * Mirrors `TemplateField.signerIndex`. Consumers map this back to the
-   * matching signer in the new envelope's roster (which is pre-filled
-   * from `template.lastSigners` in the same order). Undefined for older
-   * templates saved before signer-indexing was added.
+   * Mirrors `TemplateField.signerIndex`. Kept for legacy fallback;
+   * the rebinder prefers `signerRoleId` when present.
    */
   readonly signerIndex?: number;
+  /**
+   * Mirrors `TemplateField.signerRoleId` — the stable per-signer id
+   * that owned this field at template-save time. `resolveTemplateFields`
+   * also backfills it from `lastSigners[signerIndex].id` when the
+   * stored record only has `signerIndex`, so legacy templates pick up
+   * the stable-id binding without a save round-trip.
+   */
+  readonly signerRoleId?: string;
   /**
    * Stable identifier shared by every copy expanded from the same
    * multi-page source rule (e.g. `pageRule: 'all'` on a 3-page doc
@@ -195,6 +201,7 @@ export interface ResolvedField {
 export function resolveTemplateFields(
   fields: ReadonlyArray<TemplateFieldLayout>,
   totalPages: number,
+  lastSigners?: ReadonlyArray<{ readonly id: string }>,
 ): ReadonlyArray<ResolvedField> {
   const out: ResolvedField[] = [];
   let id = 1;
@@ -215,6 +222,14 @@ export function resolveTemplateFields(
     // Only mint a linkId when the source rule expanded into more than
     // one peer — single-page rules don't need linking.
     const linkId = pages.length > 1 ? `tpl-link-${linkSeq++}` : undefined;
+    // Backfill `signerRoleId` from the original `last_signers` roster
+    // when the stored field only has `signerIndex`. Legacy templates
+    // (saved before stable-id binding shipped) pick up the new
+    // mid-list-removal-safe behavior at first reuse without a save.
+    let signerRoleId: string | undefined = tf.signerRoleId;
+    if (signerRoleId === undefined && tf.signerIndex !== undefined && lastSigners) {
+      signerRoleId = lastSigners[tf.signerIndex]?.id;
+    }
     for (const p of pages) {
       const resolved: ResolvedField = {
         id: `tpl-f${id++}`,
@@ -224,6 +239,7 @@ export function resolveTemplateFields(
         y: tf.y,
         ...(tf.label !== undefined ? { label: tf.label } : {}),
         ...(tf.signerIndex !== undefined ? { signerIndex: tf.signerIndex } : {}),
+        ...(signerRoleId !== undefined ? { signerRoleId } : {}),
         ...(linkId !== undefined ? { linkId } : {}),
       };
       out.push(resolved);

--- a/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
+++ b/apps/web/src/pages/MobileSendPage/MobileSendPage.tsx
@@ -58,6 +58,7 @@ import { useSendEnvelope } from '@/features/envelopes/useSendEnvelope';
 import type { SendEnvelopeSignerInput } from '@/features/envelopes/useSendEnvelope';
 import type { FieldPlacement } from '@/features/envelopes/envelopesApi';
 import { SIGNER_COLOR_PALETTE } from '@/lib/mockApi';
+import { pickAvailableColor } from '@/features/signers/pickAvailableColor';
 
 const STEP_LABELS: Readonly<Record<MobileStep, string>> = {
   start: 'Pick your starting point',
@@ -266,13 +267,16 @@ export function MobileSendPage() {
       if (meIncluded && !has) {
         const fallbackName = user?.name || sessionUser.email || 'Me';
         const fallbackEmail = user?.email || sessionUser.email || '';
-        const colorIdx = prev.length % SIGNER_COLOR_PALETTE.length;
+        const color = pickAvailableColor(
+          SIGNER_COLOR_PALETTE,
+          prev.map((s) => s.color),
+        );
         return [
           {
             id: meId,
             name: fallbackName,
             email: fallbackEmail,
-            color: SIGNER_COLOR_PALETTE[colorIdx] ?? '#818CF8',
+            color,
             initials: initialsFromName(fallbackName),
           },
           ...prev,
@@ -375,14 +379,17 @@ export function MobileSendPage() {
   // for the signers list; the sheet only validates against it.
   const addSignerLocal = useCallback((input: SignerInput): void => {
     setSigners((prev) => {
-      const colorIdx = prev.length % SIGNER_COLOR_PALETTE.length;
+      const color = pickAvailableColor(
+        SIGNER_COLOR_PALETTE,
+        prev.map((s) => s.color),
+      );
       return [
         ...prev,
         {
           id: `s_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`,
           name: input.name,
           email: input.email,
-          color: SIGNER_COLOR_PALETTE[colorIdx] ?? '#818CF8',
+          color,
           initials: initialsFromName(input.name),
         },
       ];

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.test.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.test.tsx
@@ -181,4 +181,59 @@ describe('UseTemplatePage — pre-filled signers from lastSigners', () => {
     expect(screen.queryByText('Jamie Okonkwo')).toBeNull();
     expect(screen.queryByText('Avery Lin')).toBeNull();
   });
+
+  // Bug 1 (2026-05-10 user report): a template's prefilled signer is
+  // removed, a fresh guest is added in their place — both remaining
+  // signers must keep distinct colors. Pre-fix the new guest got
+  // `prev.length % palette.length` which collided with the kept
+  // signer's slot whenever a mid-list removal had freed an earlier
+  // index.
+  it('keeps every signer row a unique color even after a mid-list remove + add cycle', async () => {
+    // Three prefills covering the first three palette slots so the
+    // collision is observable without exhausting the 6-color palette.
+    const SAVED_THREE = [
+      { id: 'c-jamie', name: 'Jamie', email: 'jamie@x.test', color: '#F472B6' },
+      { id: 'c-avery', name: 'Avery', email: 'avery@x.test', color: '#7DD3FC' },
+      { id: 'c-bo', name: 'Bo', email: 'bo@x.test', color: '#FBBF24' },
+    ];
+    setTemplates(
+      TEMPLATES.map((t) => (t.id === SAMPLE.id ? { ...t, lastSigners: SAVED_THREE } : t)),
+    );
+    renderAt(`/templates/${encodeURIComponent(SAMPLE.id)}/use`);
+    await userEvent.click(screen.getByRole('button', { name: /^continue$/i }));
+    expect(
+      await screen.findByRole('heading', { name: /who's signing this time/i }),
+    ).toBeInTheDocument();
+
+    // Remove Avery (mid-list — frees palette slot #7DD3FC).
+    await userEvent.click(screen.getByRole('button', { name: /remove avery/i }));
+
+    // Add a new guest. Pre-fix this would have re-used Bo's #FBBF24
+    // because `prev.length = 2` after the removal. Post-fix the guest
+    // picks the lowest-index unused color (#7DD3FC, freed by Avery).
+    await userEvent.click(screen.getByRole('button', { name: /^add signer$/i }));
+    await userEvent.type(screen.getByPlaceholderText(/search contacts/i), 'fresh@x.test');
+    await userEvent.click(await screen.findByRole('button', { name: /add .* as guest signer/i }));
+
+    // Collect the avatar background colors of every visible signer
+    // row. Each row's first child is the styled `<Avatar $color={...}>`
+    // so we read its computed background. The kept signer (Jamie),
+    // remaining prefilled (Bo), and the freshly-added guest must each
+    // resolve to a distinct color.
+    const expectedNames = ['Jamie', 'Bo', 'fresh@x.test'];
+    const colors = expectedNames.map((name) => {
+      const nameEl = screen.getByText(name);
+      // Walk up until we find the listitem ancestor (SignerRow).
+      let cursor: HTMLElement | null = nameEl;
+      while (cursor && cursor.getAttribute('role') !== 'listitem') {
+        cursor = cursor.parentElement;
+      }
+      if (!cursor) throw new Error(`could not find listitem ancestor for ${name}`);
+      const avatar = cursor.firstElementChild as HTMLElement | null;
+      if (!avatar) throw new Error(`row for ${name} has no avatar child`);
+      return window.getComputedStyle(avatar).backgroundColor.toLowerCase();
+    });
+    expect(colors.every((c) => c.length > 0)).toBe(true);
+    expect(new Set(colors).size).toBe(colors.length);
+  });
 });

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
@@ -26,6 +26,7 @@ import {
   subscribeToTemplates,
   type TemplateSummary,
 } from '@/features/templates';
+import { pickAvailableColor } from '@/features/signers/pickAvailableColor';
 import { useAppState } from '@/providers/AppStateProvider';
 import {
   DocumentTitle,
@@ -285,6 +286,14 @@ export function UseTemplatePage() {
       if (exists) {
         return prev.filter((s) => s.email.toLowerCase() !== contact.email.toLowerCase());
       }
+      // Override the contact's stored color when it would collide with a
+      // signer already in the roster. Two contacts can carry the same
+      // palette entry in the contact-store; we still want each signer in
+      // a single envelope to render in a unique color.
+      const used = prev.map((s) => s.color);
+      const color = used.includes(contact.color)
+        ? pickAvailableColor(SIGNER_COLORS, used)
+        : contact.color;
       return [
         ...prev,
         {
@@ -292,7 +301,7 @@ export function UseTemplatePage() {
           contactId: contact.id,
           name: contact.name,
           email: contact.email,
-          color: contact.color,
+          color,
         },
       ];
     });
@@ -304,7 +313,10 @@ export function UseTemplatePage() {
       if (prev.some((s) => s.email.toLowerCase() === email.toLowerCase())) {
         return prev;
       }
-      const colorIdx = prev.length % SIGNER_COLORS.length;
+      const color = pickAvailableColor(
+        SIGNER_COLORS,
+        prev.map((s) => s.color),
+      );
       return [
         ...prev,
         {
@@ -312,7 +324,7 @@ export function UseTemplatePage() {
           contactId: null,
           name: name || email.split('@')[0] || email,
           email,
-          color: SIGNER_COLORS[colorIdx]!,
+          color,
         },
       ];
     });

--- a/apps/web/src/routes/TemplateEditorRoute.tsx
+++ b/apps/web/src/routes/TemplateEditorRoute.tsx
@@ -354,7 +354,15 @@ export function TemplateEditorRoute() {
 
     let pendingFields: ReadonlyArray<PlacedFieldValue> = [];
     if (sourceTemplate) {
-      const resolved = resolveTemplateFields(sourceTemplate.fields, resolvedPages);
+      // Pass `lastSigners` so the resolver backfills `signerRoleId`
+      // for legacy templates that only stored `signerIndex` — see the
+      // rebinder's stable-id rules. Without it, the wizard's
+      // remove-then-add path would still shift kept signers' fields.
+      const resolved = resolveTemplateFields(
+        sourceTemplate.fields,
+        resolvedPages,
+        sourceTemplate.lastSigners,
+      );
       // Apply the user-spec signer-count rules: bind by ordinal, drop
       // fields whose owning signer was removed, fall back to signers[0]
       // only for legacy (pre-signerIndex) templates. Centralized in

--- a/apps/web/src/routes/UploadRoute.tsx
+++ b/apps/web/src/routes/UploadRoute.tsx
@@ -10,6 +10,7 @@ import { DrivePicker } from '../components/drive-picker';
 import { useAppState } from '../providers/AppStateProvider';
 import { useAuth } from '../providers/AuthProvider';
 import { SIGNER_COLOR_PALETTE } from '../lib/mockApi/data/palette';
+import { pickAvailableColor } from '../features/signers/pickAvailableColor';
 import { usePdfDocument } from '../lib/pdf';
 import { ConversionFailedDialog, ImportOverlay, useDriveImport } from '../features/gdriveImport';
 import type { ImportPhase } from '../features/gdriveImport';
@@ -239,12 +240,16 @@ export function UploadRoute() {
       // pushed to the server later as part of the envelope POST when the
       // sender clicks "Send to sign".
       const synthLocalSigner = (): AddSignerContact => {
-        const colorIdx = (contacts.length + selectedSigners.length) % SIGNER_COLOR_PALETTE.length;
+        // Pick the lowest-index palette color not already in use by the
+        // current envelope roster. `prev.length % palette.length` reused
+        // colors after a mid-list signer was removed; this walks the
+        // palette and picks the first free entry instead.
+        const used = [...contacts.map((c) => c.color), ...selectedSigners.map((s) => s.color)];
         return {
           id: `guest-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
           name,
           email,
-          color: SIGNER_COLOR_PALETTE[colorIdx] ?? '#818CF8',
+          color: pickAvailableColor(SIGNER_COLOR_PALETTE, used),
         };
       };
 
@@ -271,7 +276,7 @@ export function UploadRoute() {
           });
         });
     },
-    [addContact, contacts.length, isGuest, selectedSigners.length],
+    [addContact, contacts, isGuest, selectedSigners],
   );
 
   const handleRemoveSelected = useCallback((id: string) => {
@@ -289,7 +294,10 @@ export function UploadRoute() {
     // we surface a console warning so the dropoff is observable.
     let pendingFields: ReturnType<typeof rebindFieldsToSigners> = [];
     if (template) {
-      const resolved = resolveTemplateFields(template.fields, resolvedPages);
+      // Pass `lastSigners` so the resolver backfills `signerRoleId`
+      // for legacy templates — keeps the rebind stable when the user
+      // mid-list-removes a signer in the wizard.
+      const resolved = resolveTemplateFields(template.fields, resolvedPages, template.lastSigners);
       pendingFields = rebindFieldsToSigners(resolved, selectedSigners);
       if (resolvedPages < template.pages) {
         // Use console.warn so the SPA's debug build flags the gap. The

--- a/cspell.json
+++ b/cspell.json
@@ -437,6 +437,7 @@
     "ungroup",
     "ungrouping",
     "misbind",
+    "rebinder",
     "untick",
     "unzoomed",
     "rasterizing",

--- a/packages/shared/src/templates.ts
+++ b/packages/shared/src/templates.ts
@@ -45,14 +45,24 @@ export interface TemplateField {
   readonly label?: string;
   /**
    * Zero-based index into the signer roster active when the template was
-   * saved. When the template is reused (and `last_signers` re-pre-fills
-   * the new envelope's roster in the same order), each field is rebound
-   * to the signer at this index — so signer #1's signature stays signer
-   * #1's signature instead of every field collapsing onto signers[0].
-   * Optional for back-compat with older saved templates: missing values
-   * still fall back to signers[0] on the consumer side.
+   * saved. Kept for legacy templates predating `signerRoleId`; new saves
+   * populate both fields, and consumers prefer `signerRoleId` when
+   * present so that mid-list signer removals don't cause kept signers'
+   * placements to shift up.
    */
   readonly signerIndex?: number;
+  /**
+   * Stable per-signer id from the roster active when the template was
+   * saved — matches `TemplateLastSigner.id`. Resolves the wizard bug
+   * where removing a prefilled signer in the use-template flow caused
+   * remaining signers' placements to inherit the removed signer's
+   * position (an artifact of the old ordinal-only binding compressing
+   * indexes). Optional: legacy templates without this field fall back
+   * to `signerIndex`, and consumers backfill it at resolve time using
+   * `last_signers` so even unsaved legacy templates pick up the new
+   * behavior.
+   */
+  readonly signerRoleId?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

User-reported bugs against the use-template wizard (2026-05-10):

### Bug 1 — same color for two signers after remove + add
Open a template with prefilled signers, remove one, add a guest in their place — both remaining signers ended up with the same color. The roster's `prev.length % palette.length` reused colors after a mid-list removal had freed an earlier palette slot.

**Fix:** new `pickAvailableColor(palette, used)` helper walks the palette and picks the first unused color; falls back to `used.length % palette` only when every slot is taken. Applied at every guest/signer-add site (`UseTemplatePage.tsx:281,301`, `UploadRoute.tsx:241`, `MobileSendPage.tsx:269,376`).

### Bug 2 — kept signer's placement moves when another signer is removed
The kept signer's signature placement got reordered to where the removed signer's placement had been. Saved fields were bound to signers by ordinal (`signerIndex`), and removing a signer compressed the indexes so every other signer's fields shifted up.

**Fix (per user-approved design):** stable signer-role binding.

- `TemplateField` (shared) and the API DTO gain `signerRoleId?: string` alongside `signerIndex`.
- `deriveTemplateFieldLayout` populates both on save.
- `rebindFieldsToSigners` prefers `signerRoleId` (drops on no match), falls back to `signerIndex` only for legacy templates.
- `resolveTemplateFields` accepts an optional `lastSigners` and **backfills `signerRoleId` from `lastSigners[signerIndex].id`** so legacy templates pick up stable-id binding without a save round-trip — the user's existing templates self-heal on first reuse after this lands.
- `mergeFieldLayoutOnReducedRoster` matches by `signerRoleId` when present; ordinal fallback for legacy.

### Tests

| Layer | Path | What it asserts |
|---|---|---|
| Unit (helper) | `apps/web/src/features/signers/pickAvailableColor.test.ts` | First-unused pick, mid-list-hole skip, case-insensitive compare, full-palette wrap. RED before helper existed → GREEN. |
| Unit (rebind) | `apps/web/src/features/templates/__tests__/rebindFieldsToSigners.test.ts` | New scenarios: role-id match keeps remaining placements pinned; no role-id match drops the field even when an ordinal would have bound it; role-id wins over signerIndex. |
| Page-level | `apps/web/src/pages/UseTemplatePage/UseTemplatePage.test.tsx` | After remove-then-add, every avatar's computed background color is unique (3 prefilled → remove mid-list → add guest → asserts 3 distinct colors). |
| Updated | `apps/web/src/features/templates/__tests__/deriveFieldLayout.test.ts` | Now expects the new `signerRoleId` alongside `signerIndex`. |

## Test plan

- [x] typecheck (web + api + landing + shared) clean
- [x] lint (web) — 0 warnings, 0 errors
- [x] vitest run — 1475/1475 GREEN
- [x] api jest — templates suite 85/85 GREEN
- [x] `seald-react-pr-review` walked the diff — no MUST-FIX / SHOULD-FIX
- [ ] Post-deploy: re-verify on https://seald.nromomentum.com — `/templates/<id>/use` flow, remove a prefilled signer, add a guest, confirm (a) every signer row has a distinct color and (b) the kept signer's signature placement on the editor screen does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)