### PR TITLE
feat(web): replace dashboard tabs with single-screen filter toolbar

### DIFF
--- a/apps/web/e2e/pages/DashboardPage.ts
+++ b/apps/web/e2e/pages/DashboardPage.ts
@@ -4,6 +4,14 @@ export class DashboardPage {
   constructor(private readonly page: Page) {}
 
   async goto(): Promise<void> {
+    // Append the `status=all` sentinel so tests see every seeded envelope
+    // (the dashboard's first-visit default narrows to the actionable
+    // inbox: Awaiting you + Awaiting others). Tests that need to assert
+    // the actionable-inbox default should call `gotoDefault()` instead.
+    await this.page.goto('/documents?status=all');
+  }
+
+  async gotoDefault(): Promise<void> {
     await this.page.goto('/documents');
   }
 
@@ -14,19 +22,22 @@ export class DashboardPage {
   }
 
   async filterBy(status: string): Promise<void> {
-    // Dashboard tabs: All / Awaiting you / Awaiting others / Completed /
-    // Drafts. "awaiting" alone is ambiguous; map common shorthands to the
-    // right tab so scenarios stay declarative.
-    const map: Record<string, RegExp> = {
-      awaiting: /awaiting others/i,
-      'awaiting others': /awaiting others/i,
-      'awaiting you': /awaiting you/i,
-      completed: /^completed$/i,
-      drafts: /^drafts$/i,
-      all: /^all$/i,
+    // The dashboard now reads filter state from `?status=…` (replacing
+    // the old tab UI). Push the URL directly so tests stay independent
+    // of the chip popover's checkbox UX.
+    const map: Record<string, string> = {
+      awaiting: 'awaiting_others',
+      'awaiting others': 'awaiting_others',
+      'awaiting you': 'awaiting_you',
+      completed: 'sealed',
+      sealed: 'sealed',
+      drafts: 'draft',
+      draft: 'draft',
+      declined: 'declined',
+      all: 'all',
     };
-    const pattern = map[status.toLowerCase()] ?? new RegExp(status, 'i');
-    await this.page.getByRole('tab', { name: pattern }).click();
+    const slug = map[status.toLowerCase()] ?? status.toLowerCase();
+    await this.page.goto(`/documents?status=${slug}`);
   }
 
   async openEnvelope(title: string): Promise<void> {

--- a/apps/web/src/components/EnvelopeIllustration/EnvelopeIllustration.tsx
+++ b/apps/web/src/components/EnvelopeIllustration/EnvelopeIllustration.tsx
@@ -1,0 +1,55 @@
+import { forwardRef } from 'react';
+import type { SVGProps } from 'react';
+
+export interface EnvelopeIllustrationProps extends SVGProps<SVGSVGElement> {
+  /** Outer width in px. Height scales to preserve the 160:110 ratio. */
+  readonly size?: number;
+}
+
+/**
+ * Static envelope illustration — same visual treatment as the
+ * `SendingOverlay`'s in-flight envelope (gradient body + lifted flap)
+ * but without the wax-seal, shimmer, or any animation. Used as the
+ * placeholder graphic for empty list states (dashboard "no
+ * envelopes match", future templates / contacts blank states).
+ *
+ * The SVG is fully self-contained — no theme-tokens — so it renders
+ * identically in light + dark and inside surfaces with arbitrary
+ * background colors.
+ */
+export const EnvelopeIllustration = forwardRef<SVGSVGElement, EnvelopeIllustrationProps>(
+  (props, ref) => {
+    const { size = 120, ...rest } = props;
+    const height = Math.round(size * (110 / 160));
+    return (
+      <svg
+        ref={ref}
+        viewBox="0 0 160 110"
+        width={size}
+        height={height}
+        role="img"
+        aria-label="Envelope"
+        {...rest}
+      >
+        <defs>
+          <linearGradient id="ei-body" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stopColor="#F8FAFC" />
+            <stop offset="1" stopColor="#EEF2FF" />
+          </linearGradient>
+          <linearGradient id="ei-flap" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0" stopColor="#FFFFFF" />
+            <stop offset="1" stopColor="#E0E7FF" />
+          </linearGradient>
+        </defs>
+        <rect x="8" y="18" width="144" height="84" rx="8" fill="url(#ei-body)" stroke="#C7D2FE" />
+        <path d="M8 26 L80 70 L152 26" fill="none" stroke="#A5B4FC" strokeWidth="1.2" />
+        <path
+          d="M8 26 L80 2 L152 26 L152 34 L80 12 L8 34 Z"
+          fill="url(#ei-flap)"
+          stroke="#C7D2FE"
+        />
+      </svg>
+    );
+  },
+);
+EnvelopeIllustration.displayName = 'EnvelopeIllustration';

--- a/apps/web/src/components/EnvelopeIllustration/index.ts
+++ b/apps/web/src/components/EnvelopeIllustration/index.ts
@@ -1,0 +1,2 @@
+export { EnvelopeIllustration } from './EnvelopeIllustration';
+export type { EnvelopeIllustrationProps } from './EnvelopeIllustration';

--- a/apps/web/src/components/FilterToolbar/FilterChipPopover.tsx
+++ b/apps/web/src/components/FilterToolbar/FilterChipPopover.tsx
@@ -1,0 +1,146 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { CSSProperties, ReactNode } from 'react';
+import { ChevronDown, X } from 'lucide-react';
+import {
+  ChipButton,
+  ChipLabel,
+  ChipValue,
+  PopoverCard,
+  ChipClearButton,
+} from './FilterToolbar.styles';
+
+export interface FilterChipPopoverProps {
+  /** Static label rendered in the trigger ("Status", "Date", etc.). */
+  readonly label: string;
+  /**
+   * Compact value preview rendered after the label (e.g. "Awaiting
+   * you, +1"). Empty string means no filter is active and the chip
+   * sits in its neutral state.
+   */
+  readonly value: string;
+  /** Renders the chip with the active accent treatment. */
+  readonly active: boolean;
+  /**
+   * Optional clear handler. When provided AND the chip is active, an
+   * inline ✕ button appears that calls this without opening the
+   * popover. Lets the user reset a single filter without first
+   * dismissing the popover.
+   */
+  readonly onClear?: () => void;
+  /** Popover body. Re-rendered each open; keep state owned upstream. */
+  readonly children: ReactNode;
+}
+
+/**
+ * Shared shell for every dashboard filter chip. Opens on click and on
+ * keyboard activation; the popover content portals to `document.body`
+ * so it escapes any `overflow: hidden` ancestor (the dashboard's
+ * TableShell crops the table area — same constraint that bit
+ * SignerStack in PR #225).
+ *
+ * The chip's open/closed state lives here. Filter state itself
+ * (selected statuses, date range, etc.) lives in the URL via the
+ * caller; the popover body is just a controlled UI for it.
+ */
+export const FilterChipPopover = forwardRef<HTMLButtonElement, FilterChipPopoverProps>(
+  (props, ref) => {
+    const { label, value, active, onClear, children } = props;
+    const triggerRef = useRef<HTMLButtonElement | null>(null);
+    useImperativeHandle(ref, () => triggerRef.current as HTMLButtonElement, []);
+    const [open, setOpen] = useState(false);
+    const [anchor, setAnchor] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+
+    const reposition = useCallback(() => {
+      const rect = triggerRef.current?.getBoundingClientRect();
+      if (rect) setAnchor({ top: rect.bottom + 6, left: rect.left });
+    }, []);
+
+    const openPopover = useCallback(() => {
+      reposition();
+      setOpen(true);
+    }, [reposition]);
+
+    // Outside-click / Escape dismiss while the popover is open. We
+    // listen on `document` and only attach the handlers when open so
+    // we don't hold them open for every chip on the page.
+    useEffect(() => {
+      if (!open) return undefined;
+      function onDocPointer(e: MouseEvent) {
+        const target = e.target as Node;
+        const trigger = triggerRef.current;
+        if (trigger && trigger.contains(target)) return;
+        if ((target as HTMLElement | null)?.closest?.('[data-filter-chip-popover]')) return;
+        setOpen(false);
+      }
+      function onKey(e: KeyboardEvent) {
+        if (e.key === 'Escape') setOpen(false);
+      }
+      function onScrollOrResize() {
+        // Update anchor so the popover stays glued to the trigger as
+        // the user scrolls the dashboard or resizes the window.
+        reposition();
+      }
+      document.addEventListener('mousedown', onDocPointer);
+      document.addEventListener('keydown', onKey);
+      window.addEventListener('scroll', onScrollOrResize, true);
+      window.addEventListener('resize', onScrollOrResize);
+      return () => {
+        document.removeEventListener('mousedown', onDocPointer);
+        document.removeEventListener('keydown', onKey);
+        window.removeEventListener('scroll', onScrollOrResize, true);
+        window.removeEventListener('resize', onScrollOrResize);
+      };
+    }, [open, reposition]);
+
+    const popoverStyle: CSSProperties = {
+      position: 'fixed',
+      top: anchor.top,
+      left: anchor.left,
+    };
+
+    return (
+      <>
+        <ChipButton
+          ref={triggerRef}
+          type="button"
+          onClick={openPopover}
+          $active={active}
+          aria-label={`${label} filter`}
+          aria-expanded={open}
+          aria-haspopup="dialog"
+        >
+          <ChipLabel>{label}</ChipLabel>
+          {value !== '' ? <ChipValue>{value}</ChipValue> : null}
+          <ChevronDown size={14} aria-hidden />
+          {active && onClear ? (
+            <ChipClearButton
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onClear();
+              }}
+              aria-label={`Clear ${label} filter`}
+            >
+              <X size={12} aria-hidden />
+            </ChipClearButton>
+          ) : null}
+        </ChipButton>
+        {open && typeof document !== 'undefined'
+          ? createPortal(
+              <PopoverCard
+                role="dialog"
+                aria-label={`${label} filter`}
+                data-filter-chip-popover
+                style={popoverStyle}
+              >
+                {children}
+              </PopoverCard>,
+              document.body,
+            )
+          : null}
+      </>
+    );
+  },
+);
+FilterChipPopover.displayName = 'FilterChipPopover';

--- a/apps/web/src/components/FilterToolbar/FilterToolbar.styles.ts
+++ b/apps/web/src/components/FilterToolbar/FilterToolbar.styles.ts
@@ -1,0 +1,369 @@
+import styled, { css, keyframes } from 'styled-components';
+
+// Mirrors `DownloadMenu`'s `menuIn` so every dropdown surface in the
+// app shares the same enter motion.
+const menuIn = keyframes`
+  from { opacity: 0; transform: translateY(-4px) scale(0.98); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+`;
+
+export const ToolbarRoot = styled.div`
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: ${({ theme }) => theme.space[2]};
+  padding: ${({ theme }) => `${theme.space[3]} 0 ${theme.space[3]}`};
+  margin-top: ${({ theme }) => theme.space[2]};
+`;
+
+const baseChip = css`
+  display: inline-flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[1]};
+  padding: ${({ theme }) => `${theme.space[1]} ${theme.space[3]}`};
+  border-radius: ${({ theme }) => theme.radius.pill};
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  background: ${({ theme }) => theme.color.bg.surface};
+  color: ${({ theme }) => theme.color.fg[1]};
+  font-size: 13px;
+  line-height: 1.4;
+  cursor: pointer;
+  transition:
+    background 80ms,
+    border-color 80ms;
+  &:hover {
+    background: ${({ theme }) => theme.color.ink[50]};
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const ChipButton = styled.button<{ $active: boolean }>`
+  ${baseChip}
+  ${({ theme, $active }) =>
+    $active
+      ? css`
+          border-color: ${theme.color.indigo[500]};
+          background: ${theme.color.indigo[50]};
+          color: ${theme.color.indigo[700]};
+        `
+      : ''}
+`;
+
+export const ChipLabel = styled.span`
+  font-weight: ${({ theme }) => theme.font.weight.medium};
+`;
+
+export const ChipValue = styled.span`
+  color: ${({ theme }) => theme.color.fg[3]};
+  max-width: 180px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const ChipClearButton = styled.button`
+  all: unset;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin-left: ${({ theme }) => theme.space[1]};
+  border-radius: ${({ theme }) => theme.radius.pill};
+  color: ${({ theme }) => theme.color.fg[3]};
+  &:hover {
+    background: ${({ theme }) => theme.color.ink[100]};
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+`;
+
+/**
+ * Search chip is a regular text input rather than a popover trigger
+ * because the search-as-you-type interaction is fundamentally inline.
+ */
+export const SearchInputWrap = styled.label`
+  ${baseChip}
+  flex: 0 1 280px;
+  padding: ${({ theme }) => `${theme.space[1]} ${theme.space[3]}`};
+  cursor: text;
+  &:focus-within {
+    border-color: ${({ theme }) => theme.color.indigo[500]};
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const SearchInput = styled.input`
+  border: none;
+  background: transparent;
+  outline: none;
+  flex: 1;
+  font: inherit;
+  color: inherit;
+  &::placeholder {
+    color: ${({ theme }) => theme.color.fg[3]};
+  }
+`;
+
+export const SearchClear = styled.button`
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: ${({ theme }) => theme.radius.pill};
+  color: ${({ theme }) => theme.color.fg[3]};
+  cursor: pointer;
+  &:hover {
+    background: ${({ theme }) => theme.color.ink[100]};
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+// Matches the `DownloadMenu.Menu` surface: 14px radius, full pad,
+// large soft shadow, and the same enter animation. Keeps every
+// dropdown in the app reading as one design language.
+export const PopoverCard = styled.div`
+  z-index: 20;
+  min-width: 280px;
+  max-width: 360px;
+  padding: ${({ theme }) => theme.space[2]};
+  background: ${({ theme }) => theme.color.bg.surface};
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  border-radius: 14px;
+  box-shadow: ${({ theme }) => theme.shadow.lg};
+  display: flex;
+  flex-direction: column;
+  font-family: ${({ theme }) => theme.font.sans};
+  animation: ${menuIn} 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
+`;
+
+// Equivalent of `DownloadMenu.MenuHeading` — uppercase mono kicker
+// that opens each section.
+export const PopoverHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px 6px;
+  font-family: ${({ theme }) => theme.font.mono};
+  font-size: 11px;
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  letter-spacing: 0.08em;
+  color: ${({ theme }) => theme.color.fg[3]};
+  text-transform: uppercase;
+`;
+
+export const PopoverHeaderAction = styled.button`
+  all: unset;
+  font-family: ${({ theme }) => theme.font.sans};
+  font-size: 12px;
+  text-transform: none;
+  letter-spacing: 0;
+  color: ${({ theme }) => theme.color.indigo[600]};
+  cursor: pointer;
+  &:hover {
+    text-decoration: underline;
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+// `DownloadMenu.Item` analogue. Larger touch target, 10px padding
+// and rounded radius, hover background. The full row is the click
+// affordance; consumers nest the checkbox/radio + label inside.
+//
+// Tints native checkboxes / radios with the brand indigo via the
+// modern `accent-color` property — works in every browser we
+// target (Chromium 93+, Safari 15.4+, Firefox 92+) and avoids
+// having to re-implement the input chrome.
+export const Option = styled.label<{ $disabled?: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[3]};
+  padding: 10px;
+  border-radius: 10px;
+  font-size: 13px;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  transition: background 140ms;
+  accent-color: ${({ theme }) => theme.color.indigo[600]};
+  & input[type='checkbox'],
+  & input[type='radio'] {
+    width: 16px;
+    height: 16px;
+    flex-shrink: 0;
+    cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  }
+  &:hover {
+    background: ${({ theme }) => theme.color.ink[50]};
+  }
+`;
+
+// Square icon slot to the left of each option — same dimensions as
+// `DownloadMenu.ItemIcon`. Status chips drop a colored status dot
+// inside; signer chips drop an initials avatar.
+export const OptionIcon = styled.div<{
+  $tone?: 'indigo' | 'amber' | 'emerald' | 'red' | 'neutral';
+}>`
+  width: 36px;
+  height: 36px;
+  border-radius: 9px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${({ theme, $tone }) => {
+    switch ($tone) {
+      case 'indigo':
+        return theme.color.indigo[50];
+      case 'amber':
+        return theme.color.warn[50];
+      case 'emerald':
+        return theme.color.success[50];
+      case 'red':
+        return theme.color.danger[50];
+      default:
+        return theme.color.ink[50];
+    }
+  }};
+  border: 1px solid
+    ${({ theme, $tone }) => ($tone === 'indigo' ? theme.color.indigo[200] : theme.color.border[1])};
+  color: ${({ theme, $tone }) => {
+    switch ($tone) {
+      case 'indigo':
+        return theme.color.indigo[600];
+      case 'amber':
+        return theme.color.warn[700];
+      case 'emerald':
+        return theme.color.success[700];
+      case 'red':
+        return theme.color.danger[700];
+      default:
+        return theme.color.fg[2];
+    }
+  }};
+`;
+
+export const OptionBody = styled.div`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export const OptionLabel = styled.span`
+  flex: 1;
+  font-size: 13px;
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.fg[1]};
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
+export const OptionDesc = styled.span`
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  line-height: 1.45;
+`;
+
+// Right-aligned monospace count badge (matches `ItemMeta` rhythm).
+export const OptionCount = styled.span`
+  font-family: ${({ theme }) => theme.font.mono};
+  font-size: 11px;
+  color: ${({ theme }) => theme.color.fg[3]};
+`;
+
+// Equivalent of `DownloadMenu.Footer` — tucks the divider + small
+// helper note at the bottom of a popover.
+export const PopoverFooter = styled.div`
+  padding: 10px 10px 4px;
+  border-top: 1px solid ${({ theme }) => theme.color.border[1]};
+  margin-top: 6px;
+  font-size: 11px;
+  color: ${({ theme }) => theme.color.fg[4]};
+  line-height: 1.5;
+  display: flex;
+  gap: ${({ theme }) => theme.space[2]};
+  align-items: flex-start;
+`;
+
+export const PopoverFooterIcon = styled.span`
+  color: ${({ theme }) => theme.color.fg[4]};
+  margin-top: 2px;
+  flex-shrink: 0;
+  display: inline-flex;
+`;
+
+// Match the option-row text size (13 px) instead of inheriting the
+// page's default body font, which made the placeholder dwarf the
+// rest of the popover (bug 2026-05-10).
+export const SignerInput = styled.input`
+  margin: 4px 6px 6px;
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: ${({ theme }) => theme.font.sans};
+  font-size: 13px;
+  line-height: 1.4;
+  background: ${({ theme }) => theme.color.bg.surface};
+  color: ${({ theme }) => theme.color.fg[1]};
+  &::placeholder {
+    color: ${({ theme }) => theme.color.fg[3]};
+  }
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.color.indigo[500]};
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const CustomDateRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: ${({ theme }) => theme.space[2]};
+  padding: ${({ theme }) => `${theme.space[1]} ${theme.space[2]}`};
+`;
+
+export const CustomDateField = styled.input`
+  border: 1px solid ${({ theme }) => theme.color.border[1]};
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-family: ${({ theme }) => theme.font.sans};
+  font-size: 13px;
+  line-height: 1.4;
+  background: ${({ theme }) => theme.color.bg.surface};
+  color: ${({ theme }) => theme.color.fg[1]};
+  &:focus {
+    outline: none;
+    border-color: ${({ theme }) => theme.color.indigo[500]};
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const ResetButton = styled.button`
+  all: unset;
+  font-size: 12px;
+  color: ${({ theme }) => theme.color.fg[3]};
+  cursor: pointer;
+  padding: ${({ theme }) => `${theme.space[1]} ${theme.space[2]}`};
+  border-radius: ${({ theme }) => theme.radius.pill};
+  &:hover {
+    color: ${({ theme }) => theme.color.fg[1]};
+    background: ${({ theme }) => theme.color.ink[50]};
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;

--- a/apps/web/src/components/FilterToolbar/FilterToolbar.tsx
+++ b/apps/web/src/components/FilterToolbar/FilterToolbar.tsx
@@ -1,0 +1,516 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { Info, Search, X } from 'lucide-react';
+import type { EnvelopeListItem } from 'shared';
+import {
+  parseFilters,
+  serializeFilters,
+  type EnvelopeFilters,
+  type StatusOption,
+  type DateFilter,
+  type DatePreset,
+  bucketEnvelope,
+} from '@/features/dashboardFilters';
+import { FilterChipPopover } from './FilterChipPopover';
+import {
+  CustomDateField,
+  CustomDateRow,
+  Option,
+  OptionBody,
+  OptionCount,
+  OptionDesc,
+  OptionLabel,
+  PopoverFooter,
+  PopoverFooterIcon,
+  PopoverHeader,
+  PopoverHeaderAction,
+  ResetButton,
+  SearchClear,
+  SearchInput,
+  SearchInputWrap,
+  SignerInput,
+  ToolbarRoot,
+} from './FilterToolbar.styles';
+
+const STATUS_LABELS: Record<StatusOption, string> = {
+  draft: 'Draft',
+  awaiting_you: 'Awaiting you',
+  awaiting_others: 'Awaiting others',
+  sealed: 'Sealed',
+  declined: 'Declined',
+};
+
+const STATUS_DESCRIPTIONS: Record<StatusOption, string> = {
+  draft: 'Not sent yet',
+  awaiting_you: 'Your turn to sign',
+  awaiting_others: 'Out for signature',
+  sealed: 'All signers complete',
+  declined: 'Someone declined',
+};
+
+const DATE_PRESET_LABELS: Record<DatePreset, string> = {
+  today: 'Today',
+  '7d': 'Last 7 days',
+  '30d': 'Last 30 days',
+  thisMonth: 'This month',
+  all: 'All time',
+};
+
+const DATE_PRESET_DESCRIPTIONS: Record<DatePreset, string> = {
+  today: 'Activity in the last 24 hours',
+  '7d': 'A week of recent activity',
+  '30d': 'Roughly the last month',
+  thisMonth: 'From the 1st of this month',
+  all: 'No date filter',
+};
+
+const STATUS_ORDER: ReadonlyArray<StatusOption> = [
+  'awaiting_you',
+  'awaiting_others',
+  'draft',
+  'sealed',
+  'declined',
+];
+const PRESET_ORDER: ReadonlyArray<DatePreset> = ['today', '7d', '30d', 'thisMonth', 'all'];
+
+export interface FilterToolbarProps {
+  /**
+   * Current envelope list. Used to derive status counts (shown in the
+   * Status chip popover) and the unique signer roster (shown in the
+   * Signer chip popover). The toolbar does not filter; the page does.
+   */
+  readonly envelopes: ReadonlyArray<EnvelopeListItem>;
+  /**
+   * Viewer email — needed for the awaiting-you bucket count. Pass
+   * `null` for unauthenticated viewers (count for awaiting-you will
+   * be zero in that case, which is also correct).
+   */
+  readonly viewerEmail: string | null;
+}
+
+interface DraftRange {
+  readonly from: string;
+  readonly to: string;
+}
+
+export function FilterToolbar({ envelopes, viewerEmail }: FilterToolbarProps) {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const filters = useMemo(() => parseFilters(searchParams), [searchParams]);
+
+  // Local-only buffer for the search input so the user gets instant
+  // typing feedback without writing the URL on every keystroke. The
+  // debounced effect below is the single source that pushes to the
+  // URL after 250 ms of silence — the spec's "do not overwhelm"
+  // contract for the search field.
+  const [searchDraft, setSearchDraft] = useState(filters.q);
+  // Re-sync the draft when the URL changes from elsewhere (e.g. the
+  // Clear chip stripping every param). Skipped while the user is
+  // mid-typing — the debounced write below will reconcile.
+  const userTypingRef = useRef(false);
+  useEffect(() => {
+    if (!userTypingRef.current) setSearchDraft(filters.q);
+  }, [filters.q]);
+
+  // Debounced write of the search draft to the URL. Replace history
+  // (don't push) so back-button doesn't accumulate every keystroke.
+  useEffect(() => {
+    if (searchDraft === filters.q) return undefined;
+    const t = setTimeout(() => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (searchDraft === '') next.delete('q');
+          else next.set('q', searchDraft);
+          return next;
+        },
+        { replace: true },
+      );
+      userTypingRef.current = false;
+    }, 250);
+    return () => clearTimeout(t);
+  }, [searchDraft, filters.q, setSearchParams]);
+
+  /** Replace the entire filter set, leaving non-filter params alone. */
+  const applyFilters = useCallback(
+    (next: { filters: EnvelopeFilters; explicitAllStatus?: boolean }) => {
+      setSearchParams(
+        (prev) => {
+          const carrier = new URLSearchParams(prev);
+          carrier.delete('q');
+          carrier.delete('status');
+          carrier.delete('date');
+          carrier.delete('signer');
+          const written = new URLSearchParams(
+            serializeFilters({
+              ...next.filters,
+              ...(next.explicitAllStatus !== undefined
+                ? { explicitAllStatus: next.explicitAllStatus }
+                : {}),
+            }),
+          );
+          for (const [k, v] of written) carrier.set(k, v);
+          return carrier;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const setStatus = useCallback(
+    (next: ReadonlyArray<StatusOption>, options?: { explicitAllStatus?: boolean }) => {
+      applyFilters({
+        filters: { ...filters, status: next },
+        ...(options?.explicitAllStatus !== undefined
+          ? { explicitAllStatus: options.explicitAllStatus }
+          : {}),
+      });
+    },
+    [applyFilters, filters],
+  );
+
+  const setDate = useCallback(
+    (next: DateFilter) => {
+      applyFilters({ filters: { ...filters, date: next } });
+    },
+    [applyFilters, filters],
+  );
+
+  const setSigner = useCallback(
+    (next: ReadonlyArray<string>) => {
+      applyFilters({ filters: { ...filters, signer: next } });
+    },
+    [applyFilters, filters],
+  );
+
+  // Local-only buffer for the in-popover signer search box. The
+  // search just narrows the visible list of selectable signers; only
+  // the checkbox toggle actually changes the URL filter.
+  const [signerSearch, setSignerSearch] = useState('');
+
+  const clearAll = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete('q');
+        next.delete('status');
+        next.delete('date');
+        next.delete('signer');
+        return next;
+      },
+      { replace: true },
+    );
+    setSearchDraft('');
+    userTypingRef.current = false;
+  }, [setSearchParams]);
+
+  // Derived: status counts (for the Status chip's popover) and the
+  // unique signer list (for the Signer chip's popover). Both are
+  // O(envelopes) so a single useMemo over the source list keeps the
+  // toolbar render cheap.
+  const statusCounts = useMemo(() => {
+    const counts = new Map<StatusOption, number>();
+    for (const env of envelopes) {
+      const bucket = bucketEnvelope(env, viewerEmail);
+      if (bucket !== null) counts.set(bucket, (counts.get(bucket) ?? 0) + 1);
+    }
+    return counts;
+  }, [envelopes, viewerEmail]);
+
+  const uniqueSigners = useMemo(() => {
+    const map = new Map<string, { name: string; email: string }>();
+    for (const env of envelopes) {
+      for (const s of env.signers) {
+        const key = s.email.toLowerCase();
+        if (!map.has(key)) map.set(key, { name: s.name, email: s.email });
+      }
+    }
+    return Array.from(map.values()).sort(
+      (a, b) => a.name.localeCompare(b.name) || a.email.localeCompare(b.email),
+    );
+  }, [envelopes]);
+
+  // Active flags drive the chip's accent + clear-button affordance.
+  // Search active is computed from the draft so the chip lights up
+  // immediately while typing, before the URL has been written.
+  const isStatusActive = filters.status.length > 0;
+  const isDateActive = filters.date.kind !== 'preset' || filters.date.preset !== 'all';
+  const isSignerActive = filters.signer.length > 0;
+  const isSearchActive = searchDraft !== '';
+  const anyActive = isStatusActive || isDateActive || isSignerActive || isSearchActive;
+
+  // Compact value previews shown in the trigger when a chip is active.
+  const statusPreview = formatStatusPreview(filters.status);
+  const datePreview = formatDatePreview(filters.date);
+  const signerPreview = formatSignerPreview(filters.signer, uniqueSigners);
+
+  // Local draft for custom date range until the user blurs / picks an
+  // explicit preset — saves a URL write per arrow-key on the date input.
+  const [draftRange, setDraftRange] = useState<DraftRange>(() => {
+    if (filters.date.kind === 'custom') return filters.date.range;
+    return { from: '', to: '' };
+  });
+  useEffect(() => {
+    if (filters.date.kind === 'custom') setDraftRange(filters.date.range);
+  }, [filters.date]);
+
+  return (
+    <ToolbarRoot role="toolbar" aria-label="Document filters">
+      <SearchInputWrap>
+        <Search size={14} aria-hidden />
+        <SearchInput
+          type="search"
+          placeholder="Search documents…"
+          value={searchDraft}
+          onChange={(e) => {
+            userTypingRef.current = true;
+            setSearchDraft(e.target.value);
+          }}
+          aria-label="Search documents"
+        />
+        {searchDraft !== '' ? (
+          <SearchClear
+            type="button"
+            onClick={() => {
+              userTypingRef.current = false;
+              setSearchDraft('');
+              setSearchParams(
+                (prev) => {
+                  const next = new URLSearchParams(prev);
+                  next.delete('q');
+                  return next;
+                },
+                { replace: true },
+              );
+            }}
+            aria-label="Clear search"
+          >
+            <X size={14} aria-hidden />
+          </SearchClear>
+        ) : null}
+      </SearchInputWrap>
+
+      <FilterChipPopover
+        label="Status"
+        value={statusPreview}
+        active={isStatusActive}
+        {...(isStatusActive ? { onClear: () => setStatus([]) } : {})}
+      >
+        <PopoverHeader>
+          <span>Status</span>
+          {/* Smart toggle: when at least one option is checked the
+              header link becomes "Deselect all" (un-ticks every box
+              + writes the `?status=all` sentinel so the actionable
+              inbox default doesn't re-apply on reload). When nothing
+              is checked the link flips to "Select all" and ticks
+              every option in one click. */}
+          {filters.status.length > 0 ? (
+            <PopoverHeaderAction
+              type="button"
+              onClick={() => setStatus([], { explicitAllStatus: true })}
+            >
+              Deselect all
+            </PopoverHeaderAction>
+          ) : (
+            <PopoverHeaderAction type="button" onClick={() => setStatus([...STATUS_ORDER])}>
+              Select all
+            </PopoverHeaderAction>
+          )}
+        </PopoverHeader>
+        {STATUS_ORDER.map((opt) => {
+          const checked = filters.status.includes(opt);
+          const count = statusCounts.get(opt) ?? 0;
+          return (
+            <Option key={opt}>
+              <input
+                type="checkbox"
+                checked={checked}
+                onChange={(e) => {
+                  const isOn = e.currentTarget.checked;
+                  const next = isOn
+                    ? [...filters.status, opt]
+                    : filters.status.filter((s) => s !== opt);
+                  setStatus(next);
+                }}
+                aria-label={STATUS_LABELS[opt]}
+              />
+              <OptionBody>
+                <OptionLabel>{STATUS_LABELS[opt]}</OptionLabel>
+                <OptionDesc>{STATUS_DESCRIPTIONS[opt]}</OptionDesc>
+              </OptionBody>
+              <OptionCount>{count}</OptionCount>
+            </Option>
+          );
+        })}
+      </FilterChipPopover>
+
+      <FilterChipPopover
+        label="Date"
+        value={datePreview}
+        active={isDateActive}
+        {...(isDateActive ? { onClear: () => setDate({ kind: 'preset', preset: 'all' }) } : {})}
+      >
+        <PopoverHeader>
+          <span>Last activity</span>
+        </PopoverHeader>
+        {PRESET_ORDER.map((preset) => {
+          const checked = filters.date.kind === 'preset' && filters.date.preset === preset;
+          return (
+            <Option key={preset}>
+              <input
+                type="radio"
+                name="date-preset"
+                checked={checked}
+                onChange={() => setDate({ kind: 'preset', preset })}
+                aria-label={DATE_PRESET_LABELS[preset]}
+              />
+              <OptionBody>
+                <OptionLabel>{DATE_PRESET_LABELS[preset]}</OptionLabel>
+                <OptionDesc>{DATE_PRESET_DESCRIPTIONS[preset]}</OptionDesc>
+              </OptionBody>
+            </Option>
+          );
+        })}
+        <PopoverHeader>
+          <span>Custom range</span>
+        </PopoverHeader>
+        <CustomDateRow>
+          <CustomDateField
+            type="date"
+            value={draftRange.from}
+            onChange={(e) => setDraftRange((p) => ({ ...p, from: e.target.value }))}
+            onBlur={() => {
+              if (
+                draftRange.from !== '' &&
+                draftRange.to !== '' &&
+                draftRange.from <= draftRange.to
+              ) {
+                setDate({ kind: 'custom', range: draftRange });
+              }
+            }}
+            aria-label="From"
+          />
+          <CustomDateField
+            type="date"
+            value={draftRange.to}
+            onChange={(e) => setDraftRange((p) => ({ ...p, to: e.target.value }))}
+            onBlur={() => {
+              if (
+                draftRange.from !== '' &&
+                draftRange.to !== '' &&
+                draftRange.from <= draftRange.to
+              ) {
+                setDate({ kind: 'custom', range: draftRange });
+              }
+            }}
+            aria-label="To"
+          />
+        </CustomDateRow>
+      </FilterChipPopover>
+
+      <FilterChipPopover
+        label="Signer"
+        value={signerPreview}
+        active={isSignerActive}
+        {...(isSignerActive ? { onClear: () => setSigner([]) } : {})}
+      >
+        <PopoverHeader>
+          <span>Signer</span>
+          {filters.signer.length > 0 ? (
+            <PopoverHeaderAction type="button" onClick={() => setSigner([])}>
+              Clear
+            </PopoverHeaderAction>
+          ) : null}
+        </PopoverHeader>
+        <SignerInput
+          type="search"
+          placeholder="Search by name or email…"
+          value={signerSearch}
+          onChange={(e) => setSignerSearch(e.target.value)}
+          aria-label="Search signers"
+        />
+        {uniqueSigners.length > 0 ? (
+          <div role="list" style={{ maxHeight: 260, overflowY: 'auto' }}>
+            {uniqueSigners
+              .filter((s) => {
+                if (signerSearch === '') return true;
+                const needle = signerSearch.toLowerCase();
+                return (
+                  s.name.toLowerCase().includes(needle) || s.email.toLowerCase().includes(needle)
+                );
+              })
+              .slice(0, 50)
+              .map((s) => {
+                const key = s.email.toLowerCase();
+                const checked = filters.signer.includes(key);
+                // Name only; fall back to the email's local part
+                // when the contact has no display name.
+                const display = s.name.trim() !== '' ? s.name : s.email.split('@')[0] || s.email;
+                return (
+                  <Option key={s.email} role="listitem">
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        const isOn = e.currentTarget.checked;
+                        setSigner(
+                          isOn ? [...filters.signer, key] : filters.signer.filter((x) => x !== key),
+                        );
+                      }}
+                      aria-label={display}
+                    />
+                    <OptionBody>
+                      <OptionLabel>{display}</OptionLabel>
+                    </OptionBody>
+                  </Option>
+                );
+              })}
+          </div>
+        ) : null}
+        <PopoverFooter>
+          <PopoverFooterIcon>
+            <Info size={12} aria-hidden />
+          </PopoverFooterIcon>
+          <span>Pick multiple to see envelopes that include any of them.</span>
+        </PopoverFooter>
+      </FilterChipPopover>
+
+      {anyActive ? (
+        <ResetButton type="button" onClick={clearAll} aria-label="Clear all filters">
+          ✕ Clear filters
+        </ResetButton>
+      ) : null}
+    </ToolbarRoot>
+  );
+}
+
+function formatStatusPreview(selected: ReadonlyArray<StatusOption>): string {
+  if (selected.length === 0) return '';
+  if (selected.length === 1) return STATUS_LABELS[selected[0]!];
+  return `${STATUS_LABELS[selected[0]!]}, +${selected.length - 1}`;
+}
+
+function formatDatePreview(date: DateFilter): string {
+  if (date.kind === 'custom') return `${date.range.from} → ${date.range.to}`;
+  if (date.preset === 'all') return '';
+  return DATE_PRESET_LABELS[date.preset];
+}
+
+function formatSignerPreview(
+  selected: ReadonlyArray<string>,
+  roster: ReadonlyArray<{ name: string; email: string }>,
+): string {
+  if (selected.length === 0) return '';
+  // Resolve each selected email back to a display name so the chip
+  // preview reads "Eliran" instead of "eliran@nromomentum.com". Fall
+  // back to the email's local part when the contact has no name.
+  const byEmail = new Map(roster.map((s) => [s.email.toLowerCase(), s] as const));
+  const displays = selected.map((emailKey) => {
+    const found = byEmail.get(emailKey);
+    if (found && found.name.trim() !== '') return found.name;
+    if (found) return found.email.split('@')[0] ?? found.email;
+    return emailKey.split('@')[0] ?? emailKey;
+  });
+  if (displays.length === 1) return displays[0]!;
+  return `${displays[0]!}, +${displays.length - 1}`;
+}

--- a/apps/web/src/components/FilterToolbar/index.ts
+++ b/apps/web/src/components/FilterToolbar/index.ts
@@ -1,0 +1,2 @@
+export { FilterToolbar } from './FilterToolbar';
+export type { FilterToolbarProps } from './FilterToolbar';

--- a/apps/web/src/components/SignerStack/SignerStack.styles.ts
+++ b/apps/web/src/components/SignerStack/SignerStack.styles.ts
@@ -74,10 +74,11 @@ export const Fraction = styled.span`
   white-space: nowrap;
 `;
 
+// Top/left/position are supplied at the call site via an inline style
+// because the popover is portaled to document.body and pinned to the
+// trigger's measured viewport rect. Keeping the static styles here so
+// styled-components still owns the visual treatment.
 export const Popover = styled.div`
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
   z-index: 10;
   min-width: 240px;
   max-width: 320px;

--- a/apps/web/src/components/SignerStack/SignerStack.test.tsx
+++ b/apps/web/src/components/SignerStack/SignerStack.test.tsx
@@ -51,6 +51,38 @@ describe('SignerStack', () => {
     expect(screen.queryByText('bob@example.com')).not.toBeInTheDocument();
   });
 
+  // Bug 2026-05-10 (user report): on the dashboard, hovering the
+  // signer-stack pill rendered the popover inside the table row,
+  // and the surrounding `TableShell` (which has `overflow: hidden`
+  // to clip the bottom rounded corners) cut the popover off — only
+  // a thin sliver was visible. Asserts the popover renders OUTSIDE
+  // its containing overflow box (i.e. via a portal to document.body).
+  it('renders the popover outside an `overflow: hidden` ancestor (portaled)', async () => {
+    const user = userEvent.setup();
+    const wrapper = document.createElement('div');
+    wrapper.setAttribute('data-testid', 'overflow-clipper');
+    wrapper.style.overflow = 'hidden';
+    document.body.appendChild(wrapper);
+    const { container, unmount } = renderWithTheme(
+      <SignerStack
+        signers={[
+          mk({ id: '1', name: 'Ada Lovelace', email: 'ada@example.com', status: 'signed' }),
+        ]}
+      />,
+      { container: wrapper },
+    );
+    const root = container.firstElementChild as HTMLElement;
+    await user.hover(root);
+    const popoverContent = screen.getByText('ada@example.com');
+    // The popover row's text must be reachable, and its DOM ancestry
+    // must NOT pass through the overflow-hidden wrapper — otherwise
+    // it would still be clipped on screen.
+    expect(popoverContent).toBeInTheDocument();
+    expect(wrapper.contains(popoverContent)).toBe(false);
+    unmount();
+    document.body.removeChild(wrapper);
+  });
+
   it('counts only signed signers in the fraction', () => {
     renderWithTheme(
       <SignerStack

--- a/apps/web/src/components/SignerStack/SignerStack.tsx
+++ b/apps/web/src/components/SignerStack/SignerStack.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useState, useCallback, useId } from 'react';
+import { forwardRef, useCallback, useId, useImperativeHandle, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Badge } from '../Badge';
 import type { BadgeTone } from '../Badge/Badge.types';
 import type { SignerStackProps, SignerStackStatus } from './SignerStack.types';
@@ -45,11 +46,32 @@ function initialsOf(name: string): string {
  * overflow chip, and a mono signed/total fraction. Hover or focus
  * reveals a popover listing every signer with a status pill.
  */
+// Default position when we open before measuring (e.g. SSR / first
+// render). Off-screen so it can't flash in the wrong spot if the
+// measurement read fails.
+const DEFAULT_ANCHOR = { top: -9999, left: -9999 } as const;
+
 export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, ref) => {
   const { signers, maxVisible = 4, onMouseEnter, onMouseLeave, onFocus, onBlur, ...rest } = props;
   const popoverId = useId();
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  // Forward our internal ref so consumers' refs still work.
+  useImperativeHandle(ref, () => rootRef.current as HTMLDivElement, []);
+
+  // `open` toggles render; `anchor` carries the viewport-relative
+  // coordinates the portaled popover uses. We measure on each show
+  // because the anchor position can change between hides (scroll,
+  // resize, list reorder) without us getting an event.
   const [open, setOpen] = useState(false);
-  const show = useCallback(() => setOpen(true), []);
+  const [anchor, setAnchor] = useState<{ top: number; left: number }>(DEFAULT_ANCHOR);
+
+  const show = useCallback(() => {
+    const rect = rootRef.current?.getBoundingClientRect();
+    if (rect) {
+      setAnchor({ top: rect.bottom + 6, left: rect.left });
+    }
+    setOpen(true);
+  }, []);
   const hide = useCallback(() => setOpen(false), []);
 
   const total = signers.length;
@@ -57,9 +79,41 @@ export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, 
   const visible = signers.slice(0, maxVisible);
   const overflow = total - visible.length;
 
+  // The popover is portaled to `document.body` so it can escape any
+  // ancestor with `overflow: hidden` (the dashboard's TableShell
+  // clipped it before — bug 2026-05-10). We pin it via
+  // `position: fixed` + the measured anchor instead of leaning on
+  // the trigger's containing block.
+  const popoverNode =
+    open && total > 0 && typeof document !== 'undefined'
+      ? createPortal(
+          <Popover
+            id={popoverId}
+            role="tooltip"
+            style={{ position: 'fixed', top: anchor.top, left: anchor.left }}
+          >
+            {signers.map((s) => (
+              <PopoverRow key={s.id}>
+                <Avatar as="span" $status={s.status} aria-hidden>
+                  {initialsOf(s.name)}
+                </Avatar>
+                <PopoverMeta>
+                  <PopoverName>{s.name}</PopoverName>
+                  <PopoverEmail>{s.email}</PopoverEmail>
+                </PopoverMeta>
+                <Badge tone={STATUS_TONE[s.status]} dot={false}>
+                  {STATUS_LABEL[s.status]}
+                </Badge>
+              </PopoverRow>
+            ))}
+          </Popover>,
+          document.body,
+        )
+      : null;
+
   return (
     <Root
-      ref={ref}
+      ref={rootRef}
       onMouseEnter={(e) => {
         show();
         onMouseEnter?.(e);
@@ -97,24 +151,7 @@ export const SignerStack = forwardRef<HTMLDivElement, SignerStackProps>((props, 
       <Fraction aria-label={`${signed} of ${total} signed`}>
         {signed}/{total} signed
       </Fraction>
-      {open && total > 0 && (
-        <Popover id={popoverId} role="tooltip">
-          {signers.map((s) => (
-            <PopoverRow key={s.id}>
-              <Avatar as="span" $status={s.status} aria-hidden>
-                {initialsOf(s.name)}
-              </Avatar>
-              <PopoverMeta>
-                <PopoverName>{s.name}</PopoverName>
-                <PopoverEmail>{s.email}</PopoverEmail>
-              </PopoverMeta>
-              <Badge tone={STATUS_TONE[s.status]} dot={false}>
-                {STATUS_LABEL[s.status]}
-              </Badge>
-            </PopoverRow>
-          ))}
-        </Popover>
-      )}
+      {popoverNode}
     </Root>
   );
 });

--- a/apps/web/src/features/dashboardFilters/filterEnvelopes.test.ts
+++ b/apps/web/src/features/dashboardFilters/filterEnvelopes.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { EnvelopeListItem } from 'shared';
+import { filterEnvelopes, isAwaitingYou } from './filterEnvelopes';
+import { ACTIONABLE_INBOX, type EnvelopeFilters } from './types';
+
+function envelope(over: Partial<EnvelopeListItem> = {}): EnvelopeListItem {
+  return {
+    id: over.id ?? 'env-1',
+    title: over.title ?? 'Untitled',
+    short_code: over.short_code ?? 'abc12345',
+    status: over.status ?? 'draft',
+    original_pages: over.original_pages ?? 1,
+    sent_at: over.sent_at ?? null,
+    completed_at: over.completed_at ?? null,
+    expires_at: over.expires_at ?? null,
+    created_at: over.created_at ?? '2026-05-01T00:00:00Z',
+    updated_at: over.updated_at ?? '2026-05-01T00:00:00Z',
+    signers: over.signers ?? [],
+  } as EnvelopeListItem;
+}
+
+const NO_FILTER: EnvelopeFilters = {
+  q: '',
+  status: [],
+  date: { kind: 'preset', preset: 'all' },
+  signer: [],
+};
+
+describe('filterEnvelopes', () => {
+  it('returns the input unchanged when every filter is in the no-op state', () => {
+    const list = [envelope({ id: '1' }), envelope({ id: '2' })];
+    expect(filterEnvelopes(list, NO_FILTER, null)).toEqual(list);
+  });
+
+  describe('search (q)', () => {
+    it('matches a substring of the document title (case-insensitive)', () => {
+      const list = [
+        envelope({ id: '1', title: 'Acme Master Service Agreement' }),
+        envelope({ id: '2', title: 'Other doc' }),
+      ];
+      const out = filterEnvelopes(list, { ...NO_FILTER, q: 'acme' }, null);
+      expect(out.map((e) => e.id)).toEqual(['1']);
+    });
+
+    it('matches a substring of the envelope short code', () => {
+      const list = [
+        envelope({ id: '1', short_code: 'm6nHh9mL7jbvx' }),
+        envelope({ id: '2', short_code: 'zzzzzz' }),
+      ];
+      const out = filterEnvelopes(list, { ...NO_FILTER, q: '7jbvx' }, null);
+      expect(out.map((e) => e.id)).toEqual(['1']);
+    });
+  });
+
+  describe('status filter', () => {
+    it('does not filter when status is the empty array (caller "select all")', () => {
+      const list = [
+        envelope({ id: '1', status: 'draft' }),
+        envelope({ id: '2', status: 'completed' }),
+      ];
+      expect(filterEnvelopes(list, { ...NO_FILTER, status: [] }, null)).toEqual(list);
+    });
+
+    it('keeps only envelopes whose status matches one of the selected options', () => {
+      const list = [
+        envelope({ id: '1', status: 'draft' }),
+        envelope({ id: '2', status: 'completed' }),
+        envelope({ id: '3', status: 'awaiting_others' }),
+      ];
+      const out = filterEnvelopes(list, { ...NO_FILTER, status: ['draft', 'sealed'] }, null);
+      expect(out.map((e) => e.id)).toEqual(['1', '2']);
+    });
+
+    it('honors the actionable-inbox default (mutual-exclusion with awaiting-you)', () => {
+      // Envelope 1: awaiting_others, viewer is a signer who hasn't acted → awaiting_you
+      // Envelope 2: awaiting_others, viewer is NOT a signer → awaiting_others
+      // Envelope 3: completed → out
+      const list = [
+        envelope({
+          id: '1',
+          status: 'awaiting_others',
+          signers: [
+            {
+              id: 's1',
+              name: 'You',
+              email: 'you@example.com',
+              status: 'awaiting',
+            },
+          ] as EnvelopeListItem['signers'],
+        }),
+        envelope({
+          id: '2',
+          status: 'awaiting_others',
+          signers: [
+            {
+              id: 's2',
+              name: 'Other',
+              email: 'other@example.com',
+              status: 'awaiting',
+            },
+          ] as EnvelopeListItem['signers'],
+        }),
+        envelope({ id: '3', status: 'completed' }),
+      ];
+      const out = filterEnvelopes(
+        list,
+        { ...NO_FILTER, status: [...ACTIONABLE_INBOX] },
+        'you@example.com',
+      );
+      expect(out.map((e) => e.id)).toEqual(['1', '2']);
+    });
+  });
+
+  describe('date filter (binds to updated_at)', () => {
+    beforeEach(() => {
+      // Pin "now" to 2026-05-10T12:00:00Z for predictable preset windows.
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('preset "today" includes today and excludes yesterday', () => {
+      const list = [
+        envelope({ id: 'today', updated_at: '2026-05-10T03:00:00Z' }),
+        envelope({ id: 'yesterday', updated_at: '2026-05-09T23:59:00Z' }),
+      ];
+      const out = filterEnvelopes(
+        list,
+        { ...NO_FILTER, date: { kind: 'preset', preset: 'today' } },
+        null,
+      );
+      expect(out.map((e) => e.id)).toEqual(['today']);
+    });
+
+    it('preset "7d" includes the last 7 calendar days', () => {
+      const list = [
+        envelope({ id: 'fresh', updated_at: '2026-05-10T00:00:00Z' }),
+        envelope({ id: 'edge', updated_at: '2026-05-04T00:00:00Z' }),
+        envelope({ id: 'stale', updated_at: '2026-04-30T00:00:00Z' }),
+      ];
+      const out = filterEnvelopes(
+        list,
+        { ...NO_FILTER, date: { kind: 'preset', preset: '7d' } },
+        null,
+      );
+      expect(out.map((e) => e.id).sort()).toEqual(['edge', 'fresh']);
+    });
+
+    it('custom range is inclusive on both ends', () => {
+      const list = [
+        envelope({ id: 'before', updated_at: '2026-04-30T23:59:00Z' }),
+        envelope({ id: 'lower', updated_at: '2026-05-01T00:00:00Z' }),
+        envelope({ id: 'inside', updated_at: '2026-05-05T12:00:00Z' }),
+        envelope({ id: 'upper', updated_at: '2026-05-10T23:59:00Z' }),
+        envelope({ id: 'after', updated_at: '2026-05-11T00:00:00Z' }),
+      ];
+      const out = filterEnvelopes(
+        list,
+        {
+          ...NO_FILTER,
+          date: { kind: 'custom', range: { from: '2026-05-01', to: '2026-05-10' } },
+        },
+        null,
+      );
+      expect(out.map((e) => e.id).sort()).toEqual(['inside', 'lower', 'upper']);
+    });
+  });
+
+  describe('signer filter', () => {
+    it('matches envelopes whose signer email is in the selected set', () => {
+      const list = [
+        envelope({
+          id: '1',
+          signers: [
+            { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        envelope({
+          id: '2',
+          signers: [
+            { id: 's2', name: 'Bob', email: 'bob@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+      ];
+      const out = filterEnvelopes(list, { ...NO_FILTER, signer: ['alice@example.com'] }, null);
+      expect(out.map((e) => e.id)).toEqual(['1']);
+    });
+
+    it('OR-matches multiple selected signers (returns envelopes containing ANY)', () => {
+      const list = [
+        envelope({
+          id: '1',
+          signers: [
+            { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        envelope({
+          id: '2',
+          signers: [
+            { id: 's2', name: 'Bob', email: 'bob@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        envelope({
+          id: '3',
+          signers: [
+            { id: 's3', name: 'Carol', email: 'carol@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+      ];
+      const out = filterEnvelopes(
+        list,
+        { ...NO_FILTER, signer: ['alice@example.com', 'bob@example.com'] },
+        null,
+      );
+      expect(out.map((e) => e.id).sort()).toEqual(['1', '2']);
+    });
+  });
+
+  it('AND-combines every active filter', () => {
+    const list = [
+      envelope({
+        id: '1',
+        title: 'Acme Waiver',
+        status: 'draft',
+        updated_at: '2026-05-10T00:00:00Z',
+        signers: [
+          { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
+        ] as EnvelopeListItem['signers'],
+      }),
+      // Same status + signer + date — but title misses the search.
+      envelope({
+        id: '2',
+        title: 'Other',
+        status: 'draft',
+        updated_at: '2026-05-10T00:00:00Z',
+        signers: [
+          { id: 's2', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
+        ] as EnvelopeListItem['signers'],
+      }),
+    ];
+    const out = filterEnvelopes(
+      list,
+      {
+        q: 'acme',
+        status: ['draft'],
+        date: { kind: 'preset', preset: 'all' },
+        signer: ['alice@example.com'],
+      },
+      null,
+    );
+    expect(out.map((e) => e.id)).toEqual(['1']);
+  });
+});
+
+describe('isAwaitingYou', () => {
+  it('returns false when no viewer email is supplied', () => {
+    expect(
+      isAwaitingYou(
+        envelope({
+          status: 'awaiting_others',
+          signers: [
+            { id: 's', name: '', email: 'you@x', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true when viewer is a signer that has not yet acted', () => {
+    expect(
+      isAwaitingYou(
+        envelope({
+          status: 'awaiting_others',
+          signers: [
+            { id: 's', name: 'You', email: 'you@example.com', status: 'awaiting' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        'you@example.com',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false once the viewer has signed', () => {
+    expect(
+      isAwaitingYou(
+        envelope({
+          status: 'awaiting_others',
+          signers: [
+            { id: 's', name: 'You', email: 'you@example.com', status: 'completed' },
+          ] as EnvelopeListItem['signers'],
+        }),
+        'you@example.com',
+      ),
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
+++ b/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
@@ -3,7 +3,7 @@ import type { EnvelopeFilters, StatusOption } from './types';
 
 /**
  * Returns true when the viewer is a signer on the envelope and hasn't
- * yet completed/declined. Centralises the predicate so both the
+ * yet completed/declined. Centralizes the predicate so both the
  * status-bucketing logic and any UI badge that wants to surface
  * "your turn" agree on what that means.
  *

--- a/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
+++ b/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
@@ -1,0 +1,136 @@
+import type { EnvelopeListItem } from 'shared';
+import type { EnvelopeFilters, StatusOption } from './types';
+
+/**
+ * Returns true when the viewer is a signer on the envelope and hasn't
+ * yet completed/declined. Centralises the predicate so both the
+ * status-bucketing logic and any UI badge that wants to surface
+ * "your turn" agree on what that means.
+ *
+ * Note: the dashboard view treats `awaiting_others` AND `sealing` as
+ * candidates — `sealing` only fires at the tail end of the envelope
+ * lifecycle, but if the viewer's signer entry is still open (e.g.
+ * co-sign races), they should still see it bucketed under awaiting-you.
+ */
+export function isAwaitingYou(envelope: EnvelopeListItem, viewerEmail: string | null): boolean {
+  if (viewerEmail === null) return false;
+  if (envelope.status !== 'awaiting_others' && envelope.status !== 'sealing') return false;
+  const v = viewerEmail.toLowerCase();
+  return envelope.signers.some(
+    (s) => s.email.toLowerCase() === v && s.status !== 'completed' && s.status !== 'declined',
+  );
+}
+
+/**
+ * Bucket an envelope into one of the status options surfaced in the
+ * filter chip. Mutually exclusive: every envelope belongs to exactly
+ * one bucket, so a status-filter intersection is well-defined.
+ */
+export function bucketEnvelope(
+  envelope: EnvelopeListItem,
+  viewerEmail: string | null,
+): StatusOption | null {
+  if (envelope.status === 'draft') return 'draft';
+  if (envelope.status === 'completed') return 'sealed';
+  if (envelope.status === 'declined') return 'declined';
+  if (isAwaitingYou(envelope, viewerEmail)) return 'awaiting_you';
+  if (envelope.status === 'awaiting_others' || envelope.status === 'sealing') {
+    return 'awaiting_others';
+  }
+  return null;
+}
+
+/**
+ * Anchor every preset window to UTC midnight so the dashboard renders
+ * the same buckets regardless of the user's local timezone (and so
+ * the tests aren't flaky on CI runners). Server-side timestamps on
+ * envelopes are stored in UTC; treating the windows the same way
+ * keeps the comparison apples-to-apples.
+ */
+function startOfUtcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+function dateRangeFromFilter(filter: EnvelopeFilters['date']): { from: Date; to: Date } | null {
+  if (filter.kind === 'preset') {
+    if (filter.preset === 'all') return null;
+    const now = new Date();
+    const today = startOfUtcDay(now);
+    if (filter.preset === 'today') {
+      const end = new Date(today);
+      end.setUTCDate(end.getUTCDate() + 1);
+      return { from: today, to: end };
+    }
+    if (filter.preset === '7d') {
+      const from = new Date(today);
+      from.setUTCDate(from.getUTCDate() - 6);
+      const to = new Date(today);
+      to.setUTCDate(to.getUTCDate() + 1);
+      return { from, to };
+    }
+    if (filter.preset === '30d') {
+      const from = new Date(today);
+      from.setUTCDate(from.getUTCDate() - 29);
+      const to = new Date(today);
+      to.setUTCDate(to.getUTCDate() + 1);
+      return { from, to };
+    }
+    if (filter.preset === 'thisMonth') {
+      const from = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      const to = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 1));
+      return { from, to };
+    }
+    return null;
+  }
+  // Custom range: inclusive on both ends. We treat the bounds as UTC
+  // calendar days and add 1 day to `to` so the half-open interval
+  // `[from, to)` still includes the upper-bound day.
+  const from = new Date(`${filter.range.from}T00:00:00Z`);
+  const toExclusive = new Date(`${filter.range.to}T00:00:00Z`);
+  toExclusive.setUTCDate(toExclusive.getUTCDate() + 1);
+  return { from, to: toExclusive };
+}
+
+/**
+ * Apply the four dashboard filters in AND.
+ *
+ *   - q (search): substring match on `title` + `short_code`
+ *   - status: each envelope is bucketed into exactly one option;
+ *     keep when the bucket is in the selected list
+ *   - date: half-open `[from, to)` window over `updated_at`
+ *   - signer: substring match across each signer's name + email
+ *
+ * `viewerEmail` is needed to resolve the awaiting-you bucket. Pure;
+ * does not mutate the input.
+ */
+export function filterEnvelopes(
+  envelopes: ReadonlyArray<EnvelopeListItem>,
+  filters: EnvelopeFilters,
+  viewerEmail: string | null,
+): ReadonlyArray<EnvelopeListItem> {
+  const range = dateRangeFromFilter(filters.date);
+  const q = filters.q;
+  const signerSet = filters.signer.length > 0 ? new Set(filters.signer) : null;
+  const statusSet = filters.status.length > 0 ? new Set(filters.status) : null;
+
+  return envelopes.filter((env) => {
+    if (q !== '') {
+      const title = env.title.toLowerCase();
+      const code = env.short_code.toLowerCase();
+      if (!title.includes(q) && !code.includes(q)) return false;
+    }
+    if (statusSet !== null) {
+      const bucket = bucketEnvelope(env, viewerEmail);
+      if (bucket === null || !statusSet.has(bucket)) return false;
+    }
+    if (range !== null) {
+      const updated = new Date(env.updated_at);
+      if (updated < range.from || updated >= range.to) return false;
+    }
+    if (signerSet !== null) {
+      const matched = env.signers.some((s) => signerSet.has(s.email.toLowerCase()));
+      if (!matched) return false;
+    }
+    return true;
+  });
+}

--- a/apps/web/src/features/dashboardFilters/index.ts
+++ b/apps/web/src/features/dashboardFilters/index.ts
@@ -1,0 +1,12 @@
+export { parseFilters, serializeFilters, type SerializeInput } from './parseFilters';
+export { filterEnvelopes, isAwaitingYou, bucketEnvelope } from './filterEnvelopes';
+export {
+  ACTIONABLE_INBOX,
+  DATE_PRESETS,
+  STATUS_OPTIONS,
+  type CustomDateRange,
+  type DateFilter,
+  type DatePreset,
+  type EnvelopeFilters,
+  type StatusOption,
+} from './types';

--- a/apps/web/src/features/dashboardFilters/parseFilters.test.ts
+++ b/apps/web/src/features/dashboardFilters/parseFilters.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { parseFilters, serializeFilters } from './parseFilters';
+import { ACTIONABLE_INBOX } from './types';
+
+describe('parseFilters', () => {
+  it('returns the actionable-inbox default when there are no params', () => {
+    expect(parseFilters(new URLSearchParams())).toMatchObject({
+      q: '',
+      status: ACTIONABLE_INBOX,
+      date: { kind: 'preset', preset: 'all' },
+      signer: [],
+    });
+  });
+
+  it('lower-cases the search string and respects URL encoding', () => {
+    const f = parseFilters(new URLSearchParams('q=Acme%20Waiver'));
+    expect(f.q).toBe('acme waiver');
+  });
+
+  it('parses comma-separated status values and ignores unknown tokens', () => {
+    const f = parseFilters(new URLSearchParams('status=draft,sealed,bogus'));
+    expect(f.status).toEqual(['draft', 'sealed']);
+  });
+
+  it('honors the `status=all` sentinel as "no status filter"', () => {
+    const f = parseFilters(new URLSearchParams('status=all'));
+    expect(f.status).toEqual([]);
+  });
+
+  it('parses preset date filters', () => {
+    expect(parseFilters(new URLSearchParams('date=7d')).date).toEqual({
+      kind: 'preset',
+      preset: '7d',
+    });
+  });
+
+  it('parses custom date ranges with from:to', () => {
+    const f = parseFilters(new URLSearchParams('date=custom:2026-04-01:2026-05-10'));
+    expect(f.date).toEqual({
+      kind: 'custom',
+      range: { from: '2026-04-01', to: '2026-05-10' },
+    });
+  });
+
+  it('ignores malformed custom date ranges (falls back to all-time)', () => {
+    expect(parseFilters(new URLSearchParams('date=custom:nope')).date).toEqual({
+      kind: 'preset',
+      preset: 'all',
+    });
+  });
+
+  it('ignores unknown date preset tokens', () => {
+    expect(parseFilters(new URLSearchParams('date=garbage')).date).toEqual({
+      kind: 'preset',
+      preset: 'all',
+    });
+  });
+
+  it('parses comma-separated signer emails and lower-cases them', () => {
+    expect(parseFilters(new URLSearchParams('signer=Alice@Example.com,Bob@x.com')).signer).toEqual([
+      'alice@example.com',
+      'bob@x.com',
+    ]);
+  });
+
+  it('returns an empty signer list when the param is empty', () => {
+    expect(parseFilters(new URLSearchParams('signer=')).signer).toEqual([]);
+  });
+
+  it('does NOT apply the actionable-inbox default once any other param is present', () => {
+    // User searched but didn't touch status — they want to search across
+    // every envelope, not just the actionable subset.
+    const f = parseFilters(new URLSearchParams('q=acme'));
+    expect(f.status).toEqual([]);
+  });
+});
+
+describe('serializeFilters', () => {
+  it('emits an empty string when filters match the no-op state (no q, status=all, date=all, no signer)', () => {
+    expect(
+      serializeFilters({
+        q: '',
+        status: [],
+        date: { kind: 'preset', preset: 'all' },
+        signer: [],
+      }),
+    ).toBe('');
+  });
+
+  it('round-trips through parseFilters when explicitly set', () => {
+    const original = {
+      q: 'waiver',
+      status: ['draft', 'sealed'] as const,
+      date: { kind: 'preset' as const, preset: '7d' as const },
+      signer: ['alice@example.com'] as ReadonlyArray<string>,
+    };
+    const serialized = serializeFilters(original);
+    const params = new URLSearchParams(serialized);
+    const parsed = parseFilters(params);
+    expect(parsed).toMatchObject(original);
+  });
+
+  it('round-trips a custom date range', () => {
+    const params = new URLSearchParams(
+      serializeFilters({
+        q: '',
+        status: [],
+        date: { kind: 'custom', range: { from: '2026-04-01', to: '2026-05-10' } },
+        signer: [],
+      }),
+    );
+    expect(parseFilters(params).date).toEqual({
+      kind: 'custom',
+      range: { from: '2026-04-01', to: '2026-05-10' },
+    });
+  });
+
+  it('uses the all-status sentinel when the user has explicitly opted into "everything"', () => {
+    // Distinguishes "user cleared the chip" from "first visit". Without
+    // the sentinel, both would be empty status arrays — and the next
+    // page load would re-apply the actionable-inbox default.
+    const serialized = serializeFilters({
+      q: '',
+      status: [],
+      date: { kind: 'preset', preset: 'all' },
+      signer: [],
+      // The sentinel is signaled by an opt-in flag at the call site —
+      // see the toolbar test for the integration assertion.
+      explicitAllStatus: true,
+    });
+    expect(new URLSearchParams(serialized).get('status')).toBe('all');
+  });
+});

--- a/apps/web/src/features/dashboardFilters/parseFilters.ts
+++ b/apps/web/src/features/dashboardFilters/parseFilters.ts
@@ -1,0 +1,104 @@
+import {
+  ACTIONABLE_INBOX,
+  DATE_PRESETS,
+  STATUS_OPTIONS,
+  type DateFilter,
+  type DatePreset,
+  type EnvelopeFilters,
+  type StatusOption,
+} from './types';
+
+const STATUS_SET = new Set<string>(STATUS_OPTIONS);
+const PRESET_SET = new Set<string>(DATE_PRESETS);
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Decode the dashboard filter URL contract into a structured object.
+ *
+ * Default-on-first-visit (no params at all) returns the actionable
+ * inbox: `Awaiting you + Awaiting others`. Once any other param is
+ * present (search / date / signer), the default is suppressed —
+ * the user has begun narrowing and the actionable filter would
+ * otherwise hide envelopes they likely want to see.
+ *
+ * Malformed values (unknown preset, broken custom range, unknown
+ * status token) are silently ignored — the filter behaves as if
+ * absent. Per spec: never error on an unparseable URL.
+ */
+export function parseFilters(params: URLSearchParams): EnvelopeFilters {
+  const hasAnyParam =
+    params.has('q') || params.has('status') || params.has('date') || params.has('signer');
+
+  return {
+    q: (params.get('q') ?? '').toLowerCase(),
+    status: parseStatus(params.get('status'), hasAnyParam),
+    date: parseDate(params.get('date')),
+    signer: parseSigners(params.get('signer')),
+  };
+}
+
+function parseSigners(raw: string | null): ReadonlyArray<string> {
+  if (raw === null || raw === '') return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+}
+
+function parseStatus(raw: string | null, hasAnyParam: boolean): ReadonlyArray<StatusOption> {
+  if (raw === null) {
+    // No `status` param at all: apply the actionable-inbox default
+    // ONLY if no other filter is active. Otherwise treat as "no
+    // status filter" so the user's search/date/signer scope spans
+    // every envelope.
+    return hasAnyParam ? [] : ACTIONABLE_INBOX;
+  }
+  if (raw === 'all') return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s): s is StatusOption => STATUS_SET.has(s));
+}
+
+function parseDate(raw: string | null): DateFilter {
+  if (raw === null) return { kind: 'preset', preset: 'all' };
+  if (raw.startsWith('custom:')) {
+    const [, from, to] = raw.split(':');
+    if (from && to && DATE_RE.test(from) && DATE_RE.test(to) && from <= to) {
+      return { kind: 'custom', range: { from, to } };
+    }
+    return { kind: 'preset', preset: 'all' };
+  }
+  if (PRESET_SET.has(raw)) return { kind: 'preset', preset: raw as DatePreset };
+  return { kind: 'preset', preset: 'all' };
+}
+
+export interface SerializeInput extends Omit<EnvelopeFilters, 'status'> {
+  readonly status: ReadonlyArray<StatusOption>;
+  /**
+   * When `true`, an empty `status` list serializes to `?status=all`.
+   * Distinguishes "user cleared the chip" (explicit) from "first
+   * visit" (defaults will re-apply on reload). Defaults to `false`,
+   * which omits the param entirely.
+   */
+  readonly explicitAllStatus?: boolean;
+}
+
+/**
+ * Inverse of `parseFilters` — emits a URL search-params string. Omits
+ * params that match the no-op state so the URL stays clean. Used by
+ * the toolbar chips to write filter changes back to the URL.
+ */
+export function serializeFilters(filters: SerializeInput): string {
+  const out = new URLSearchParams();
+  if (filters.q !== '') out.set('q', filters.q);
+  if (filters.status.length > 0) out.set('status', filters.status.join(','));
+  else if (filters.explicitAllStatus === true) out.set('status', 'all');
+  if (filters.date.kind === 'preset' && filters.date.preset !== 'all') {
+    out.set('date', filters.date.preset);
+  } else if (filters.date.kind === 'custom') {
+    out.set('date', `custom:${filters.date.range.from}:${filters.date.range.to}`);
+  }
+  if (filters.signer.length > 0) out.set('signer', filters.signer.join(','));
+  return out.toString();
+}

--- a/apps/web/src/features/dashboardFilters/types.ts
+++ b/apps/web/src/features/dashboardFilters/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Filter shape parsed from the dashboard URL search params. Lives in
+ * its own module so the pure helpers (`parseFilters`, `filterEnvelopes`)
+ * stay decoupled from React.
+ */
+
+export const STATUS_OPTIONS = [
+  'draft',
+  'awaiting_you',
+  'awaiting_others',
+  'sealed',
+  'declined',
+] as const;
+export type StatusOption = (typeof STATUS_OPTIONS)[number];
+
+export const DATE_PRESETS = ['today', '7d', '30d', 'thisMonth', 'all'] as const;
+export type DatePreset = (typeof DATE_PRESETS)[number];
+
+export interface CustomDateRange {
+  /** ISO yyyy-mm-dd, inclusive lower bound. */
+  readonly from: string;
+  /** ISO yyyy-mm-dd, inclusive upper bound. */
+  readonly to: string;
+}
+
+export type DateFilter =
+  | { readonly kind: 'preset'; readonly preset: DatePreset }
+  | {
+      readonly kind: 'custom';
+      readonly range: CustomDateRange;
+    };
+
+export interface EnvelopeFilters {
+  /** Lower-cased substring; matches doc title + envelope short code. */
+  readonly q: string;
+  /**
+   * Selected status options. Empty array = no status filter (treat as
+   * "show all"). Default-on-first-visit (no `status` param) is set at
+   * the call site, not here.
+   */
+  readonly status: ReadonlyArray<StatusOption>;
+  readonly date: DateFilter;
+  /**
+   * Lower-cased emails of selected signers. Empty array = no signer
+   * filter. Matched as exact emails because the UI lets the user
+   * pick from a known roster (no free-text fallback).
+   */
+  readonly signer: ReadonlyArray<string>;
+}
+
+/**
+ * Default applied when the URL has no params at all (first visit /
+ * page reset). Per spec: actionable inbox.
+ */
+export const ACTIONABLE_INBOX: ReadonlyArray<StatusOption> = ['awaiting_you', 'awaiting_others'];

--- a/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -124,14 +124,27 @@ describe('DashboardPage', () => {
     expect(
       screen.getByRole('heading', { level: 1, name: /everything you've sent/i }),
     ).toBeInTheDocument();
+    // Default filter is the actionable inbox (Awaiting you + Awaiting
+    // others). MSA is awaiting_others, so it lands in the visible set.
     expect(await screen.findByText(/master services agreement/i)).toBeInTheDocument();
   });
 
-  it('filters the table when a tab is selected', async () => {
+  it('narrows the table when the user picks a status from the toolbar', async () => {
+    // Default visible set is the actionable inbox (Awaiting you +
+    // Awaiting others). Sealed and Drafts are hidden by default. The
+    // toolbar's Draft checkbox flips Drafts into the visible set.
     renderDashboard();
     await screen.findByText(/master services agreement/i);
-    fireEvent.click(screen.getByRole('tab', { name: /drafts/i }));
+    expect(screen.queryByText(/vendor onboarding — argus/i)).toBeNull();
+    expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
+
+    // Open the Status chip and add "Draft" to the selection.
+    fireEvent.click(screen.getByRole('button', { name: /^status filter$/i }));
+    fireEvent.click(await screen.findByLabelText('Draft'));
     expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
+    // Awaiting-others is still selected, so MSA stays visible.
+    expect(screen.getByText(/master services agreement/i)).toBeInTheDocument();
+    // Sealed remains unchecked, so the offer letter stays hidden.
     expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
   });
 
@@ -153,20 +166,22 @@ describe('DashboardPage', () => {
     expect(screen.getAllByText(/awaiting you/i).length).toBeGreaterThan(0);
   });
 
-  it('counts the viewer as Awaiting you in the stat tile + tab', async () => {
+  it('counts the viewer as Awaiting you in the stat tile and the toolbar Status chip', async () => {
     renderDashboard();
     await screen.findByText(/self-sign — jamie cv/i);
-    // The "Awaiting you" tab in the FilterTabs reflects the count.
-    const tab = screen.getByRole('tab', { name: /awaiting you/i });
-    // Tab name renders as `Label N` — assert we see at least one match.
-    expect(tab.textContent ?? '').toMatch(/1/);
+    // Open the Status chip; the "Awaiting you" option carries the count.
+    fireEvent.click(screen.getByRole('button', { name: /^status filter$/i }));
+    const opt = await screen.findByLabelText('Awaiting you');
+    // Walk up to the row and look for the count rendered next to the
+    // option label. The styled OptionCount uses the mono font; we
+    // just assert "1" is present in the row.
+    const row = opt.closest('label');
+    expect(row?.textContent ?? '').toMatch(/1/);
   });
 
-  it('reads the initial filter from the ?filter= query param', async () => {
-    renderDashboard('/documents?filter=drafts');
+  it('reads the initial filter from the ?status= query param', async () => {
+    renderDashboard('/documents?status=draft');
     await screen.findByText(/vendor onboarding — argus/i);
-    const draftsTab = screen.getByRole('tab', { name: /drafts/i });
-    expect(draftsTab).toHaveAttribute('aria-selected', 'true');
     expect(screen.queryByText(/master services agreement/i)).toBeNull();
     expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
   });

--- a/apps/web/src/pages/DashboardPage/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { JSX } from 'react';
 import { ChevronRight, UploadCloud } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -7,7 +7,8 @@ import type { BadgeTone } from '@/components/Badge/Badge.types';
 import { Button } from '@/components/Button';
 import { DocThumb } from '@/components/DocThumb';
 import { EmptyState } from '@/components/EmptyState';
-import { FilterTabs } from '@/components/FilterTabs';
+import { EnvelopeIllustration } from '@/components/EnvelopeIllustration';
+import { FilterToolbar } from '@/components/FilterToolbar';
 import { PageHeader } from '@/components/PageHeader';
 import { SignerProgressBar } from '@/components/SignerProgressBar';
 import type { SignerProgressBarEntry } from '@/components/SignerProgressBar';
@@ -17,6 +18,7 @@ import { Skeleton } from '@/components/Skeleton';
 import { StatCard } from '@/components/StatCard';
 import { useEnvelopesQuery } from '@/features/envelopes';
 import type { EnvelopeListItem, EnvelopeStatus } from '@/features/envelopes';
+import { filterEnvelopes, isAwaitingYou, parseFilters } from '@/features/dashboardFilters';
 import { formatShortDate } from '@/lib/dateFormat';
 import { useAuth } from '@/providers/AuthProvider';
 import {
@@ -35,53 +37,6 @@ import {
   TableRow,
   TableShell,
 } from './DashboardPage.styles';
-
-type FilterId = 'all' | 'you' | 'others' | 'completed' | 'drafts';
-
-const FILTER_IDS: ReadonlyArray<FilterId> = ['all', 'you', 'others', 'completed', 'drafts'];
-
-function isFilterId(value: string | null): value is FilterId {
-  return value !== null && (FILTER_IDS as ReadonlyArray<string>).includes(value);
-}
-
-interface FilterDef {
-  readonly id: FilterId;
-  readonly label: string;
-  readonly matches: (d: EnvelopeListItem) => boolean;
-}
-
-// Returns true when the dashboard viewer is one of the envelope's signers
-// AND that signer hasn't completed/declined yet AND the envelope is still
-// open. Lets the dashboard correctly bucket envelopes the viewer needs to
-// sign themselves (was previously stubbed `() => false` because the
-// dashboard pre-dated co-signing — when a sender adds themselves as a
-// signer, those envelopes were mis-bucketed under "Awaiting others").
-function isAwaitingYou(envelope: EnvelopeListItem, viewerEmail: string | null): boolean {
-  if (!viewerEmail) return false;
-  if (envelope.status !== 'awaiting_others' && envelope.status !== 'sealing') return false;
-  const v = viewerEmail.toLowerCase();
-  return envelope.signers.some(
-    (s) => s.email.toLowerCase() === v && s.status !== 'completed' && s.status !== 'declined',
-  );
-}
-
-function buildFilters(viewerEmail: string | null): ReadonlyArray<FilterDef> {
-  return [
-    { id: 'all', label: 'All', matches: () => true },
-    { id: 'you', label: 'Awaiting you', matches: (d) => isAwaitingYou(d, viewerEmail) },
-    {
-      id: 'others',
-      label: 'Awaiting others',
-      // Mutually exclusive with 'you' so a single envelope only lands in
-      // one bucket. Awaiting-you takes precedence (it's actionable).
-      matches: (d) =>
-        (d.status === 'awaiting_others' || d.status === 'sealing') &&
-        !isAwaitingYou(d, viewerEmail),
-    },
-    { id: 'completed', label: 'Sealed', matches: (d) => d.status === 'completed' },
-    { id: 'drafts', label: 'Drafts', matches: (d) => d.status === 'draft' },
-  ];
-}
 
 const STATUS_LABEL: Record<EnvelopeStatus, string> = {
   draft: 'Draft',
@@ -209,7 +164,22 @@ function renderDocumentsBody(args: RenderDocumentsBodyArgs): JSX.Element | JSX.E
     ));
   }
   if (filtered.length === 0) {
-    return <EmptyState>No documents match this filter.</EmptyState>;
+    return (
+      <EmptyState>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 12,
+            paddingBlock: 24,
+          }}
+        >
+          <EnvelopeIllustration size={140} />
+          <span>No documents match these filters.</span>
+        </div>
+      </EmptyState>
+    );
   }
   return filtered.map((d) => (
     <TableRow
@@ -257,9 +227,7 @@ function renderDocumentsBody(args: RenderDocumentsBodyArgs): JSX.Element | JSX.E
  */
 export function DashboardPage() {
   const navigate = useNavigate();
-  const [searchParams, setSearchParams] = useSearchParams();
-  const rawFilter = searchParams.get('filter');
-  const tab: FilterId = isFilterId(rawFilter) ? rawFilter : 'all';
+  const [searchParams] = useSearchParams();
 
   const q = useEnvelopesQuery(true, { limit: 100 });
   const envelopes: ReadonlyArray<EnvelopeListItem> = useMemo(() => q.data?.items ?? [], [q.data]);
@@ -269,28 +237,16 @@ export function DashboardPage() {
   // is themselves a signer on are bucketed correctly.
   const { user } = useAuth();
   const viewerEmail = user?.email ?? null;
-  const filters = useMemo(() => buildFilters(viewerEmail), [viewerEmail]);
 
-  const handleSelectTab = useCallback(
-    (id: FilterId): void => {
-      if (id === 'all') setSearchParams({});
-      else setSearchParams({ filter: id });
-    },
-    [setSearchParams],
+  // The new toolbar owns filter UI and writes to the URL; the page
+  // reads the URL and applies a single combined filter pass. Keeps
+  // the toolbar pluggable (piece #2 will add a tag chip) without
+  // pushing per-filter state into the page.
+  const parsedFilters = useMemo(() => parseFilters(searchParams), [searchParams]);
+  const filtered = useMemo(
+    () => filterEnvelopes(envelopes, parsedFilters, viewerEmail),
+    [envelopes, parsedFilters, viewerEmail],
   );
-
-  const counts = useMemo(() => {
-    const byFilter = new Map<FilterId, number>();
-    filters.forEach((f) => {
-      byFilter.set(f.id, envelopes.filter(f.matches).length);
-    });
-    return byFilter;
-  }, [envelopes, filters]);
-
-  const filtered = useMemo(() => {
-    const match = filters.find((f) => f.id === tab) ?? filters[0]!;
-    return envelopes.filter(match.matches);
-  }, [envelopes, filters, tab]);
 
   const stats = useMemo(() => {
     const awaitingYou = envelopes.filter((d) => isAwaitingYou(d, viewerEmail)).length;
@@ -318,11 +274,6 @@ export function DashboardPage() {
     ];
   }, [envelopes, viewerEmail]);
 
-  const tabItems = useMemo(
-    () => filters.map((f) => ({ id: f.id, label: f.label, count: counts.get(f.id) ?? 0 })),
-    [counts, filters],
-  );
-
   return (
     <Main>
       <Inner>
@@ -348,12 +299,7 @@ export function DashboardPage() {
           ))}
         </StatGrid>
 
-        <FilterTabs
-          items={tabItems}
-          activeId={tab}
-          onSelect={(id) => handleSelectTab(id as FilterId)}
-          aria-label="Document filters"
-        />
+        <FilterToolbar envelopes={envelopes} viewerEmail={viewerEmail} />
 
         <TableShell>
           <TableHead role="row">

--- a/docs/superpowers/specs/2026-05-10-dashboard-filter-toolbar-design.md
+++ b/docs/superpowers/specs/2026-05-10-dashboard-filter-toolbar-design.md
@@ -1,0 +1,120 @@
+# Dashboard filter toolbar — design
+
+**Date:** 2026-05-10
+**Scope:** Piece 1 of 3 in the user's "single screen with filters + tags + resizable columns" request. This spec covers only the tabs → filter-toolbar refactor. Tags is piece 2; resizable columns is piece 3, each with its own spec.
+
+## Goal
+
+Replace the dashboard's status tabs (`All / Awaiting you / Awaiting others / Sealed / Drafts`) with a single horizontal filter toolbar above the envelope table. Filter state lives in the URL so views are shareable and survive refresh / back-forward.
+
+Default state on first visit: actionable inbox (Awaiting you + Awaiting others). Two clicks (Status ▾ → Select all) widens to everything.
+
+## Non-goals (deferred to later pieces)
+
+- Tag chips on envelopes and tag filtering — piece 2.
+- Resizable column widths — piece 3.
+- Per-user persistence of filters beyond the URL — out of scope.
+
+## Architecture
+
+```
+DashboardPage
+  ├─ <StatGrid />                 (unchanged)
+  ├─ <FilterToolbar>              (NEW — replaces <FilterTabs />)
+  │     ├─ <SearchChip>           free-text on doc title + envelope code
+  │     ├─ <MultiSelectChip>      Status — checkboxes + counts
+  │     ├─ <DateRangeChip>        presets + custom range
+  │     ├─ <SignerChip>           signer-name/email lookup
+  │     └─ <ClearChip>            visible only when ≥1 filter active
+  └─ <Table>                      filtered via useMemo over the search-params
+```
+
+`FilterToolbar` reads / writes via `useSearchParams`. The page applies a single `useMemo` that combines all four filters against the envelope list. The existing `FilterTabs` import is removed; the component itself stays in the library if other pages still use it (verify before deleting).
+
+## URL contract
+
+| Param   | Format                                                | Example                                |
+|---------|-------------------------------------------------------|----------------------------------------|
+| `q`     | URI-encoded substring (lowercased on read)            | `?q=waiver`                            |
+| `status`| comma-separated subset of {`draft`,`awaiting_you`,`awaiting_others`,`sealed`,`declined`} | `?status=awaiting_you,awaiting_others` |
+| `date`  | preset key OR `custom:<from>:<to>` (ISO yyyy-mm-dd)   | `?date=7d` or `?date=custom:2026-04-01:2026-05-10` |
+| `signer`| URI-encoded email (exact-match) OR substring of name  | `?signer=alice@example.com`            |
+
+**No params present** → apply the default actionable-inbox filter (`status=awaiting_you,awaiting_others`).
+
+**`status=all` sentinel** → user has explicitly opted into "everything". Without this sentinel, "no `status` param" can't disambiguate between *first visit* (apply default) and *user cleared the chip* (show all). With it, the URL becomes:
+- first visit → no `status` → render with default
+- user clicks all checkboxes in the chip → `?status=all` → render with no status filter
+- user picks specific subset → `?status=draft,sealed` → render with that subset
+
+**Invariant:** any param that fails to parse is silently ignored (filter behaves as if absent). No error toasts for malformed URLs.
+
+## Defaults & special cases
+
+- First visit (no params): default to `status=awaiting_you,awaiting_others`. After the first filter change, the user's choices are reflected verbatim.
+- "Select all" status → omit `status` from URL (clean slate).
+- Search debounced 250 ms before URL update.
+- Date filter pegs to **last activity** (`updated_at`), matching the table's existing `DATE` column.
+- Signer filter matches if any of the envelope's signers' name OR email contains the substring (case-insensitive).
+- All four filters AND together; status options OR within the chip.
+
+## Empty state
+
+When filters narrow the result set to zero rows: render a small inline message ("No envelopes match these filters.") with a `Clear filters` button. The stat cards above stay visible.
+
+## Components
+
+### `<FilterToolbar />`
+Top-level container. No props (it owns no state beyond the URL). Lays out children with `display: flex; gap: 8px; flex-wrap: wrap;` so it reflows on narrow viewports.
+
+### `<FilterChipPopover />` (primitive)
+Generic shell every chip uses. Renders the trigger button + a portaled popover (escapes any `overflow: hidden` ancestor — same pattern as the SignerStack popover fix from PR #225). Props: `label`, `value` (compact preview), `active` (boolean for amber accent), `onClear`, `children` (popover body).
+
+### `<SearchChip />`
+Inline input, not a popover. 250 ms debounced; writes `q` to URL. Clear "✕" inside the input.
+
+### `<MultiSelectChip />` (used by Status)
+Checkbox list. Each option may render a count to its right. "Select all / Clear" links at the top of the popover.
+
+### `<DateRangeChip />`
+Preset options + "Custom range…" footer that reveals two date inputs.
+
+### `<SignerChip />`
+Search input + scrollable list of distinct signers across the user's envelopes (derived in `useMemo` over the envelope list).
+
+### `<ClearChip />`
+One-button shortcut that strips every filter param from the URL.
+
+## Data flow
+
+```
+useSearchParams()  →  parseFilters(params)  →  filterEnvelopes(envelopes, parsed)  →  rendered rows
+                ↑                          ↓
+                └────  setSearchParams  ←──┘
+                       (called by chips)
+```
+
+`parseFilters` is a pure helper (`apps/web/src/features/dashboardFilters/parseFilters.ts`) — easy to unit-test the URL contract without a dom.
+
+`filterEnvelopes` is also pure. Already-existing logic in `DashboardPage.tsx` (the `FilterTabs` predicates) is extracted into this helper.
+
+## Tests
+
+| Layer | What it asserts |
+|-------|-----------------|
+| `parseFilters.test.ts` (unit) | Each URL param shape resolves to the right filter object; malformed values are silently ignored. |
+| `filterEnvelopes.test.ts` (unit) | Status / date / signer / search predicates AND together correctly. |
+| `FilterToolbar.test.tsx` (component) | Selecting an option updates URL; Clear strips all params; popovers portal to body (escapes overflow). |
+| `DashboardPage.test.tsx` (existing — extend) | Default URL → actionable inbox; status filter narrows visible rows; empty state shown when no matches. |
+
+No new Cucumber feature file for this piece — the existing E2E covers the table; this refactor doesn't change its observable behavior at the row level. (We can revisit if regressions appear.)
+
+## Risk + rollback
+
+- Same React Query / data-fetch layer as today; no API changes.
+- The four chip popovers all use the portal pattern proven in PR #225 — no overflow-clipping risk.
+- Rollback = revert the PR; the old `FilterTabs` component and its test stay in the library so the revert is one commit, not a code-restoration job.
+
+## Local review checkpoint
+
+Per the user's standing rule (2026-05-10): I run `pnpm --filter web dev` and surface localhost; the user walks the page (clicks each chip, types a search, verifies URL state, checks empty state and the actionable-inbox default). Only after the user signs off do I push to a branch and open a PR.


### PR DESCRIPTION
## Summary

Piece 1 of 3 in the user's "single screen + filters + tags + resizable columns" request. Spec lives at \`docs/superpowers/specs/2026-05-10-dashboard-filter-toolbar-design.md\` (committed alongside the implementation).

The dashboard's five status tabs (\`All / Awaiting you / Awaiting others / Sealed / Drafts\`) are gone. The page is now a single screen with a horizontal filter toolbar above the table:

\`\`\`
[🔍 Search]  [Status ▾]  [Date ▾]  [Signer ▾]   [✕ Clear filters]
\`\`\`

## What's in the box

- **\`features/dashboardFilters/\`** — pure helpers (\`parseFilters\`, \`serializeFilters\`, \`filterEnvelopes\`, \`bucketEnvelope\`, \`isAwaitingYou\`) decoupled from React. Easy to unit-test the URL contract + AND-combined predicate without touching the DOM.
- **\`components/FilterToolbar/\`** — toolbar shell + per-chip popover bodies + a \`FilterChipPopover\` primitive that portals to \`document.body\` so the popover never gets cropped by an ancestor \`overflow: hidden\` (same pattern as PR #225).
- **\`components/EnvelopeIllustration/\`** — static envelope SVG extracted from \`SendingOverlay\` (gradient body + lifted flap, no wax-seal, no shimmer, no animation). Shown above the "No documents match these filters." copy when filters narrow to zero.

## URL contract

\`?q=…&status=draft,sealed&date=7d&signer=email1,email2\`

Bookmarkable, refresh-safe, back/forward steps through filter history. **First-visit default** is the actionable inbox (Awaiting you + Awaiting others); a \`?status=all\` sentinel distinguishes "user explicitly cleared the chip" from "first visit" so the actionable default doesn't snap back on reload.

## Visual language

Matches the existing \`DownloadMenu\`: 14 px radius, soft shadow, \`menuIn\` enter animation, uppercase mono section headings, 13 px option rows. Native checkboxes / radios pick up the brand indigo via \`accent-color\`.

- **Status chip:** smart toggle header link reads "Deselect all" when ≥1 option is checked, flips to "Select all" when everything is cleared.
- **Signer chip:** multi-select with checkbox rows. Display name only (no email tail). OR-matched within the chip; AND-combined with the others.

## Tests

- \`parseFilters.test.ts\` (14) — RED before the module existed. URL-contract round-trip + malformed-input ignore + actionable-inbox default suppression once any other param is present.
- \`filterEnvelopes.test.ts\` (13) — RED before the module existed. Search / status (with bucket) / date (UTC-anchored windows for timezone safety) / signer (OR within chip) / AND combination.
- \`DashboardPage.test.tsx\` rewritten for the new URL contract (\`?status=draft\` was \`?filter=drafts\`); status-chip multi-select add behavior; empty actionable-inbox default visibility.

## Test plan

- [x] typecheck / lint / vitest 1514/1514 GREEN locally
- [x] \`seald-react-pr-review\` walked the diff — no MUST-FIX / SHOULD-FIX
- [x] User reviewed and signed off on \`http://localhost:5173/documents\` before this push (filter chips, popover styling, empty state, URL state, defaults)
- [ ] Post-deploy: re-verify on https://seald.nromomentum.com — open \`/documents\`, confirm the actionable-inbox default, exercise each chip, narrow to zero rows to confirm the envelope illustration empty state

## Pieces 2 + 3 (separate PRs)

- **#2 — Envelope tags** — adds \`tags: string[]\` to the DB schema + API, "Add tag" UI on the envelope, and a tag chip that slots into this toolbar.
- **#3 — Resizable columns** — drag-handles + \`localStorage\` persistence, Monday-style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)