### PR TITLE
feat: server-side dashboard column sorting (sort-aware keyset cursor)

### DIFF
--- a/apps/api/src/envelopes/__tests__/envelopes.service.flows.spec.ts
+++ b/apps/api/src/envelopes/__tests__/envelopes.service.flows.spec.ts
@@ -504,7 +504,7 @@ class FakeRepo extends EnvelopesRepository {
     return this.filePaths.get(envelope_id) ?? null;
   }
   decodeCursorOrThrow(cursor: string) {
-    return { updated_at: '', id: cursor };
+    return { sort_value: '', updated_at: '', id: cursor };
   }
 
   /** Test helper: hard-stamp file paths so getDownloadUrl resolves. */

--- a/apps/api/src/envelopes/__tests__/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/__tests__/envelopes.service.spec.ts
@@ -37,6 +37,7 @@ import {
   InvalidCursorError,
   ShortCodeCollisionError,
 } from '../envelopes.repository';
+import { sortValueForKey } from '../list-cursor';
 import { eventHash } from '../event-hash';
 import { EnvelopesService } from '../envelopes.service';
 
@@ -156,7 +157,18 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
   async listByOwner(owner_id: string, opts: ListOptions): Promise<ListResult> {
     let items = [...this.envelopes.values()].filter((e) => e.owner_id === owner_id);
     if (opts.statuses) items = items.filter((e) => opts.statuses!.includes(e.status));
-    items.sort((a, b) => b.updated_at.localeCompare(a.updated_at) || b.id.localeCompare(a.id));
+    const sortKey = opts.sort ?? 'date';
+    const asc = (opts.dir ?? 'desc') === 'asc';
+    const numericKey = sortKey === 'status' || sortKey === 'signers' || sortKey === 'progress';
+    items.sort((a, b) => {
+      const va = sortValueForKey(a, sortKey);
+      const vb = sortValueForKey(b, sortKey);
+      const cmp = numericKey ? Number(va) - Number(vb) : va < vb ? -1 : va > vb ? 1 : 0;
+      const p = cmp * (asc ? 1 : -1);
+      if (p !== 0) return p;
+      if (a.updated_at !== b.updated_at) return b.updated_at.localeCompare(a.updated_at);
+      return a.id.localeCompare(b.id);
+    });
     if (opts.cursor) {
       items = items.filter(
         (e) =>
@@ -466,12 +478,12 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
     throw new Error('not_implemented_in_fake');
   }
 
-  decodeCursorOrThrow(cursor: string): { updated_at: string; id: string } {
+  decodeCursorOrThrow(cursor: string): { sort_value: string; updated_at: string; id: string } {
     try {
       const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
       const pipe = decoded.indexOf('|');
       if (pipe <= 0) throw new InvalidCursorError();
-      return { updated_at: decoded.slice(0, pipe), id: decoded.slice(pipe + 1) };
+      return { sort_value: '', updated_at: decoded.slice(0, pipe), id: decoded.slice(pipe + 1) };
     } catch (err) {
       if (err instanceof InvalidCursorError) throw err;
       throw new InvalidCursorError();
@@ -647,6 +659,27 @@ describe('EnvelopesService', () => {
         constructor: BadRequestException,
         message: 'invalid_cursor',
       });
+    });
+
+    it('rejects an unknown sort key', async () => {
+      await expect(svc.list(OWNER, { sort: 'bogus' })).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'validation_error',
+      });
+    });
+
+    it('rejects an unknown sort direction', async () => {
+      await expect(svc.list(OWNER, { sort: 'title', dir: 'sideways' })).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'validation_error',
+      });
+    });
+
+    it('accepts a valid sort key + direction and threads them to the repo', async () => {
+      await svc.createDraft(OWNER, { title: 'Banana' });
+      await svc.createDraft(OWNER, { title: 'Apple' });
+      const res = await svc.list(OWNER, { sort: 'title', dir: 'asc' });
+      expect(res.items.map((e) => e.title)).toEqual(['Apple', 'Banana']);
     });
   });
 

--- a/apps/api/src/envelopes/envelopes.controller.ts
+++ b/apps/api/src/envelopes/envelopes.controller.ts
@@ -61,6 +61,8 @@ export class EnvelopesController {
     @Query('status') statusQuery?: string,
     @Query('limit') limitQuery?: string,
     @Query('cursor') cursor?: string,
+    @Query('sort') sort?: string,
+    @Query('dir') dir?: string,
   ): Promise<ListResult> {
     const statuses = parseStatuses(statusQuery);
     const limit = limitQuery ? Number.parseInt(limitQuery, 10) : undefined;
@@ -68,6 +70,8 @@ export class EnvelopesController {
       ...(statuses ? { statuses } : {}),
       ...(limit !== undefined && Number.isFinite(limit) ? { limit } : {}),
       ...(cursor ? { cursor } : {}),
+      ...(sort ? { sort } : {}),
+      ...(dir ? { dir } : {}),
     });
   }
 

--- a/apps/api/src/envelopes/envelopes.repository.pg.ts
+++ b/apps/api/src/envelopes/envelopes.repository.pg.ts
@@ -11,10 +11,15 @@ import type {
 import { DB_TOKEN } from '../db/db.provider';
 import type { Envelope, EnvelopeSigner, EnvelopeField, EnvelopeEvent } from './envelope.entity';
 import {
+  STATUS_SORT_ORDINAL,
+  decodeListCursor,
+  encodeListCursor,
+  isNumericSortKey,
+} from './list-cursor';
+import {
   EnvelopesRepository,
   EnvelopeSignerEmailTakenError,
   EnvelopeTerminalError,
-  InvalidCursorError,
   ShortCodeCollisionError,
   type AddSignerInput,
   type CreateDraftInput,
@@ -23,6 +28,7 @@ import {
   type ListOptions,
   type ListResult,
   type EnvelopeListItem,
+  type EnvelopeSortKey,
   type SendDraftInput,
   type SetOriginalFileInput,
   type ClaimedJob,
@@ -222,24 +228,9 @@ function toListItem(row: EnvelopeRow, signerRows: ReadonlyArray<SignerRow>): Env
   };
 }
 
-function encodeCursor(updated_at: string, id: string): string {
-  return Buffer.from(`${updated_at}|${id}`, 'utf8').toString('base64');
-}
-function decodeCursor(cursor: string): { updated_at: string; id: string } {
-  let decoded: string;
-  try {
-    decoded = Buffer.from(cursor, 'base64').toString('utf8');
-  } catch {
-    throw new InvalidCursorError();
-  }
-  const pipe = decoded.indexOf('|');
-  if (pipe <= 0 || pipe === decoded.length - 1) throw new InvalidCursorError();
-  const updated_at = decoded.slice(0, pipe);
-  const id = decoded.slice(pipe + 1);
-  if (!/^\d{4}-\d{2}-\d{2}T/.test(updated_at)) throw new InvalidCursorError();
-  if (!/^[0-9a-f-]{36}$/i.test(id)) throw new InvalidCursorError();
-  return { updated_at, id };
-}
+// Keyset-cursor codec + sort-value helpers are shared with the
+// in-memory test double so the on-the-wire cursor format is
+// guaranteed identical. See ./list-cursor.ts.
 
 @Injectable()
 export class EnvelopesPgRepository extends EnvelopesRepository {
@@ -332,28 +323,102 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
   }
 
   async listByOwner(owner_id: string, opts: ListOptions): Promise<ListResult> {
-    let q = this.db
-      .selectFrom('envelopes')
-      .selectAll()
-      .where('owner_id', '=', owner_id)
-      .orderBy('updated_at', 'desc')
-      .orderBy('id', 'desc')
-      .limit(opts.limit + 1);
-    if (opts.statuses && opts.statuses.length > 0) {
-      q = q.where('status', 'in', [...opts.statuses]);
-    }
+    const sortKey: EnvelopeSortKey = opts.sort ?? 'date';
+    const asc = (opts.dir ?? 'desc') === 'asc';
+
+    // Per-envelope signer counts, materialized once via a grouped
+    // LEFT JOIN so the sort expression for `signers` / `progress`
+    // references plain columns (no correlated subquery in ORDER BY /
+    // WHERE — keeps pg-mem happy and the keyset clean).
+    //   signer_count — total envelope_signers rows
+    //   signed_count — rows with a non-null signed_at
+    //   progress_pm  — signed/total as a 0..1000 "permille" integer
+    //                  (denominator clamped to 1 so a zero-signer
+    //                   envelope is 0, never a divide-by-zero)
+    const base = this.db
+      .selectFrom('envelopes as e')
+      .leftJoin(
+        (eb) =>
+          eb
+            .selectFrom('envelope_signers as s')
+            .select((s) => [
+              's.envelope_id',
+              s.fn.countAll<number>().as('signer_count'),
+              sql<number>`sum(case when s.signed_at is not null then 1 else 0 end)`.as(
+                'signed_count',
+              ),
+            ])
+            .groupBy('s.envelope_id')
+            .as('sc'),
+        (join) => join.onRef('sc.envelope_id', '=', 'e.id'),
+      )
+      .selectAll('e')
+      .select((eb) => [
+        eb.fn.coalesce(sql<number>`sc.signer_count`, sql<number>`0`).as('signer_count'),
+        sql<number>`(coalesce(sc.signed_count, 0) * 1000 / greatest(coalesce(sc.signer_count, 0), 1))`.as(
+          'progress_pm',
+        ),
+      ])
+      .where('e.owner_id', '=', owner_id);
+
+    let q = (
+      opts.statuses && opts.statuses.length > 0
+        ? base.where('e.status', 'in', [...opts.statuses])
+        : base
+    ).limit(opts.limit + 1);
+
+    // Sort expression for the active key, expressed against the
+    // columns available after the JOIN. `title` is lower-cased so the
+    // alphabetical ordering is case-insensitive; `status` maps to a
+    // fixed presentation ordinal.
+    const sortExpr = (() => {
+      switch (sortKey) {
+        case 'date':
+          return sql<string>`e.updated_at`;
+        case 'created':
+          return sql<string>`e.created_at`;
+        case 'title':
+          return sql<string>`lower(e.title)`;
+        case 'status':
+          return sql<number>`(case e.status when 'draft' then 0 when 'awaiting_others' then 1 when 'sealing' then 2 when 'completed' then 3 when 'declined' then 4 when 'expired' then 5 when 'canceled' then 6 else 99 end)`;
+        case 'signers':
+          return sql<number>`coalesce(sc.signer_count, 0)`;
+        case 'progress':
+          return sql<number>`(coalesce(sc.signed_count, 0) * 1000 / greatest(coalesce(sc.signer_count, 0), 1))`;
+      }
+    })();
+
+    q = q
+      .orderBy(sortExpr, asc ? 'asc' : 'desc')
+      // Tie-break is ALWAYS newest-first then id ascending so a
+      // re-render never reshuffles rows the primary comparator
+      // can't distinguish, regardless of `dir`.
+      .orderBy('e.updated_at', 'desc')
+      .orderBy('e.id', 'asc');
+
     if (opts.cursor) {
-      const cursor = opts.cursor;
-      // Keyset: (updated_at, id) < (cursor.updated_at, cursor.id), desc order.
-      // `updated_at` is typed with `never` for the writes-side of Kysely's
-      // ColumnType, so we compare via sql. pg-mem does not implement the
-      // row-value comparison form `(a,b) < (c,d)`, so we spell it out as an
-      // explicit OR/AND — this also matches verbatim what real Postgres does
-      // under the hood for row comparisons.
+      const c = opts.cursor;
+      // 3-tuple keyset. The primary column follows `dir`; the
+      // `updated_at` tie-break is fixed-desc (`<`), the `id`
+      // tie-break fixed-asc (`>`). Spelled out as OR/AND rather
+      // than a row-value comparison so pg-mem can run it.
+      const primaryCmp = asc ? sql`>` : sql`<`;
+      // The cursor's sort value is re-cast to the column's type so
+      // the comparison is apples-to-apples. Numeric ordinals/counts/
+      // permille → numeric; title → text (already lower-cased when
+      // encoded); dates → timestamptz.
+      const cursorSortVal = isNumericSortKey(sortKey)
+        ? sql`${sql.lit(Number(c.sort_value))}::numeric`
+        : sortKey === 'title'
+          ? sql`${sql.lit(c.sort_value)}`
+          : sql`${sql.lit(c.sort_value)}::timestamptz`;
       q = q.where(
-        sql<boolean>`(updated_at < ${sql.lit(cursor.updated_at)}::timestamptz) or (updated_at = ${sql.lit(cursor.updated_at)}::timestamptz and id < ${sql.lit(cursor.id)}::uuid)`,
+        sql<boolean>`(${sortExpr} ${primaryCmp} ${cursorSortVal})
+          or (${sortExpr} = ${cursorSortVal} and e.updated_at < ${sql.lit(c.updated_at)}::timestamptz)
+          or (${sortExpr} = ${cursorSortVal} and e.updated_at = ${sql.lit(c.updated_at)}::timestamptz and e.id > ${sql.lit(c.id)}::uuid)`,
       );
     }
+
     const rows = await q.execute();
     const hasMore = rows.length > opts.limit;
     const page = hasMore ? rows.slice(0, opts.limit) : rows;
@@ -378,9 +443,30 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
     }
 
     const items = page.map((row) => toListItem(row, signersByEnvelope.get(row.id) ?? []));
+
+    // The next cursor's `sort_value` is the stringified value of the
+    // active sort expression for the last row of this page.
+    const sortValueOf = (row: (typeof page)[number]): string => {
+      switch (sortKey) {
+        case 'date':
+          return toIsoRequired(row.updated_at);
+        case 'created':
+          return toIsoRequired(row.created_at);
+        case 'title':
+          return row.title.toLowerCase();
+        case 'status':
+          return String(STATUS_SORT_ORDINAL[row.status]);
+        case 'signers':
+          return String(Number(row.signer_count ?? 0));
+        case 'progress':
+          return String(Number(row.progress_pm ?? 0));
+      }
+    };
     const last = page[page.length - 1];
     const next_cursor =
-      hasMore && last ? encodeCursor(toIsoRequired(last.updated_at), last.id) : null;
+      hasMore && last
+        ? encodeListCursor(sortValueOf(last), toIsoRequired(last.updated_at), last.id)
+        : null;
     return { items, next_cursor };
   }
 
@@ -589,8 +675,8 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
 
   // Decode helper exposed for the service layer — keeps base64 format internal
   // to the adapter. Not part of the port because cursors are a repo concern.
-  decodeCursorOrThrow(cursor: string): { updated_at: string; id: string } {
-    return decodeCursor(cursor);
+  decodeCursorOrThrow(cursor: string): { sort_value: string; updated_at: string; id: string } {
+    return decodeListCursor(cursor);
   }
 
   // ---------- Draft composition ----------

--- a/apps/api/src/envelopes/envelopes.repository.ts
+++ b/apps/api/src/envelopes/envelopes.repository.ts
@@ -120,10 +120,41 @@ export interface SignerAuditDetail {
   readonly signing_ip: string | null;
 }
 
+/**
+ * Sortable columns for the envelope list. `signers` orders by the
+ * count of `envelope_signers` rows; `progress` by the completed /
+ * total ratio (0 when an envelope has no signers). The rest map to
+ * literal `envelopes` columns. Default is `date` (i.e. `updated_at`).
+ */
+export const ENVELOPE_SORT_KEYS = [
+  'date',
+  'created',
+  'title',
+  'status',
+  'signers',
+  'progress',
+] as const;
+export type EnvelopeSortKey = (typeof ENVELOPE_SORT_KEYS)[number];
+export type SortDir = 'asc' | 'desc';
+
+/**
+ * Keyset cursor. `sort_value` is the stringified value of the active
+ * sort expression for the last row of the previous page; `updated_at`
+ * + `id` are the always-unique tie-break so the 3-tuple is a total
+ * order even when many rows share the same `sort_value`.
+ */
+export interface ListCursor {
+  readonly sort_value: string;
+  readonly updated_at: string;
+  readonly id: string;
+}
+
 export interface ListOptions {
   readonly statuses?: ReadonlyArray<EnvelopeStatus>;
   readonly limit: number; // 1..100
-  readonly cursor?: { readonly updated_at: string; readonly id: string } | null;
+  readonly sort?: EnvelopeSortKey; // default 'date'
+  readonly dir?: SortDir; // default 'desc'
+  readonly cursor?: ListCursor | null;
 }
 
 export interface EnvelopeListSignerSnippet {
@@ -378,10 +409,11 @@ export abstract class EnvelopesRepository {
     }>
   >;
 
-  // Cursor helper — decode the opaque cursor returned by listByOwner. Throws
-  // InvalidCursorError on malformed input. Lives on the port so the service
-  // layer doesn't need to know the cursor encoding format.
-  abstract decodeCursorOrThrow(cursor: string): { updated_at: string; id: string };
+  // Cursor helper — decode the opaque 3-tuple cursor returned by
+  // listByOwner. Throws InvalidCursorError on malformed input. Lives
+  // on the port so the service layer doesn't need to know the cursor
+  // encoding format.
+  abstract decodeCursorOrThrow(cursor: string): ListCursor;
 
   /**
    * Issues #38 / #43 — atomic account-deletion purge for the

--- a/apps/api/src/envelopes/envelopes.service.ts
+++ b/apps/api/src/envelopes/envelopes.service.ts
@@ -32,11 +32,15 @@ import type {
   EnvelopeEvent,
   EnvelopeField,
   EnvelopeSigner,
+  EnvelopeSortKey,
+  ListCursor,
   ListResult,
   SetOriginalFileInput,
+  SortDir,
   UpdateDraftMetadataPatch,
 } from './envelopes.repository';
 import {
+  ENVELOPE_SORT_KEYS,
   EnvelopeSignerEmailTakenError,
   EnvelopesRepository,
   InvalidCursorError,
@@ -126,7 +130,13 @@ export class EnvelopesService {
 
   async list(
     owner_id: string,
-    opts: { statuses?: readonly EnvelopeStatus[]; limit?: number; cursor?: string },
+    opts: {
+      statuses?: readonly EnvelopeStatus[];
+      limit?: number;
+      cursor?: string;
+      sort?: string;
+      dir?: string;
+    },
   ): Promise<ListResult> {
     const clampedLimit = Math.max(1, Math.min(100, opts.limit ?? 20));
 
@@ -138,7 +148,22 @@ export class EnvelopesService {
       }
     }
 
-    let cursor: { updated_at: string; id: string } | null = null;
+    let sort: EnvelopeSortKey | undefined;
+    if (opts.sort !== undefined) {
+      if (!(ENVELOPE_SORT_KEYS as readonly string[]).includes(opts.sort)) {
+        throw new BadRequestException('validation_error');
+      }
+      sort = opts.sort as EnvelopeSortKey;
+    }
+    let dir: SortDir | undefined;
+    if (opts.dir !== undefined) {
+      if (opts.dir !== 'asc' && opts.dir !== 'desc') {
+        throw new BadRequestException('validation_error');
+      }
+      dir = opts.dir;
+    }
+
+    let cursor: ListCursor | null = null;
     if (opts.cursor) {
       try {
         cursor = this.repo.decodeCursorOrThrow(opts.cursor);
@@ -151,6 +176,8 @@ export class EnvelopesService {
     return this.repo.listByOwner(owner_id, {
       ...(opts.statuses ? { statuses: opts.statuses } : {}),
       limit: clampedLimit,
+      ...(sort !== undefined ? { sort } : {}),
+      ...(dir !== undefined ? { dir } : {}),
       cursor,
     });
   }

--- a/apps/api/src/envelopes/list-cursor.ts
+++ b/apps/api/src/envelopes/list-cursor.ts
@@ -1,0 +1,86 @@
+import type { Envelope } from './envelope.entity';
+import { InvalidCursorError, type EnvelopeSortKey, type ListCursor } from './envelopes.repository';
+
+/**
+ * Shared keyset-cursor codec + sort-value helpers for the envelope
+ * list. Both the Postgres adapter and the in-memory test double use
+ * these so the on-the-wire cursor format is guaranteed identical
+ * (the e2e suite runs against the in-memory repo; production runs
+ * against Pg — they must agree byte-for-byte).
+ *
+ * Cursor wire format: `base64("<sortValue><updatedAt><id>")`.
+ * The unit-separator (``) can't appear in any of the three
+ * fields (sort values are dates / lower-cased titles / numbers, all
+ * separator-free), so a plain split is unambiguous.
+ */
+
+const SEP = '';
+
+/**
+ * Fixed presentation order for the Status column sort. Independent of
+ * the `ENVELOPE_STATUSES` declaration order so re-ordering the enum
+ * upstream never changes the dashboard sort.
+ */
+export const STATUS_SORT_ORDINAL: Record<Envelope['status'], number> = {
+  draft: 0,
+  awaiting_others: 1,
+  sealing: 2,
+  completed: 3,
+  declined: 4,
+  expired: 5,
+  canceled: 6,
+};
+
+/** signed/total expressed as a 0..1000 integer "permille" (0 for no signers). */
+function progressPermille(e: Envelope): number {
+  const total = e.signers.length;
+  if (total === 0) return 0;
+  const signed = e.signers.filter((s) => s.signed_at !== null).length;
+  return Math.trunc((signed * 1000) / Math.max(total, 1));
+}
+
+/**
+ * Stringified value of the active sort expression for an envelope —
+ * this is what gets baked into the next-page cursor. Mirrors the SQL
+ * expressions in `EnvelopesPgRepository.listByOwner`.
+ */
+export function sortValueForKey(e: Envelope, key: EnvelopeSortKey): string {
+  switch (key) {
+    case 'date':
+      return e.updated_at;
+    case 'created':
+      return e.created_at;
+    case 'title':
+      return e.title.toLowerCase();
+    case 'status':
+      return String(STATUS_SORT_ORDINAL[e.status]);
+    case 'signers':
+      return String(e.signers.length);
+    case 'progress':
+      return String(progressPermille(e));
+  }
+}
+
+/** Whether a sort key compares as a number (vs a string). */
+export function isNumericSortKey(key: EnvelopeSortKey): boolean {
+  return key === 'status' || key === 'signers' || key === 'progress';
+}
+
+export function encodeListCursor(sortValue: string, updatedAt: string, id: string): string {
+  return Buffer.from(`${sortValue}${SEP}${updatedAt}${SEP}${id}`, 'utf8').toString('base64');
+}
+
+export function decodeListCursor(cursor: string): ListCursor {
+  let decoded: string;
+  try {
+    decoded = Buffer.from(cursor, 'base64').toString('utf8');
+  } catch {
+    throw new InvalidCursorError();
+  }
+  const parts = decoded.split(SEP);
+  if (parts.length !== 3) throw new InvalidCursorError();
+  const [sort_value, updated_at, id] = parts as [string, string, string];
+  if (!/^\d{4}-\d{2}-\d{2}T/.test(updated_at)) throw new InvalidCursorError();
+  if (!/^[0-9a-f-]{36}$/i.test(id)) throw new InvalidCursorError();
+  return { sort_value, updated_at, id };
+}

--- a/apps/api/src/me/me.service.ts
+++ b/apps/api/src/me/me.service.ts
@@ -499,7 +499,11 @@ export class MeService {
    */
   private async collectEnvelopeIds(ownerId: string): Promise<ReadonlyArray<string>> {
     const ids: string[] = [];
-    let cursor: { updated_at: string; id: string } | null = null;
+    // 3-tuple keyset cursor (sort_value, updated_at, id). The export
+    // pages with the default sort (date desc), so `sort_value` is
+    // just the row's `updated_at` — but we let the repo own the
+    // shape via `decodeCursorOrThrow`.
+    let cursor: { sort_value: string; updated_at: string; id: string } | null = null;
     // Hard upper bound to keep tests deterministic and detect misuse if
     // a future bug returns a non-advancing cursor.
     for (let i = 0; i < 1000; i++) {

--- a/apps/api/test/in-memory-envelopes-repository.ts
+++ b/apps/api/test/in-memory-envelopes-repository.ts
@@ -20,9 +20,9 @@ import type {
 import {
   EnvelopeSignerEmailTakenError,
   EnvelopesRepository,
-  InvalidCursorError,
   ShortCodeCollisionError,
 } from '../src/envelopes/envelopes.repository';
+import { decodeListCursor, encodeListCursor, sortValueForKey } from '../src/envelopes/list-cursor';
 
 /**
  * In-memory envelopes repository for e2e tests. Covers the subset of methods
@@ -122,14 +122,50 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
       const set = new Set(opts.statuses);
       items = items.filter((e) => set.has(e.status));
     }
-    items.sort((a, b) => b.updated_at.localeCompare(a.updated_at) || b.id.localeCompare(a.id));
+
+    const sortKey = opts.sort ?? 'date';
+    const asc = (opts.dir ?? 'desc') === 'asc';
+    const sortValueOf = (e: Envelope): string => sortValueForKey(e, sortKey);
+    // Lexicographic comparison on the same column type the Pg repo
+    // uses: dates / titles compare as strings, the numeric keys as
+    // numbers.
+    const primaryCmp = (a: Envelope, b: Envelope): number => {
+      const va = sortValueOf(a);
+      const vb = sortValueOf(b);
+      if (sortKey === 'date' || sortKey === 'created' || sortKey === 'title') {
+        return va < vb ? -1 : va > vb ? 1 : 0;
+      }
+      return Number(va) - Number(vb);
+    };
+    items.sort((a, b) => {
+      const p = primaryCmp(a, b) * (asc ? 1 : -1);
+      if (p !== 0) return p;
+      // Fixed tie-break: newest first, then id ascending.
+      if (a.updated_at !== b.updated_at) return b.updated_at.localeCompare(a.updated_at);
+      return a.id.localeCompare(b.id);
+    });
+
     if (opts.cursor) {
-      items = items.filter(
-        (e) =>
-          e.updated_at < opts.cursor!.updated_at ||
-          (e.updated_at === opts.cursor!.updated_at && e.id < opts.cursor!.id),
-      );
+      const c = opts.cursor;
+      const after = (e: Envelope): boolean => {
+        const v = sortValueOf(e);
+        const numericKey = !(sortKey === 'date' || sortKey === 'created' || sortKey === 'title');
+        const primary = numericKey
+          ? asc
+            ? Number(v) > Number(c.sort_value)
+            : Number(v) < Number(c.sort_value)
+          : asc
+            ? v > c.sort_value
+            : v < c.sort_value;
+        if (primary) return true;
+        const eq = numericKey ? Number(v) === Number(c.sort_value) : v === c.sort_value;
+        if (!eq) return false;
+        if (e.updated_at < c.updated_at) return true;
+        return e.updated_at === c.updated_at && e.id > c.id;
+      };
+      items = items.filter(after);
     }
+
     const page = items.slice(0, opts.limit);
     const mapped = page.map((e) => ({
       id: e.id,
@@ -152,11 +188,10 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
         signed_at: s.signed_at,
       })),
     }));
+    const lastEnv = page[page.length - 1];
     const next =
-      page.length === opts.limit && items.length > opts.limit
-        ? Buffer.from(`${page[page.length - 1]!.updated_at}|${page[page.length - 1]!.id}`).toString(
-            'base64url',
-          )
+      page.length === opts.limit && items.length > opts.limit && lastEnv
+        ? encodeListCursor(sortValueOf(lastEnv), lastEnv.updated_at, lastEnv.id)
         : null;
     return { items: mapped, next_cursor: next };
   }
@@ -773,16 +808,8 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
     };
   }
 
-  decodeCursorOrThrow(cursor: string): { updated_at: string; id: string } {
-    try {
-      const decoded = Buffer.from(cursor, 'base64url').toString('utf8');
-      const pipe = decoded.indexOf('|');
-      if (pipe <= 0) throw new InvalidCursorError();
-      return { updated_at: decoded.slice(0, pipe), id: decoded.slice(pipe + 1) };
-    } catch (err) {
-      if (err instanceof InvalidCursorError) throw err;
-      throw new InvalidCursorError();
-    }
+  decodeCursorOrThrow(cursor: string): { sort_value: string; updated_at: string; id: string } {
+    return decodeListCursor(cursor);
   }
 
   /**

--- a/apps/web/src/features/dashboardFilters/index.ts
+++ b/apps/web/src/features/dashboardFilters/index.ts
@@ -1,6 +1,14 @@
 export { parseFilters, serializeFilters, type SerializeInput } from './parseFilters';
 export { filterEnvelopes, isAwaitingYou, bucketEnvelope } from './filterEnvelopes';
 export {
+  parseSort,
+  DEFAULT_SORT,
+  SORT_KEYS,
+  type SortKey,
+  type SortDir,
+  type SortState,
+} from './sortEnvelopes';
+export {
   ACTIONABLE_INBOX,
   DATE_PRESETS,
   STATUS_OPTIONS,

--- a/apps/web/src/features/dashboardFilters/sortEnvelopes.test.ts
+++ b/apps/web/src/features/dashboardFilters/sortEnvelopes.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { parseSort, DEFAULT_SORT } from './sortEnvelopes';
+
+describe('parseSort', () => {
+  it('returns the default (date desc) when there is no sort param', () => {
+    expect(parseSort(new URLSearchParams())).toEqual(DEFAULT_SORT);
+    expect(DEFAULT_SORT).toEqual({ key: 'date', dir: 'desc' });
+  });
+
+  it('parses a valid sort key and direction', () => {
+    expect(parseSort(new URLSearchParams('sort=title&dir=asc'))).toEqual({
+      key: 'title',
+      dir: 'asc',
+    });
+  });
+
+  it('accepts every supported sort key', () => {
+    for (const key of ['title', 'signers', 'progress', 'status', 'date'] as const) {
+      expect(parseSort(new URLSearchParams(`sort=${key}&dir=desc`)).key).toBe(key);
+    }
+  });
+
+  it('falls back to the default key when the sort param is bogus', () => {
+    expect(parseSort(new URLSearchParams('sort=bogus&dir=asc'))).toEqual({
+      key: 'date',
+      dir: 'asc',
+    });
+  });
+
+  it('falls back to the default direction when dir is bogus', () => {
+    expect(parseSort(new URLSearchParams('sort=status&dir=sideways'))).toEqual({
+      key: 'status',
+      dir: 'desc',
+    });
+  });
+});

--- a/apps/web/src/features/dashboardFilters/sortEnvelopes.ts
+++ b/apps/web/src/features/dashboardFilters/sortEnvelopes.ts
@@ -1,0 +1,43 @@
+/**
+ * Dashboard list sort — URL contract only.
+ *
+ * The actual ordering is performed server-side: the `/envelopes` list
+ * endpoint accepts `?sort=<key>&dir=<asc|desc>`, orders by that
+ * column, and keysets its cursor accordingly. The frontend's only
+ * job is to parse the sort state out of the URL and reflect it in
+ * the column headers — so this module is just the parser + the
+ * shared key/dir vocabulary.
+ *
+ * Sort-key vocabulary matches the API's `EnvelopeSortKey` (minus the
+ * `created` key, which the dashboard doesn't surface a column for).
+ * The dashboard column id `document` maps to the `title` sort key —
+ * see the `COLUMN_SORT_KEY` map in `DashboardPage`.
+ */
+
+export const SORT_KEYS = ['title', 'signers', 'progress', 'status', 'date'] as const;
+export type SortKey = (typeof SORT_KEYS)[number];
+export type SortDir = 'asc' | 'desc';
+
+export interface SortState {
+  readonly key: SortKey;
+  readonly dir: SortDir;
+}
+
+/** No `?sort=` param → newest-updated-first. */
+export const DEFAULT_SORT: SortState = { key: 'date', dir: 'desc' };
+
+const SORT_KEY_SET = new Set<string>(SORT_KEYS);
+
+/**
+ * Decode `?sort=<key>&dir=<asc|desc>` from the dashboard URL.
+ * Unknown / missing values fall back to {@link DEFAULT_SORT}'s parts
+ * — never throws.
+ */
+export function parseSort(params: URLSearchParams): SortState {
+  const rawKey = params.get('sort');
+  const rawDir = params.get('dir');
+  const key: SortKey =
+    rawKey !== null && SORT_KEY_SET.has(rawKey) ? (rawKey as SortKey) : DEFAULT_SORT.key;
+  const dir: SortDir = rawDir === 'asc' || rawDir === 'desc' ? rawDir : DEFAULT_SORT.dir;
+  return { key, dir };
+}

--- a/apps/web/src/features/envelopes/envelopesApi.ts
+++ b/apps/web/src/features/envelopes/envelopesApi.ts
@@ -68,10 +68,21 @@ export interface EnvelopeListResponse {
   readonly next_cursor: string | null;
 }
 
+/**
+ * Server-side sort keys accepted by `GET /envelopes`. `signers` orders
+ * by signer count, `progress` by the completed/total ratio; the rest
+ * map to `envelopes` columns. `title` is the dashboard's "Document"
+ * column.
+ */
+export type EnvelopeSortKey = 'date' | 'created' | 'title' | 'status' | 'signers' | 'progress';
+export type EnvelopeSortDir = 'asc' | 'desc';
+
 export interface ListEnvelopesParams {
   readonly statuses?: ReadonlyArray<EnvelopeStatus>;
   readonly limit?: number;
   readonly cursor?: string;
+  readonly sort?: EnvelopeSortKey;
+  readonly dir?: EnvelopeSortDir;
 }
 
 export interface FieldPlacement {
@@ -101,6 +112,8 @@ export async function listEnvelopes(
   if (params.statuses?.length) query.set('status', params.statuses.join(','));
   if (params.limit) query.set('limit', String(params.limit));
   if (params.cursor) query.set('cursor', params.cursor);
+  if (params.sort) query.set('sort', params.sort);
+  if (params.dir) query.set('dir', params.dir);
   const q = query.toString();
   const url = q ? `/envelopes?${q}` : '/envelopes';
   const { data } = await apiClient.get<EnvelopeListResponse>(url, configWithSignal(signal));

--- a/apps/web/src/pages/DashboardPage/DashboardPage.styles.ts
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.styles.ts
@@ -110,6 +110,42 @@ export const HeadCell = styled.div`
   /* Each header cell hosts an absolutely-positioned ColumnResizeHandle
      pinned to its right edge — needs a positioning context. */
   position: relative;
+  display: flex;
+  align-items: center;
+`;
+
+/**
+ * Clickable column label that toggles the server-side sort. Fills the
+ * cell except for the 6px resize handle at the right edge, so a click
+ * anywhere on the label sorts and a grab right at the border resizes.
+ */
+export const SortHeaderButton = styled.button<{ $active: boolean }>`
+  all: unset;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: inherit;
+  text-transform: inherit;
+  color: ${({ theme, $active }) => ($active ? theme.color.fg[1] : 'inherit')};
+  padding: 2px 4px;
+  margin-left: -4px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  &:hover {
+    color: ${({ theme }) => theme.color.fg[1]};
+  }
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;
+
+export const SortCaret = styled.span`
+  display: inline-flex;
+  font-size: 10px;
+  line-height: 1;
+  color: ${({ theme }) => theme.color.indigo[600]};
 `;
 
 export const TableRow = styled.button<{ $grid: string }>`

--- a/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { DashboardPage } from './DashboardPage';
 import { renderWithProviders } from '../../test/renderWithProviders';
@@ -189,5 +189,45 @@ describe('DashboardPage', () => {
     await screen.findByText(/vendor onboarding — argus/i);
     expect(screen.queryByText(/master services agreement/i)).toBeNull();
     expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
+  });
+
+  it('clicking a column header cycles the server-side sort params and re-queries', async () => {
+    // Resolve the mocked apiClient so we can inspect the URLs it was
+    // called with — the server does the sort, so the contract we test
+    // is "the request carried the right ?sort=&dir=".
+    const { apiClient } = await import('../../lib/api/apiClient');
+    const getMock = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+    const lastEnvelopeUrl = (): string =>
+      String(
+        [...getMock.mock.calls].reverse().find((c) => String(c[0]).startsWith('/envelopes'))![0],
+      );
+
+    renderDashboard();
+    await screen.findByText(/master services agreement/i);
+    // Initial fetch carries the default sort explicitly (server treats
+    // `date desc` the same as no params).
+    expect(lastEnvelopeUrl()).toMatch(/sort=date&dir=desc/);
+
+    // Click "Document" → ?sort=title&dir=asc, refetch.
+    fireEvent.click(screen.getByRole('button', { name: /^document$/i }));
+    await waitFor(() => {
+      expect(lastEnvelopeUrl()).toMatch(/sort=title&dir=asc/);
+    });
+    // The header now advertises its sort direction.
+    expect(
+      screen.getByRole('button', { name: /^document/i }).closest('[aria-sort]'),
+    ).toHaveAttribute('aria-sort', 'ascending');
+
+    // Click again → ?sort=title&dir=desc.
+    fireEvent.click(screen.getByRole('button', { name: /^document/i }));
+    await waitFor(() => {
+      expect(lastEnvelopeUrl()).toMatch(/sort=title&dir=desc/);
+    });
+
+    // Click a third time → back to the default order.
+    fireEvent.click(screen.getByRole('button', { name: /^document/i }));
+    await waitFor(() => {
+      expect(lastEnvelopeUrl()).toMatch(/sort=date&dir=desc/);
+    });
   });
 });

--- a/apps/web/src/pages/DashboardPage/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 import type { JSX } from 'react';
 import { ChevronRight, UploadCloud } from 'lucide-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -21,7 +21,13 @@ import { Skeleton } from '@/components/Skeleton';
 import { StatCard } from '@/components/StatCard';
 import { useEnvelopesQuery } from '@/features/envelopes';
 import type { EnvelopeListItem, EnvelopeStatus } from '@/features/envelopes';
-import { filterEnvelopes, isAwaitingYou, parseFilters } from '@/features/dashboardFilters';
+import {
+  filterEnvelopes,
+  isAwaitingYou,
+  parseFilters,
+  parseSort,
+  type SortKey,
+} from '@/features/dashboardFilters';
 import { formatShortDate } from '@/lib/dateFormat';
 import { useAuth } from '@/providers/AuthProvider';
 import {
@@ -39,6 +45,8 @@ import {
   Main,
   ProgressCell,
   SignersCell,
+  SortCaret,
+  SortHeaderButton,
   StatGrid,
   TableHead,
   TableRow,
@@ -53,6 +61,15 @@ const COLUMN_LABELS: Record<ColKey, string> = {
   progress: 'Progress',
   status: 'Status',
   date: 'Date',
+};
+// The column id (the localStorage width key) maps to the sort key the
+// API understands — only `document` differs (sorts by `title`).
+const COLUMN_SORT_KEY: Record<ColKey, SortKey> = {
+  document: 'title',
+  signers: 'signers',
+  progress: 'progress',
+  status: 'status',
+  date: 'date',
 };
 const COLUMN_SPECS = COLUMN_KEYS.map((k) => ({
   key: k,
@@ -263,9 +280,16 @@ function renderDocumentsBody(args: RenderDocumentsBodyArgs): JSX.Element | JSX.E
  */
 export function DashboardPage() {
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
 
-  const q = useEnvelopesQuery(true, { limit: 100 });
+  // Click-to-sort: the sort key + direction live in the URL
+  // (`?sort=date&dir=desc`) so the view is bookmarkable. The sort is
+  // performed server-side — the list endpoint orders + keysets by
+  // these params — so the page just reflects whatever order the API
+  // returned.
+  const sort = useMemo(() => parseSort(searchParams), [searchParams]);
+
+  const q = useEnvelopesQuery(true, { limit: 100, sort: sort.key, dir: sort.dir });
   const envelopes: ReadonlyArray<EnvelopeListItem> = useMemo(() => q.data?.items ?? [], [q.data]);
   const documentsLoading = q.isPending;
 
@@ -274,14 +298,41 @@ export function DashboardPage() {
   const { user } = useAuth();
   const viewerEmail = user?.email ?? null;
 
-  // The new toolbar owns filter UI and writes to the URL; the page
-  // reads the URL and applies a single combined filter pass. Keeps
-  // the toolbar pluggable (piece #2 will add a tag chip) without
-  // pushing per-filter state into the page.
+  // The toolbar owns filter UI and writes to the URL; the page reads
+  // the URL and applies a single combined filter pass. `filterEnvelopes`
+  // is a stable client-side narrowing (preserves input order), so the
+  // server's sort order survives it.
   const parsedFilters = useMemo(() => parseFilters(searchParams), [searchParams]);
   const filtered = useMemo(
     () => filterEnvelopes(envelopes, parsedFilters, viewerEmail),
     [envelopes, parsedFilters, viewerEmail],
+  );
+
+  // Header click cycle: not-active → asc; active+asc → desc;
+  // active+desc → back to the default (strip both params).
+  const handleSortClick = useCallback(
+    (key: SortKey): void => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const isActive = next.get('sort') === key;
+          const curDir = next.get('dir');
+          if (!isActive) {
+            next.set('sort', key);
+            next.set('dir', 'asc');
+          } else if (curDir === 'asc') {
+            next.set('sort', key);
+            next.set('dir', 'desc');
+          } else {
+            next.delete('sort');
+            next.delete('dir');
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
   );
 
   // Per-user column widths persisted in localStorage (piece 3 of the
@@ -350,16 +401,32 @@ export function DashboardPage() {
 
         <TableShell>
           <TableHead role="row" $grid={gridTemplate}>
-            {COLUMN_KEYS.map((key) => (
-              <HeadCell key={key}>
-                {COLUMN_LABELS[key]}
-                <ColumnResizeHandle
-                  width={widths[key] ?? DEFAULT_COLUMN_WIDTHS[key]}
-                  onResize={(px) => setWidth(key, px)}
-                  ariaLabel={`Resize ${COLUMN_LABELS[key]} column`}
-                />
-              </HeadCell>
-            ))}
+            {COLUMN_KEYS.map((key) => {
+              const sortKey = COLUMN_SORT_KEY[key];
+              const active = sort.key === sortKey;
+              return (
+                <HeadCell
+                  key={key}
+                  aria-sort={active ? (sort.dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+                >
+                  <SortHeaderButton
+                    type="button"
+                    $active={active}
+                    onClick={() => handleSortClick(sortKey)}
+                  >
+                    {COLUMN_LABELS[key]}
+                    {active ? (
+                      <SortCaret aria-hidden>{sort.dir === 'asc' ? '▲' : '▼'}</SortCaret>
+                    ) : null}
+                  </SortHeaderButton>
+                  <ColumnResizeHandle
+                    width={widths[key] ?? DEFAULT_COLUMN_WIDTHS[key]}
+                    onResize={(px) => setWidth(key, px)}
+                    ariaLabel={`Resize ${COLUMN_LABELS[key]} column`}
+                  />
+                </HeadCell>
+              );
+            })}
             <div aria-hidden />
           </TableHead>
           {renderDocumentsBody({

--- a/docs/superpowers/specs/2026-05-11-dashboard-column-sorting-design.md
+++ b/docs/superpowers/specs/2026-05-11-dashboard-column-sorting-design.md
@@ -1,0 +1,121 @@
+# Dashboard column sorting — design
+
+**Date:** 2026-05-11
+**Scope:** Click-to-sort on the dashboard table columns, with the sort
+key + direction in the URL so views are bookmarkable. Builds on the
+filter toolbar (#226) and the resizable columns (#228).
+
+## Goal
+
+Click a column header → sort the visible rows by that column. Three
+clicks cycle ascending → descending → default (Date, newest-first).
+The active column shows a ▲/▼ caret.
+
+## Non-goals (deferred)
+
+- Multi-column sort (shift-click to add a secondary key).
+- Server-side sort. The list is capped at 100 rows client-side; an
+  in-memory sort is plenty.
+- Drag-to-reorder columns (different gesture; the resize handle owns
+  the right edge already).
+
+## Architecture
+
+### `sortEnvelopes` pure helper (new — `features/dashboardFilters/sortEnvelopes.ts`)
+
+```ts
+type SortKey = 'document' | 'signers' | 'progress' | 'status' | 'date';
+type SortDir = 'asc' | 'desc';
+interface SortState { readonly key: SortKey; readonly dir: SortDir }
+const DEFAULT_SORT: SortState = { key: 'date', dir: 'desc' };
+
+function sortEnvelopes(
+  list: ReadonlyArray<EnvelopeListItem>,
+  sort: SortState,
+): ReadonlyArray<EnvelopeListItem>;
+```
+
+Comparators (ascending; `dir === 'desc'` reverses the result):
+
+| key | comparator |
+|---|---|
+| `document` | `a.title.localeCompare(b.title)` (case-insensitive via `localeCompare` default) |
+| `signers` | `a.signers.length - b.signers.length` |
+| `progress` | `pct(a) - pct(b)` where `pct(e) = e.signers.length === 0 ? 0 : signedCount(e) / e.signers.length`; `signedCount` counts signers with `status === 'completed'` |
+| `status` | `STATUS_ORDINAL[a.status] - STATUS_ORDINAL[b.status]` |
+| `date` | `Date.parse(a.updated_at) - Date.parse(b.updated_at)` |
+
+`STATUS_ORDINAL`: `draft 0`, `awaiting_others 1`, `sealing 2`,
+`completed 3`, `declined 4`, `expired 5`, `canceled 6`.
+
+**Tie-break:** when the primary comparator returns 0, fall back to
+`updated_at` **descending**, then `id` ascending — so a re-render
+never reshuffles equal rows. (`Array.prototype.sort` is stable in
+every engine we target, but the explicit tie-break makes the order
+deterministic regardless of input ordering from the API.)
+
+Pure; does not mutate the input — returns a fresh array.
+
+### `parseSort` (new — same file)
+
+```ts
+function parseSort(params: URLSearchParams): SortState;
+```
+
+- `sort` ∈ {document, signers, progress, status, date}; anything else
+  → `DEFAULT_SORT.key`.
+- `dir` ∈ {asc, desc}; anything else → `DEFAULT_SORT.dir`.
+- No `sort` param at all → `DEFAULT_SORT` (date desc).
+
+Companion writer is folded into the existing `DashboardPage` URL
+plumbing (it already does targeted `URLSearchParams` deletes/sets for
+the filter chips) — no new `serializeSort`; the page just sets/deletes
+`sort` and `dir` directly.
+
+### `DashboardPage` integration
+
+1. `const sort = useMemo(() => parseSort(searchParams), [searchParams])`.
+2. `const sorted = useMemo(() => sortEnvelopes(filtered, sort), [filtered, sort])`.
+   The `filtered` list (from `filterEnvelopes`) feeds straight in;
+   `renderDocumentsBody` consumes `sorted`.
+3. Header cells gain a `<SortButton>` wrapping the label + caret. The
+   `ColumnResizeHandle` stays as-is (pinned to the right edge, 6 px;
+   the label button fills the rest). Clicking the label:
+   - Not the active column → set `sort=<key>&dir=asc`.
+   - Active column, `asc` → flip to `desc`.
+   - Active column, `desc` → strip `sort` + `dir` (back to default).
+4. Caret rendering: on the active column, a `▲` for `asc` / `▼` for
+   `desc`. Inactive columns show no caret (a faint `↕` on hover is a
+   NICE-TO-HAVE, not in this PR).
+
+The chevron column header (`<div aria-hidden />`) is not sortable.
+
+## Accessibility
+
+- Each sortable header label is a `<button type="button">` inside the
+  `HeadCell`. `aria-sort` on the `HeadCell` reflects state:
+  `"ascending"` / `"descending"` on the active column, `"none"`
+  elsewhere. The button's accessible name is the column label; the
+  caret glyph is `aria-hidden`.
+
+## Tests
+
+| Layer | What it asserts |
+|---|---|
+| `sortEnvelopes.test.ts` | Each comparator orders correctly asc + desc; progress handles zero-signer envelopes; tie-break by `updated_at` desc then `id`; input is not mutated. |
+| `parseSort.test.ts` (or folded into the same file) | Defaults when no param; valid `sort`/`dir` parsed; bogus values fall back to default. |
+| `DashboardPage.test.tsx` | Clicking the Document header sorts rows A→Z (assert DOM order via `getAllByRole('button', { name: /Open / })`); a second click reverses; a third resets to date-desc; the active header carries `aria-sort`. |
+
+## Risk + rollback
+
+- Pure UI; no API/DB change. Reverting the PR drops the sort affordance
+  and the table renders in the API's default order again.
+- `Date.parse` of a malformed `updated_at` would yield `NaN` — guarded
+  by treating `NaN` as `0` so a bad row sinks to a stable position
+  rather than throwing.
+
+## Local review checkpoint
+
+Default cadence (review-before-push) — but given the velocity this
+session and the small surface, this ships through CI like the recent
+fixes. Dev server on :5173 picks it up via HMR for inspection.

--- a/docs/superpowers/specs/2026-05-11-dashboard-column-sorting-design.md
+++ b/docs/superpowers/specs/2026-05-11-dashboard-column-sorting-design.md
@@ -1,121 +1,154 @@
-# Dashboard column sorting — design
+# Dashboard column sorting — design (server-side, sort-aware cursor)
 
 **Date:** 2026-05-11
-**Scope:** Click-to-sort on the dashboard table columns, with the sort
-key + direction in the URL so views are bookmarkable. Builds on the
-filter toolbar (#226) and the resizable columns (#228).
+**Scope:** Click-to-sort on the dashboard table columns. The sort is
+performed **server-side**: clicking a header re-queries `GET /envelopes`
+with `?sort=&dir=`, and keyset pagination is made sort-aware so the
+cursor stays consistent for any sort key. Builds on the filter toolbar
+(#226) and resizable columns (#228).
 
 ## Goal
 
-Click a column header → sort the visible rows by that column. Three
-clicks cycle ascending → descending → default (Date, newest-first).
-The active column shows a ▲/▼ caret.
+Click a column header → the table re-fetches ordered by that column.
+Three clicks cycle ascending → descending → default (date, newest-
+first). The active header shows a ▲/▼ caret. The sort key + dir live
+in the URL (`?sort=title&dir=asc`) so the view is bookmarkable.
 
 ## Non-goals (deferred)
 
-- Multi-column sort (shift-click to add a secondary key).
-- Server-side sort. The list is capped at 100 rows client-side; an
-  in-memory sort is plenty.
-- Drag-to-reorder columns (different gesture; the resize handle owns
-  the right edge already).
+- Multi-column sort.
+- Reordering columns (the resize handle owns the right edge).
 
-## Architecture
+## Wire contract
 
-### `sortEnvelopes` pure helper (new — `features/dashboardFilters/sortEnvelopes.ts`)
+`GET /envelopes?sort=<key>&dir=<asc|desc>&limit=&cursor=`
 
-```ts
-type SortKey = 'document' | 'signers' | 'progress' | 'status' | 'date';
-type SortDir = 'asc' | 'desc';
-interface SortState { readonly key: SortKey; readonly dir: SortDir }
-const DEFAULT_SORT: SortState = { key: 'date', dir: 'desc' };
-
-function sortEnvelopes(
-  list: ReadonlyArray<EnvelopeListItem>,
-  sort: SortState,
-): ReadonlyArray<EnvelopeListItem>;
-```
-
-Comparators (ascending; `dir === 'desc'` reverses the result):
-
-| key | comparator |
+| `sort` value | server order-by expression |
 |---|---|
-| `document` | `a.title.localeCompare(b.title)` (case-insensitive via `localeCompare` default) |
-| `signers` | `a.signers.length - b.signers.length` |
-| `progress` | `pct(a) - pct(b)` where `pct(e) = e.signers.length === 0 ? 0 : signedCount(e) / e.signers.length`; `signedCount` counts signers with `status === 'completed'` |
-| `status` | `STATUS_ORDINAL[a.status] - STATUS_ORDINAL[b.status]` |
-| `date` | `Date.parse(a.updated_at) - Date.parse(b.updated_at)` |
+| `date` (default) | `updated_at` |
+| `created` | `created_at` |
+| `title` | `title` (collated; Postgres default `LOWER(title)` is *not* used — plain `title` keeps it index-friendly; case-folding is good enough for the dashboard) |
+| `status` | a `CASE` mapping each status to a fixed ordinal: draft 0, awaiting_others 1, sealing 2, completed 3, declined 4, expired 5, canceled 6 |
+| `signers` | `(select count(*) from envelope_signers s where s.envelope_id = e.id)` |
+| `progress` | `coalesce(signed_count::float / nullif(total_count, 0), 0)` where both counts come from a single correlated subquery / lateral over `envelope_signers` |
 
-`STATUS_ORDINAL`: `draft 0`, `awaiting_others 1`, `sealing 2`,
-`completed 3`, `declined 4`, `expired 5`, `canceled 6`.
+`dir`: `asc` | `desc`. Default `desc`.
 
-**Tie-break:** when the primary comparator returns 0, fall back to
-`updated_at` **descending**, then `id` ascending — so a re-render
-never reshuffles equal rows. (`Array.prototype.sort` is stable in
-every engine we target, but the explicit tie-break makes the order
-deterministic regardless of input ordering from the API.)
+**Validation:** `sort` must be one of the literals above (else 400
+`validation_error`); `dir` must be `asc`/`desc` (else 400). Missing →
+defaults. The frontend never sends an invalid value, but the API
+validates anyway.
 
-Pure; does not mutate the input — returns a fresh array.
+### Sort-aware cursor
 
-### `parseSort` (new — same file)
+Today the cursor is `base64("<updated_at>|<id>")` — a 2-tuple keyset on
+`(updated_at, id)`. To make pagination consistent for *any* sort key,
+the cursor becomes a **3-tuple**:
 
-```ts
-function parseSort(params: URLSearchParams): SortState;
+```
+base64("<sortValue>|<updated_at>|<id>")
 ```
 
-- `sort` ∈ {document, signers, progress, status, date}; anything else
-  → `DEFAULT_SORT.key`.
-- `dir` ∈ {asc, desc}; anything else → `DEFAULT_SORT.dir`.
-- No `sort` param at all → `DEFAULT_SORT` (date desc).
+- `sortValue` is the stringified value of the active sort expression
+  for the last row of the page (an ISO date, a title, the status
+  ordinal, the signer count, or the progress ratio — always stringified).
+- `(updated_at, id)` is the always-unique tie-break, so the 3-tuple
+  is a total order even when many rows share the same `sortValue`.
 
-Companion writer is folded into the existing `DashboardPage` URL
-plumbing (it already does targeted `URLSearchParams` deletes/sets for
-the filter chips) — no new `serializeSort`; the page just sets/deletes
-`sort` and `dir` directly.
+The keyset WHERE clause on the next page is the lexicographic
+`(sortExpr, updated_at, id) <comparator> (sortValue, updated_at, id)`
+in the chosen direction — the standard "row-value comparison" keyset
+pattern, expanded to handle the `sortValue` being a string vs number
+(we compare as the column's native type by re-parsing).
 
-### `DashboardPage` integration
+**Migration:** the cursor format is opaque base64; old 2-tuple cursors
+won't decode under the new 3-tuple parser. We treat an undecodable
+cursor the same as an absent one (start from the top) — already the
+behavior for any malformed cursor (`InvalidCursorError` → 400 today;
+we soften it to "ignore and restart" only for the legacy-shape case,
+or just keep the 400 since the SPA always re-issues a fresh request
+without a stale cursor after a deploy). **Decision:** keep the 400
+for genuinely malformed cursors; the SPA's React Query cache is keyed
+by params so a deploy invalidates old cursors naturally.
 
-1. `const sort = useMemo(() => parseSort(searchParams), [searchParams])`.
-2. `const sorted = useMemo(() => sortEnvelopes(filtered, sort), [filtered, sort])`.
-   The `filtered` list (from `filterEnvelopes`) feeds straight in;
-   `renderDocumentsBody` consumes `sorted`.
-3. Header cells gain a `<SortButton>` wrapping the label + caret. The
-   `ColumnResizeHandle` stays as-is (pinned to the right edge, 6 px;
-   the label button fills the rest). Clicking the label:
-   - Not the active column → set `sort=<key>&dir=asc`.
-   - Active column, `asc` → flip to `desc`.
-   - Active column, `desc` → strip `sort` + `dir` (back to default).
-4. Caret rendering: on the active column, a `▲` for `asc` / `▼` for
-   `desc`. Inactive columns show no caret (a faint `↕` on hover is a
-   NICE-TO-HAVE, not in this PR).
+## Backend changes
 
-The chevron column header (`<div aria-hidden />`) is not sortable.
+- `ListEnvelopesQueryDto` (or wherever the list query params are
+  validated in `envelopes.controller.ts`) gains `sort?: string` +
+  `dir?: string` with `@IsIn` guards.
+- `EnvelopesService.list` threads `sort`/`dir` through; the cursor
+  decode now yields `{ sortValue: string; updated_at: string; id: string }`.
+- `EnvelopesPgRepository.listByOwner`:
+  - SELECTs two computed columns alongside `selectAll()`:
+    `signer_count` and `progress` (via correlated subqueries).
+  - Resolves the ORDER BY expression from the `sort` key.
+  - Applies the 3-tuple keyset WHERE when a cursor is present.
+  - `encodeCursor` / `decodeCursor` updated to the 3-tuple format;
+    `decodeCursor` throws `InvalidCursorError` on a 2-part legacy
+    cursor (same as any other malformed input).
+- `InMemoryEnvelopesRepository.listByOwner` (test double): mirror the
+  logic in JS — compute `signerCount` / `progress` per envelope, sort
+  by the resolved key + dir + `(updated_at desc, id asc)` tie-break,
+  apply the keyset slice from the 3-tuple cursor.
+
+## Frontend changes
+
+- `listEnvelopes(params)` / `ListEnvelopesParams` gain `sort?: SortKey`
+  + `dir?: SortDir`; included in the query string.
+- `useEnvelopesQuery` passes them through; React Query keys on the
+  params object so a sort change triggers a refetch.
+- `features/dashboardFilters/sortEnvelopes.ts` shrinks to **just the
+  URL contract**: `SortKey`, `SortDir`, `SortState`, `SORT_KEYS`,
+  `DEFAULT_SORT`, `parseSort(URLSearchParams)`. No client-side sort
+  function — the server returns rows pre-ordered. (File could be
+  renamed to `sortParams.ts`; keeping the name to minimise churn.)
+- `DashboardPage`:
+  - `const sort = parseSort(searchParams)`.
+  - `useEnvelopesQuery(true, { limit: 100, sort: sort.key, dir: sort.dir })`.
+  - Header click handler: not-active → `?sort=<key>&dir=asc`;
+    active+asc → `&dir=desc`; active+desc → strip both params
+    (back to default). Written via `setSearchParams`.
+  - Each `HeadCell` hosts a `<button>` label + caret; `aria-sort` on
+    the cell reflects state. The `ColumnResizeHandle` stays pinned
+    to the right edge, untouched.
+  - No `sortEnvelopes` call — `filtered` (post-`filterEnvelopes`) is
+    rendered as-is, in the order the API returned. (Note:
+    `filterEnvelopes` is a client-side narrowing pass that preserves
+    input order, so the server order survives it.)
 
 ## Accessibility
 
-- Each sortable header label is a `<button type="button">` inside the
-  `HeadCell`. `aria-sort` on the `HeadCell` reflects state:
-  `"ascending"` / `"descending"` on the active column, `"none"`
-  elsewhere. The button's accessible name is the column label; the
-  caret glyph is `aria-hidden`.
+`HeadCell` gets `role` left as a grid cell; the inner label is a
+`<button type="button">` with the column name as its accessible name;
+the caret is `aria-hidden`. `aria-sort` on the `HeadCell` is
+`"ascending"` / `"descending"` on the active column, `"none"`
+otherwise.
 
 ## Tests
 
-| Layer | What it asserts |
+| Layer | Asserts |
 |---|---|
-| `sortEnvelopes.test.ts` | Each comparator orders correctly asc + desc; progress handles zero-signer envelopes; tie-break by `updated_at` desc then `id`; input is not mutated. |
-| `parseSort.test.ts` (or folded into the same file) | Defaults when no param; valid `sort`/`dir` parsed; bogus values fall back to default. |
-| `DashboardPage.test.tsx` | Clicking the Document header sorts rows A→Z (assert DOM order via `getAllByRole('button', { name: /Open / })`); a second click reverses; a third resets to date-desc; the active header carries `aria-sort`. |
+| `envelopes.service.spec.ts` / repo specs | `list` validates `sort`/`dir`; rejects bogus values; threads defaults; cursor round-trips as a 3-tuple; in-memory repo orders by each key in both directions; keyset slice from a cursor returns the right next page including the `signer_count` / `progress` tie-break. |
+| API e2e (`envelopes.e2e-spec.ts` if present) | `GET /envelopes?sort=title&dir=asc` returns rows A→Z; `?sort=progress&dir=desc` returns the most-complete first; an invalid `sort` → 400. |
+| `parseSort` (frontend) | Defaults; valid parse; bogus → default. |
+| `DashboardPage.test.tsx` | Clicking the Document header sets `?sort=title&dir=asc` and the `/envelopes` request includes those params (assert via the mocked apiClient's recorded URL); second click → `dir=desc`; third click → params stripped; active header carries `aria-sort`. |
 
 ## Risk + rollback
 
-- Pure UI; no API/DB change. Reverting the PR drops the sort affordance
-  and the table renders in the API's default order again.
-- `Date.parse` of a malformed `updated_at` would yield `NaN` — guarded
-  by treating `NaN` as `0` so a bad row sinks to a stable position
-  rather than throwing.
+- The cursor format change is the riskiest bit. Mitigated by: (a) the
+  SPA never re-uses a cursor across a page reload (React Query cache
+  is in-memory + keyed by params), and (b) malformed cursors already
+  400, so a stale 2-tuple cursor fails cleanly and the SPA re-fetches
+  page 1.
+- The `progress` subquery is the heaviest new SQL. For ≤100-row pages
+  on a per-owner index it's negligible; if it ever shows up in slow
+  logs the fix is a materialised `progress` column updated by trigger
+  — out of scope here.
+- Reverting the PR: drop the `sort`/`dir` params (server ignores
+  unknown query params), drop the header buttons. The list renders
+  in `updated_at desc` order as before.
 
 ## Local review checkpoint
 
-Default cadence (review-before-push) — but given the velocity this
-session and the small surface, this ships through CI like the recent
-fixes. Dev server on :5173 picks it up via HMR for inspection.
+Default cadence; ships through CI like the recent fixes (velocity
+this session). Dev server on :5173 picks it up via HMR.


### PR DESCRIPTION
## Summary

Click a dashboard column header → the table re-queries `GET /envelopes` with `?sort=&dir=` and renders the rows in the order the API returned. Three clicks cycle ascending → descending → default (date, newest-first). Sort key + direction live in the URL → bookmarkable.

Spec: `docs/superpowers/specs/2026-05-11-dashboard-column-sorting-design.md`.

## Backend

- `GET /envelopes` accepts `sort` ∈ {date, created, title, status, signers, progress} and `dir` ∈ {asc, desc}. The service validates (400 `validation_error` on bogus); defaults are date/desc.
- `EnvelopesPgRepository.listByOwner` LEFT-JOINs a grouped `envelope_signers` subquery for `signer_count`/`signed_count`, derives `progress` as a 0..1000 permille integer (denominator clamped — no divide-by-zero), and `ORDER BY <expr> <dir>, updated_at DESC, id ASC`. `title` is case-folded; `status` maps to a fixed presentation ordinal. Written as OR/AND (not a row-value comparison) so pg-mem can run it.
- **Sort-aware cursor:** the keyset cursor is now a 3-tuple `(sort_value, updated_at, id)` — `sort_value` is the stringified active-sort value of the previous page's last row, `(updated_at, id)` the always-unique tie-break. So pagination is consistent for **any** sort key, not just date. Codec + sort-value helpers live in the new shared `apps/api/src/envelopes/list-cursor.ts` so the Pg adapter and the in-memory test double produce byte-identical cursors. Old 2-tuple cursors no longer decode → treated as malformed (400), which the SPA recovers from by re-fetching page 1.
- `MeService.collectEnvelopeIds` (DSAR export) updated for the 3-tuple cursor.

## Frontend

- `listEnvelopes` / `ListEnvelopesParams` gain `sort?` + `dir?`; `useEnvelopesQuery` forwards them (a sort change re-keys the query → refetch).
- `features/dashboardFilters/sortEnvelopes.ts` is URL-contract only now — `SortKey` (vocab = API minus `created`), `SortDir`, `SortState`, `SORT_KEYS`, `DEFAULT_SORT` (`date desc`), `parseSort`. No client-side sort — the server returns pre-ordered rows.
- `DashboardPage` reads the sort from the URL, threads it into the query, and renders each header as a `<SortHeaderButton>` with a ▲/▼ caret + `aria-sort` on the cell. Column id `document` → `title` sort key. The `ColumnResizeHandle` stays pinned to the right edge.

## Tests

- `envelopes.service.spec.ts` — `list` rejects an unknown sort key / direction; `sort=title&dir=asc` actually orders the fake-repo results (now honors the sort via the shared `sortValueForKey`).
- In-memory repo mirrors the sort + 3-tuple keyset.
- `sortEnvelopes.test.ts` — `parseSort` defaults / valid parse / bogus → default; accepts every key.
- `DashboardPage.test.tsx` — clicking the Document header cycles `?sort=&dir=` (asserts the recorded `/envelopes` request URLs) and toggles `aria-sort`; third click → default.

## Test plan

- [x] typecheck (web + api + landing + shared) clean
- [x] lint + cspell clean
- [x] web vitest 1550/1550 GREEN
- [x] api jest 936/936 GREEN
- [x] `seald-react-pr-review` walked the diff — no MUST-FIX / SHOULD-FIX
- [ ] Post-deploy: open https://seald.nromomentum.com/documents, click each header, confirm rows reorder + the `?sort=&dir=` params + the caret/`aria-sort`; bookmark a sorted URL and reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)