### PR TITLE
fix(web): portal SignerStack popover so it escapes the dashboard table shell's overflow clip

### DIFF
--- a/apps/web/src/components/SignerStack/SignerStack.styles.ts
+++ b/apps/web/src/components/SignerStack/SignerStack.styles.ts
@@ -74,10 +74,11 @@ export const Fraction = styled.span`
   white-space: nowrap;
 `;
 
+// Top/left/position are supplied at the call site via an inline style
+// because the popover is portaled to document.body and pinned to the
+// trigger's measured viewport rect. Keeping the static styles here so
+// styled-components still owns the visual treatment.
 export const Popover = styled.div`
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
   z-index: 10;
   min-width: 240px;
   max-width: 320px;

--- a/apps/web/src/components/SignerStack/SignerStack.test.tsx
+++ b/apps/web/src/components/SignerStack/SignerStack.test.tsx
@@ -51,6 +51,38 @@ describe('SignerStack', () => {
     expect(screen.queryByText('bob@example.com')).not.toBeInTheDocument();
   });
 
+  // Bug 2026-05-10 (user report): on the dashboard, hovering the
+  // signer-stack pill rendered the popover inside the table row,
+  // and the surrounding `TableShell` (which has `overflow: hidden`
+  // to clip the bottom rounded corners) cut the popover off — only
+  // a thin sliver was visible. Asserts the popover renders OUTSIDE
+  // its containing overflow box (i.e. via a portal to document.body).
+  it('renders the popover outside an `overflow: hidden` ancestor (portaled)', async () => {
+    const user = userEvent.setup();
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-testid', 'overflow-clipper');
+    wrapper.style.overflow = 'hidden';
+    document.body.appendChild(wrapper);
+    const { container, unmount } = renderWithTheme(
+      <SignerStack
+        signers={[
+          mk({ id: '1', name: 'Ada Lovelace', email: 'ada@example.com', status: 'signed' }),
+        ]}
+      />,
+      { container: wrapper },
+    );
+    const root = container.firstElementChild as HTMLElement;
+    await user.hover(root);
+    const popoverContent = screen.getByText('ada@example.com');
+    // The popover row's text must be reachable, and its DOM ancestry
+    // must NOT pass through the overflow-hidden wrapper — otherwise
+    // it would still be clipped on screen.
+    expect(popoverContent).toBeInTheDocument();
+    expect(wrapper.contains(popoverContent)).toBe(false);
+    unmount();
+    document.body.removeChild(wrapper);
+  });
+
   it('counts only signed signers in the fraction', () => {
     renderWithTheme(
       <SignerStack

--- a/apps/web/src/components/SignerStack/SignerStack.tsx
+++ b/apps/web/src/components/SignerStack/SignerStack.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useState, useCallback, useId } from 'react';
+import { forwardRef, useCallback, useId, useImperativeHandle, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Badge } from '../Badge';
 import type { BadgeTone } from '../Badge/Badge.types';
 import type { SignerStackProps, SignerStackStatus } from './SignerStack.types';
@@ -45,11 +46,32 @@ function initialsOf(name: string): string {
  * overflow chip, and a mono signed/total fraction. Hover or focus
  * reveals a popover listing every signer with a status pill.
  */
+// Default position when we open before measuring (e.g. SSR / first
+// render). Off-screen so it can't flash in the wrong spot if the
+// measurement read fails.
+const DEFAULT_ANCHOR = { top: -9999, left: -9999 } as const;
+
 export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, ref) => {
   const { signers, maxVisible = 4, onMouseEnter, onMouseLeave, onFocus, onBlur, ...rest } = props;
   const popoverId = useId();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  // Forward our internal ref so consumers' refs still work.
+  useImperativeHandle(ref, () => rootRef.current as HTMLDivElement, []);
+
+  // `open` toggles render; `anchor` carries the viewport-relative
+  // coordinates the portaled popover uses. We measure on each show
+  // because the anchor position can change between hides (scroll,
+  // resize, list reorder) without us getting an event.
   const [open, setOpen] = useState(false);
-  const show = useCallback(() => setOpen(true), []);
+  const [anchor, setAnchor] = useState<{ top: number; left: number }>(DEFAULT_ANCHOR);
+
+  const show = useCallback(() => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (rect) {
+      setAnchor({ top: rect.bottom + 6, left: rect.left });
+    }
+    setOpen(true);
+  }, []);
   const hide = useCallback(() => setOpen(false), []);
 
   const total = signers.length;
@@ -57,9 +79,41 @@ export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, 
   const visible = signers.slice(0, maxVisible);
   const overflow = total - visible.length;
 
+  // The popover is portaled to `document.body` so it can escape any
+  // ancestor with `overflow: hidden` (the dashboard's TableShell
+  // clipped it before — bug 2026-05-10). We pin it via
+  // `position: fixed` + the measured anchor instead of leaning on
+  // the trigger's containing block.
+  const popoverNode =
+    open && total > 0 && typeof document !== 'undefined'
+      ? createPortal(
+          <Popover
+            id={popoverId}
+            role="tooltip"
+            style={{ position: 'fixed', top: anchor.top, left: anchor.left }}
+          >
+            {signers.map((s) => (
+              <PopoverRow key={s.id}>
+                <Avatar as="span" $status={s.status} aria-hidden>
+                  {initialsOf(s.name)}
+                </Avatar>
+                <PopoverMeta>
+                  <PopoverName>{s.name}</PopoverName>
+                  <PopoverEmail>{s.email}</PopoverEmail>
+                </PopoverMeta>
+                <Badge tone={STATUS_TONE[s.status]} dot={false}>
+                  {STATUS_LABEL[s.status]}
+                </Badge>
+              </PopoverRow>
+            ))}
+          </Popover>,
+          document.body,
+        )
+      : null;
+
   return (
     <Root
-      ref={ref}
+      ref={rootRef}
       onMouseEnter={(e) => {
         show();
         onMouseEnter?.(e);
@@ -97,24 +151,7 @@ export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, 
       <Fraction aria-label={`${signed} of ${total} signed`}>
         {signed}/{total} signed
       </Fraction>
-      {open && total > 0 && (
-        <Popover id={popoverId} role="tooltip">
-          {signers.map((s) => (
-            <PopoverRow key={s.id}>
-              <Avatar as="span" $status={s.status} aria-hidden>
-                {initialsOf(s.name)}
-              </Avatar>
-              <PopoverMeta>
-                <PopoverName>{s.name}</PopoverName>
-                <PopoverEmail>{s.email}</PopoverEmail>
-              </PopoverMeta>
-              <Badge tone={STATUS_TONE[s.status]} dot={false}>
-                {STATUS_LABEL[s.status]}
-              </Badge>
-            </PopoverRow>
-          ))}
-        </Popover>
-      )}
+      {popoverNode}
     </Root>
   );
 });


### PR DESCRIPTION
## Summary

User-reported on the dashboard (2026-05-10): hovering the signer-stack pill on a row revealed only a thin sliver of the popover — the rest was clipped. Root cause: `DashboardPage.styles.ts:53-59` (`TableShell`) has \`overflow: hidden\` to keep the bottom rounded corners clean, and the popover sat inside that container as an absolutely-positioned child.

**Fix:** portal the popover to \`document.body\` and pin it via \`position: fixed\` + the trigger's measured viewport rect (\`getBoundingClientRect\`). Escapes any ancestor overflow context. Position recomputed on each open so a scrolled list / resized window can't show a stale anchor.

## Test plan

- [x] New regression in \`SignerStack.test.tsx\` wraps the component in an \`overflow: hidden\` div and asserts the popover row's text DOM is NOT a descendant of that wrapper after hover. Failed against the old code → passes after the portal fix.
- [x] Existing 4 SignerStack tests still pass (unchanged behavior for hover/show/text/fraction count).
- [x] typecheck / lint / vitest 1485/1485 GREEN.
- [ ] Post-deploy: hover the avatar pill on `/` (dashboard) on https://seald.nromomentum.com — popover should render in full below the row, not be cut off by the table shell.

🤖 Generated with [Claude Code](https://claude.com/claude-code)