### PR TITLE
fix(web): drop the actionable-inbox default; Clear filters clears everything

### DIFF
--- a/apps/web/src/components/FilterToolbar/FilterToolbar.tsx
+++ b/apps/web/src/components/FilterToolbar/FilterToolbar.tsx
@@ -132,7 +132,7 @@ export function FilterToolbar({ envelopes, viewerEmail }: FilterToolbarProps) {
 
   /** Replace the entire filter set, leaving non-filter params alone. */
   const applyFilters = useCallback(
-    (next: { filters: EnvelopeFilters; explicitAllStatus?: boolean }) => {
+    (nextFilters: EnvelopeFilters) => {
       setSearchParams(
         (prev) => {
           const carrier = new URLSearchParams(prev);
@@ -141,14 +141,7 @@ export function FilterToolbar({ envelopes, viewerEmail }: FilterToolbarProps) {
           carrier.delete('date');
           carrier.delete('signer');
           carrier.delete('tags');
-          const written = new URLSearchParams(
-            serializeFilters({
-              ...next.filters,
-              ...(next.explicitAllStatus !== undefined
-                ? { explicitAllStatus: next.explicitAllStatus }
-                : {}),
-            }),
-          );
+          const written = new URLSearchParams(serializeFilters(nextFilters));
           for (const [k, v] of written) carrier.set(k, v);
           return carrier;
         },
@@ -159,34 +152,29 @@ export function FilterToolbar({ envelopes, viewerEmail }: FilterToolbarProps) {
   );
 
   const setStatus = useCallback(
-    (next: ReadonlyArray<StatusOption>, options?: { explicitAllStatus?: boolean }) => {
-      applyFilters({
-        filters: { ...filters, status: next },
-        ...(options?.explicitAllStatus !== undefined
-          ? { explicitAllStatus: options.explicitAllStatus }
-          : {}),
-      });
+    (next: ReadonlyArray<StatusOption>) => {
+      applyFilters({ ...filters, status: next });
     },
     [applyFilters, filters],
   );
 
   const setDate = useCallback(
     (next: DateFilter) => {
-      applyFilters({ filters: { ...filters, date: next } });
+      applyFilters({ ...filters, date: next });
     },
     [applyFilters, filters],
   );
 
   const setSigner = useCallback(
     (next: ReadonlyArray<string>) => {
-      applyFilters({ filters: { ...filters, signer: next } });
+      applyFilters({ ...filters, signer: next });
     },
     [applyFilters, filters],
   );
 
   const setTagsFilter = useCallback(
     (next: ReadonlyArray<string>) => {
-      applyFilters({ filters: { ...filters, tags: next } });
+      applyFilters({ ...filters, tags: next });
     },
     [applyFilters, filters],
   );
@@ -327,16 +315,12 @@ export function FilterToolbar({ envelopes, viewerEmail }: FilterToolbarProps) {
         <PopoverHeader>
           <span>Status</span>
           {/* Smart toggle: when at least one option is checked the
-              header link becomes "Deselect all" (un-ticks every box
-              + writes the `?status=all` sentinel so the actionable
-              inbox default doesn't re-apply on reload). When nothing
-              is checked the link flips to "Select all" and ticks
-              every option in one click. */}
+              header link becomes "Deselect all" (un-ticks every box →
+              empty status filter → every envelope shows). When nothing
+              is checked it flips to "Select all" and ticks every
+              option in one click. */}
           {filters.status.length > 0 ? (
-            <PopoverHeaderAction
-              type="button"
-              onClick={() => setStatus([], { explicitAllStatus: true })}
-            >
+            <PopoverHeaderAction type="button" onClick={() => setStatus([])}>
               Deselect all
             </PopoverHeaderAction>
           ) : (

--- a/apps/web/src/features/dashboardFilters/parseFilters.test.ts
+++ b/apps/web/src/features/dashboardFilters/parseFilters.test.ts
@@ -1,12 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { parseFilters, serializeFilters } from './parseFilters';
-import { ACTIONABLE_INBOX } from './types';
 
 describe('parseFilters', () => {
-  it('returns the actionable-inbox default when there are no params', () => {
+  it('applies no filters when there are no params (fresh visit shows everything)', () => {
     expect(parseFilters(new URLSearchParams())).toMatchObject({
       q: '',
-      status: ACTIONABLE_INBOX,
+      status: [],
       date: { kind: 'preset', preset: 'all' },
       signer: [],
       tags: [],
@@ -23,7 +22,7 @@ describe('parseFilters', () => {
     expect(f.status).toEqual(['draft', 'sealed']);
   });
 
-  it('honors the `status=all` sentinel as "no status filter"', () => {
+  it('treats the legacy `?status=all` alias as "no status filter"', () => {
     const f = parseFilters(new URLSearchParams('status=all'));
     expect(f.status).toEqual([]);
   });
@@ -79,16 +78,14 @@ describe('parseFilters', () => {
     expect(parseFilters(new URLSearchParams('tags=')).tags).toEqual([]);
   });
 
-  it('does NOT apply the actionable-inbox default once any other param is present', () => {
-    // User searched but didn't touch status — they want to search across
-    // every envelope, not just the actionable subset.
+  it('leaves the status filter empty when only other params are present', () => {
     const f = parseFilters(new URLSearchParams('q=acme'));
     expect(f.status).toEqual([]);
   });
 });
 
 describe('serializeFilters', () => {
-  it('emits an empty string when filters match the no-op state (no q, status=all, date=all, no signer)', () => {
+  it('emits an empty string when nothing is filtered (empty status, all-time date, no signer/tags/search)', () => {
     expect(
       serializeFilters({
         q: '',
@@ -130,20 +127,14 @@ describe('serializeFilters', () => {
     });
   });
 
-  it('uses the all-status sentinel when the user has explicitly opted into "everything"', () => {
-    // Distinguishes "user cleared the chip" from "first visit". Without
-    // the sentinel, both would be empty status arrays — and the next
-    // page load would re-apply the actionable-inbox default.
+  it('omits the status param entirely when the status filter is empty', () => {
     const serialized = serializeFilters({
-      q: '',
+      q: 'x',
       status: [],
       date: { kind: 'preset', preset: 'all' },
       signer: [],
       tags: [],
-      // The sentinel is signaled by an opt-in flag at the call site —
-      // see the toolbar test for the integration assertion.
-      explicitAllStatus: true,
     });
-    expect(new URLSearchParams(serialized).get('status')).toBe('all');
+    expect(new URLSearchParams(serialized).has('status')).toBe(false);
   });
 });

--- a/apps/web/src/features/dashboardFilters/parseFilters.ts
+++ b/apps/web/src/features/dashboardFilters/parseFilters.ts
@@ -1,5 +1,4 @@
 import {
-  ACTIONABLE_INBOX,
   DATE_PRESETS,
   STATUS_OPTIONS,
   type DateFilter,
@@ -15,27 +14,18 @@ const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 /**
  * Decode the dashboard filter URL contract into a structured object.
  *
- * Default-on-first-visit (no params at all) returns the actionable
- * inbox: `Awaiting you + Awaiting others`. Once any other param is
- * present (search / date / signer), the default is suppressed —
- * the user has begun narrowing and the actionable filter would
- * otherwise hide envelopes they likely want to see.
+ * No filters are applied by default — a fresh visit (no params) shows
+ * every envelope, and `Clear filters` (which strips every param) does
+ * the same. An empty `status` list means "no status filter".
  *
  * Malformed values (unknown preset, broken custom range, unknown
  * status token) are silently ignored — the filter behaves as if
  * absent. Per spec: never error on an unparseable URL.
  */
 export function parseFilters(params: URLSearchParams): EnvelopeFilters {
-  const hasAnyParam =
-    params.has('q') ||
-    params.has('status') ||
-    params.has('date') ||
-    params.has('signer') ||
-    params.has('tags');
-
   return {
     q: (params.get('q') ?? '').toLowerCase(),
-    status: parseStatus(params.get('status'), hasAnyParam),
+    status: parseStatus(params.get('status')),
     date: parseDate(params.get('date')),
     signer: parseList(params.get('signer')),
     tags: parseList(params.get('tags')),
@@ -50,15 +40,9 @@ function parseList(raw: string | null): ReadonlyArray<string> {
     .filter((s) => s.length > 0);
 }
 
-function parseStatus(raw: string | null, hasAnyParam: boolean): ReadonlyArray<StatusOption> {
-  if (raw === null) {
-    // No `status` param at all: apply the actionable-inbox default
-    // ONLY if no other filter is active. Otherwise treat as "no
-    // status filter" so the user's search/date/signer scope spans
-    // every envelope.
-    return hasAnyParam ? [] : ACTIONABLE_INBOX;
-  }
-  if (raw === 'all') return [];
+function parseStatus(raw: string | null): ReadonlyArray<StatusOption> {
+  // No `status` param (or the legacy `?status=all` alias) → no filter.
+  if (raw === null || raw === 'all') return [];
   return raw
     .split(',')
     .map((s) => s.trim())
@@ -78,16 +62,9 @@ function parseDate(raw: string | null): DateFilter {
   return { kind: 'preset', preset: 'all' };
 }
 
-export interface SerializeInput extends Omit<EnvelopeFilters, 'status'> {
+export type SerializeInput = Omit<EnvelopeFilters, 'status'> & {
   readonly status: ReadonlyArray<StatusOption>;
-  /**
-   * When `true`, an empty `status` list serializes to `?status=all`.
-   * Distinguishes "user cleared the chip" (explicit) from "first
-   * visit" (defaults will re-apply on reload). Defaults to `false`,
-   * which omits the param entirely.
-   */
-  readonly explicitAllStatus?: boolean;
-}
+};
 
 /**
  * Inverse of `parseFilters` — emits a URL search-params string. Omits
@@ -98,7 +75,6 @@ export function serializeFilters(filters: SerializeInput): string {
   const out = new URLSearchParams();
   if (filters.q !== '') out.set('q', filters.q);
   if (filters.status.length > 0) out.set('status', filters.status.join(','));
-  else if (filters.explicitAllStatus === true) out.set('status', 'all');
   if (filters.date.kind === 'preset' && filters.date.preset !== 'all') {
     out.set('date', filters.date.preset);
   } else if (filters.date.kind === 'custom') {

--- a/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -119,33 +119,38 @@ function renderDashboard(initialPath = '/documents') {
 }
 
 describe('DashboardPage', () => {
-  it('renders the heading and rows from the /envelopes response', async () => {
+  it('renders the heading and every envelope by default (no status filter)', async () => {
     renderDashboard();
     expect(
       screen.getByRole('heading', { level: 1, name: /everything you've sent/i }),
     ).toBeInTheDocument();
-    // Default filter is the actionable inbox (Awaiting you + Awaiting
-    // others). MSA is awaiting_others, so it lands in the visible set.
+    // No default filter — a fresh visit shows the whole list.
     expect(await screen.findByText(/master services agreement/i)).toBeInTheDocument();
+    expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
+    expect(screen.getByText(/offer letter — m\. chen/i)).toBeInTheDocument();
   });
 
   it('narrows the table when the user picks a status from the toolbar', async () => {
-    // Default visible set is the actionable inbox (Awaiting you +
-    // Awaiting others). Sealed and Drafts are hidden by default. The
-    // toolbar's Draft checkbox flips Drafts into the visible set.
     renderDashboard();
     await screen.findByText(/master services agreement/i);
-    expect(screen.queryByText(/vendor onboarding — argus/i)).toBeNull();
-    expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
-
-    // Open the Status chip and add "Draft" to the selection.
+    // Open the Status chip and pick ONLY "Draft" (no defaults to fight).
     fireEvent.click(screen.getByRole('button', { name: /^status filter$/i }));
     fireEvent.click(await screen.findByLabelText('Draft'));
     expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
-    // Awaiting-others is still selected, so MSA stays visible.
-    expect(screen.getByText(/master services agreement/i)).toBeInTheDocument();
-    // Sealed remains unchecked, so the offer letter stays hidden.
+    // MSA (awaiting_others) and the offer letter (sealed) are now hidden.
+    expect(screen.queryByText(/master services agreement/i)).toBeNull();
     expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
+  });
+
+  it('"Clear filters" wipes every active filter and shows the whole list again', async () => {
+    // Start narrowed via the URL, then clear.
+    renderDashboard('/documents?status=draft');
+    await screen.findByText(/vendor onboarding — argus/i);
+    expect(screen.queryByText(/master services agreement/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /clear all filters/i }));
+    expect(await screen.findByText(/master services agreement/i)).toBeInTheDocument();
+    expect(screen.getByText(/offer letter — m\. chen/i)).toBeInTheDocument();
+    expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
   });
 
   it('exposes a link to start a new document', () => {


### PR DESCRIPTION
## Summary

User report (2026-05-11): the dashboard opened pre-filtered to *Awaiting you + Awaiting others*, and "Clear filters" appeared to do nothing — it stripped the URL params but \`parseFilters\` re-applied the same default, so the table never widened to the full list.

Both stem from the actionable-inbox default that landed in #226. Removing it fixes both:

- \`parseFilters\` no longer injects \`ACTIONABLE_INBOX\` when \`status\` is absent — an empty status list now means "no status filter", so a fresh visit **and** a post-Clear URL both show every envelope.
- The \`?status=all\` sentinel + \`explicitAllStatus\` plumbing (which only existed to disambiguate "first visit" from "user cleared the chip") is gone. \`?status=all\` is still accepted as a no-op alias for any bookmarked URLs, but \`serializeFilters\` simply omits the param when the status filter is empty.
- The Status chip's "Deselect all" link is now just \`setStatus([])\`.

## Tests

- \`parseFilters.test.ts\` — first-visit asserts \`status: []\`; \`serializeFilters\` no longer accepts \`explicitAllStatus\`; added "omits the status param when the filter is empty".
- \`DashboardPage.test.tsx\` — "renders every envelope by default"; new regression: open with \`?status=draft\` → click "Clear filters" → all envelopes visible again.

## Test plan

- [x] typecheck / lint / vitest 1544/1544 GREEN
- [x] \`seald-react-pr-review\` walked the diff — no MUST-FIX / SHOULD-FIX
- [ ] Post-deploy: open https://seald.nromomentum.com/documents — no filter active, full list shown; apply a status filter, click "Clear filters", list widens back

🤖 Generated with [Claude Code](https://claude.com/claude-code)