### PR TITLE
feat(envelopes): server-side dashboard table filtering

### DIFF
--- a/apps/api/src/envelopes/__tests__/envelopes.controller.spec.ts
+++ b/apps/api/src/envelopes/__tests__/envelopes.controller.spec.ts
@@ -125,6 +125,7 @@ describe('EnvelopesController', () => {
       await controller.list(USER, 'draft,awaiting_others');
       expect(svc.list).toHaveBeenCalledWith(USER.id, {
         statuses: ['draft', 'awaiting_others'],
+        viewerEmail: USER.email,
       });
     });
 
@@ -133,49 +134,56 @@ describe('EnvelopesController', () => {
       await controller.list(USER, ' draft , , awaiting_others ');
       expect(svc.list).toHaveBeenCalledWith(USER.id, {
         statuses: ['draft', 'awaiting_others'],
+        viewerEmail: USER.email,
       });
     });
 
     it('omits statuses when query is empty string', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, '');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, {});
+      expect(svc.list).toHaveBeenCalledWith(USER.id, { viewerEmail: USER.email });
     });
 
     it('omits statuses when query is undefined', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER);
-      expect(svc.list).toHaveBeenCalledWith(USER.id, {});
+      expect(svc.list).toHaveBeenCalledWith(USER.id, { viewerEmail: USER.email });
     });
 
     it('omits statuses when only commas/whitespace', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, ' , , ');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, {});
+      expect(svc.list).toHaveBeenCalledWith(USER.id, { viewerEmail: USER.email });
     });
 
     it('still forwards unknown status values verbatim (service re-validates)', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, 'bogus');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, { statuses: ['bogus'] });
+      expect(svc.list).toHaveBeenCalledWith(USER.id, {
+        statuses: ['bogus'],
+        viewerEmail: USER.email,
+      });
     });
 
     it('parses limit query as integer', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, undefined, '50');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, { limit: 50 });
+      expect(svc.list).toHaveBeenCalledWith(USER.id, { limit: 50, viewerEmail: USER.email });
     });
 
     it('drops non-numeric limit', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, undefined, 'abc');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, {});
+      expect(svc.list).toHaveBeenCalledWith(USER.id, { viewerEmail: USER.email });
     });
 
     it('forwards cursor when present', async () => {
       svc.list.mockResolvedValue({ items: [], next_cursor: null });
       await controller.list(USER, undefined, undefined, 'opaque-cursor');
-      expect(svc.list).toHaveBeenCalledWith(USER.id, { cursor: 'opaque-cursor' });
+      expect(svc.list).toHaveBeenCalledWith(USER.id, {
+        cursor: 'opaque-cursor',
+        viewerEmail: USER.email,
+      });
     });
   });
 

--- a/apps/api/src/envelopes/__tests__/envelopes.repository.pg.spec.ts
+++ b/apps/api/src/envelopes/__tests__/envelopes.repository.pg.spec.ts
@@ -143,6 +143,81 @@ describe('EnvelopesPgRepository — listByOwner', () => {
     const malformed = Buffer.from('nope', 'utf8').toString('base64');
     expect(() => repo.decodeCursorOrThrow(malformed)).toThrow(InvalidCursorError);
   });
+
+  it('filters by q (substring on title + short_code), tags, and signer email', async () => {
+    const acme = await repo.createDraft(draftInput(ownerId, { title: 'Acme NDA' }));
+    const other = await repo.createDraft(draftInput(ownerId, { title: 'Other doc' }));
+    // Tag + signer on the Acme one only.
+    await repo.updateDraftMetadata(ownerId, acme.id, { tags: ['urgent'] });
+    await repo.addSigner(acme.id, {
+      email: 'alice@example.com',
+      name: 'Alice',
+      color: '#112233',
+    });
+    await repo.addSigner(other.id, {
+      email: 'bob@example.com',
+      name: 'Bob',
+      color: '#445566',
+    });
+
+    // q matches the title…
+    expect(
+      (await repo.listByOwner(ownerId, { limit: 10, q: 'acme' })).items.map((i) => i.id),
+    ).toEqual([acme.id]);
+    // …and the short_code (use the full code — a random 13-char prefix
+    // could otherwise coincidentally substring-match the other one).
+    expect(
+      (await repo.listByOwner(ownerId, { limit: 10, q: acme.short_code })).items.map((i) => i.id),
+    ).toEqual([acme.id]);
+    // tags (jsonb containment).
+    expect(
+      (await repo.listByOwner(ownerId, { limit: 10, tags: ['urgent'] })).items.map((i) => i.id),
+    ).toEqual([acme.id]);
+    // signer email (EXISTS subquery).
+    expect(
+      (
+        await repo.listByOwner(ownerId, { limit: 10, signerEmails: ['alice@example.com'] })
+      ).items.map((i) => i.id),
+    ).toEqual([acme.id]);
+    // Multiple signers OR-matched.
+    expect(
+      (
+        await repo.listByOwner(ownerId, {
+          limit: 10,
+          signerEmails: ['alice@example.com', 'bob@example.com'],
+        })
+      ).items.length,
+    ).toBe(2);
+  });
+
+  it('filters by the awaiting_you / awaiting_others buckets using viewerEmail', async () => {
+    const mine = await repo.createDraft(draftInput(ownerId, { title: 'Awaiting me' }));
+    const theirs = await repo.createDraft(draftInput(ownerId, { title: 'Awaiting them' }));
+    for (const id of [mine.id, theirs.id]) {
+      await handle.db
+        .updateTable('envelopes')
+        .set({ status: 'awaiting_others' })
+        .where('id', '=', id)
+        .execute();
+    }
+    // Viewer is a pending signer on `mine`, not on `theirs`.
+    await repo.addSigner(mine.id, { email: 'viewer@x.test', name: 'Viewer', color: '#111111' });
+    await repo.addSigner(theirs.id, { email: 'someone@x.test', name: 'Someone', color: '#222222' });
+
+    const you = await repo.listByOwner(ownerId, {
+      limit: 10,
+      buckets: ['awaiting_you'],
+      viewerEmail: 'viewer@x.test',
+    });
+    expect(you.items.map((i) => i.id)).toEqual([mine.id]);
+
+    const others = await repo.listByOwner(ownerId, {
+      limit: 10,
+      buckets: ['awaiting_others'],
+      viewerEmail: 'viewer@x.test',
+    });
+    expect(others.items.map((i) => i.id)).toEqual([theirs.id]);
+  });
 });
 
 describe('EnvelopesPgRepository — updateDraftMetadata', () => {

--- a/apps/api/src/envelopes/__tests__/envelopes.service.spec.ts
+++ b/apps/api/src/envelopes/__tests__/envelopes.service.spec.ts
@@ -11,7 +11,7 @@ import {
   OutboundEmailsRepository,
   type OutboundEmailRow,
 } from '../../email/outbound-emails.repository';
-import { makeEnvelope } from '../../../test/factories';
+import { makeEnvelope, makeSigner } from '../../../test/factories';
 import { SigningTokenService } from '../../signing/signing-token.service';
 import { StorageService } from '../../storage/storage.service';
 import type {
@@ -38,6 +38,7 @@ import {
   ShortCodeCollisionError,
 } from '../envelopes.repository';
 import { sortValueForKey } from '../list-cursor';
+import { applyListFilters } from '../list-filters';
 import { eventHash } from '../event-hash';
 import { EnvelopesService } from '../envelopes.service';
 
@@ -157,6 +158,7 @@ class FakeEnvelopesRepo extends EnvelopesRepository {
   async listByOwner(owner_id: string, opts: ListOptions): Promise<ListResult> {
     let items = [...this.envelopes.values()].filter((e) => e.owner_id === owner_id);
     if (opts.statuses) items = items.filter((e) => opts.statuses!.includes(e.status));
+    items = applyListFilters(items, opts);
     const sortKey = opts.sort ?? 'date';
     const asc = (opts.dir ?? 'desc') === 'asc';
     const numericKey = sortKey === 'status' || sortKey === 'signers' || sortKey === 'progress';
@@ -680,6 +682,96 @@ describe('EnvelopesService', () => {
       await svc.createDraft(OWNER, { title: 'Apple' });
       const res = await svc.list(OWNER, { sort: 'title', dir: 'asc' });
       expect(res.items.map((e) => e.title)).toEqual(['Apple', 'Banana']);
+    });
+  });
+
+  describe('list — dashboard filters', () => {
+    const mutate = (id: string, patch: Partial<Envelope>): void => {
+      repo.envelopes.set(id, { ...repo.envelopes.get(id)!, ...patch });
+    };
+
+    it('filters by q (case-insensitive substring on title)', async () => {
+      await svc.createDraft(OWNER, { title: 'Acme Master Agreement' });
+      await svc.createDraft(OWNER, { title: 'Vendor onboarding' });
+      const res = await svc.list(OWNER, { q: 'acme' });
+      expect(res.items.map((e) => e.title)).toEqual(['Acme Master Agreement']);
+    });
+
+    it('filters by status bucket (draft vs sealed)', async () => {
+      const draft = await svc.createDraft(OWNER, { title: 'Still a draft' });
+      const sealed = await svc.createDraft(OWNER, { title: 'All done' });
+      mutate(sealed.id, { status: 'completed' });
+      expect((await svc.list(OWNER, { bucket: 'draft' })).items.map((e) => e.id)).toEqual([
+        draft.id,
+      ]);
+      expect((await svc.list(OWNER, { bucket: 'sealed' })).items.map((e) => e.id)).toEqual([
+        sealed.id,
+      ]);
+    });
+
+    it('splits awaiting_you / awaiting_others by viewerEmail', async () => {
+      const mine = await svc.createDraft(OWNER, { title: 'Waiting on me' });
+      const theirs = await svc.createDraft(OWNER, { title: 'Waiting on them' });
+      mutate(mine.id, {
+        status: 'awaiting_others',
+        signers: [makeSigner({ id: 's-me', email: 'me@example.com', status: 'awaiting' })],
+      });
+      mutate(theirs.id, {
+        status: 'awaiting_others',
+        signers: [makeSigner({ id: 's-them', email: 'them@example.com', status: 'awaiting' })],
+      });
+      expect(
+        (
+          await svc.list(OWNER, { bucket: 'awaiting_you', viewerEmail: 'me@example.com' })
+        ).items.map((e) => e.id),
+      ).toEqual([mine.id]);
+      expect(
+        (
+          await svc.list(OWNER, { bucket: 'awaiting_others', viewerEmail: 'me@example.com' })
+        ).items.map((e) => e.id),
+      ).toEqual([theirs.id]);
+    });
+
+    it('filters by signer email', async () => {
+      const a = await svc.createDraft(OWNER, { title: 'Has Alice' });
+      const b = await svc.createDraft(OWNER, { title: 'Has Bob' });
+      mutate(a.id, { signers: [makeSigner({ id: 's-a', email: 'alice@example.com' })] });
+      mutate(b.id, { signers: [makeSigner({ id: 's-b', email: 'bob@example.com' })] });
+      const res = await svc.list(OWNER, { signer: 'alice@example.com' });
+      expect(res.items.map((e) => e.id)).toEqual([a.id]);
+    });
+
+    it('filters by tag', async () => {
+      const tagged = await svc.createDraft(OWNER, { title: 'Tagged' });
+      await svc.createDraft(OWNER, { title: 'Untagged' });
+      await repo.updateDraftMetadata(OWNER, tagged.id, { tags: ['urgent'] });
+      const res = await svc.list(OWNER, { tags: 'urgent' });
+      expect(res.items.map((e) => e.id)).toEqual([tagged.id]);
+    });
+
+    it('filters by a custom date window (inclusive on both calendar ends)', async () => {
+      const inside = await svc.createDraft(OWNER, { title: 'Inside' });
+      const outside = await svc.createDraft(OWNER, { title: 'Outside' });
+      mutate(inside.id, { updated_at: '2026-05-05T12:00:00.000Z' });
+      mutate(outside.id, { updated_at: '2026-05-20T12:00:00.000Z' });
+      const res = await svc.list(OWNER, { date: 'custom:2026-05-01:2026-05-10' });
+      expect(res.items.map((e) => e.id)).toEqual([inside.id]);
+    });
+
+    it('rejects an unknown bucket token', async () => {
+      await expect(svc.list(OWNER, { bucket: 'draft,bogus' })).rejects.toMatchObject({
+        constructor: BadRequestException,
+        message: 'validation_error',
+      });
+    });
+
+    it('rejects a malformed date param', async () => {
+      await expect(svc.list(OWNER, { date: 'custom:not-a-date:2026-05-10' })).rejects.toMatchObject(
+        {
+          constructor: BadRequestException,
+          message: 'validation_error',
+        },
+      );
     });
   });
 

--- a/apps/api/src/envelopes/envelopes.controller.ts
+++ b/apps/api/src/envelopes/envelopes.controller.ts
@@ -63,6 +63,11 @@ export class EnvelopesController {
     @Query('cursor') cursor?: string,
     @Query('sort') sort?: string,
     @Query('dir') dir?: string,
+    @Query('q') q?: string,
+    @Query('bucket') bucket?: string,
+    @Query('date') date?: string,
+    @Query('signer') signer?: string,
+    @Query('tags') tags?: string,
   ): Promise<ListResult> {
     const statuses = parseStatuses(statusQuery);
     const limit = limitQuery ? Number.parseInt(limitQuery, 10) : undefined;
@@ -72,6 +77,12 @@ export class EnvelopesController {
       ...(cursor ? { cursor } : {}),
       ...(sort ? { sort } : {}),
       ...(dir ? { dir } : {}),
+      ...(q ? { q } : {}),
+      ...(bucket ? { bucket } : {}),
+      ...(date ? { date } : {}),
+      ...(signer ? { signer } : {}),
+      ...(tags ? { tags } : {}),
+      viewerEmail: user.email,
     });
   }
 

--- a/apps/api/src/envelopes/envelopes.repository.pg.ts
+++ b/apps/api/src/envelopes/envelopes.repository.pg.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
-import { sql, type Kysely, type Selectable, type Transaction } from 'kysely';
+import { sql, type Kysely, type RawBuilder, type Selectable, type Transaction } from 'kysely';
 import { eventHash } from './event-hash';
 import type {
   Database,
@@ -361,11 +361,98 @@ export class EnvelopesPgRepository extends EnvelopesRepository {
       ])
       .where('e.owner_id', '=', owner_id);
 
-    let q = (
-      opts.statuses && opts.statuses.length > 0
-        ? base.where('e.status', 'in', [...opts.statuses])
-        : base
-    ).limit(opts.limit + 1);
+    // ---- Filters (all AND-combined) ----
+    //
+    // `signer` and the awaiting-you bucket can't be expressed as
+    // correlated `exists` subqueries here — pg-mem can't resolve the
+    // outer table alias inside a raw-SQL subquery — so we pre-resolve
+    // the matching envelope-id sets with a small standalone query
+    // each, then filter with `e.id in (...)`. Production Postgres
+    // would happily do the correlated form; the pre-resolved form is
+    // equivalent and adapter-portable.
+    let signerEnvelopeIds: ReadonlyArray<string> | null = null;
+    if (opts.signerEmails && opts.signerEmails.length > 0) {
+      const emails = opts.signerEmails.map((x) => x.toLowerCase());
+      const rows = await this.db
+        .selectFrom('envelope_signers')
+        .select('envelope_id')
+        .where(sql<boolean>`lower(email) in (${sql.join(emails.map((x) => sql.lit(x)))})`)
+        .execute();
+      signerEnvelopeIds = [...new Set(rows.map((r) => r.envelope_id))];
+    }
+    let viewerPendingEnvelopeIds: ReadonlyArray<string> | null = null;
+    const needsViewerSet =
+      opts.buckets?.some((b) => b === 'awaiting_you' || b === 'awaiting_others') ?? false;
+    if (needsViewerSet) {
+      const viewer = (opts.viewerEmail ?? '').toLowerCase();
+      const rows = viewer
+        ? await this.db
+            .selectFrom('envelope_signers')
+            .select('envelope_id')
+            .where(sql<boolean>`lower(email) = ${sql.lit(viewer)}`)
+            .where('signed_at', 'is', null)
+            .where('declined_at', 'is', null)
+            .execute()
+        : [];
+      viewerPendingEnvelopeIds = [...new Set(rows.map((r) => r.envelope_id))];
+    }
+
+    let filtered = base;
+    if (opts.statuses && opts.statuses.length > 0) {
+      filtered = filtered.where('e.status', 'in', [...opts.statuses]);
+    }
+    if (opts.q && opts.q.trim() !== '') {
+      const needle = `%${opts.q.trim().toLowerCase()}%`;
+      filtered = filtered.where(
+        sql<boolean>`(lower(e.title) like ${sql.lit(needle)} or lower(e.short_code) like ${sql.lit(needle)})`,
+      );
+    }
+    if (opts.date) {
+      filtered = filtered.where(
+        sql<boolean>`(e.updated_at >= ${sql.lit(opts.date.from)}::timestamptz and e.updated_at < ${sql.lit(opts.date.to)}::timestamptz)`,
+      );
+    }
+    if (signerEnvelopeIds !== null) {
+      if (signerEnvelopeIds.length === 0) return { items: [], next_cursor: null };
+      filtered = filtered.where('e.id', 'in', signerEnvelopeIds);
+    }
+    if (opts.tags && opts.tags.length > 0) {
+      // OR of one jsonb-containment check per selected tag. `e.tags`
+      // is a jsonb array of (lower-cased) strings; `@> '["x"]'`
+      // returns true iff "x" is an element.
+      const tagClauses = opts.tags.map(
+        (t) => sql<boolean>`e.tags @> ${sql.lit(JSON.stringify([t.toLowerCase()]))}::jsonb`,
+      );
+      filtered = filtered.where(sql<boolean>`(${sql.join(tagClauses, sql` or `)})`);
+    }
+    if (opts.buckets && opts.buckets.length > 0) {
+      const pendingIds = viewerPendingEnvelopeIds ?? [];
+      const bucketClause = (b: string): RawBuilder<boolean> => {
+        switch (b) {
+          case 'draft':
+            return sql<boolean>`e.status = 'draft'`;
+          case 'sealed':
+            return sql<boolean>`e.status = 'completed'`;
+          case 'declined':
+            return sql<boolean>`e.status = 'declined'`;
+          case 'awaiting_you':
+            return pendingIds.length === 0
+              ? sql<boolean>`false`
+              : sql<boolean>`(e.status in ('awaiting_others','sealing') and e.id in (${sql.join(pendingIds.map((x) => sql.lit(x)))}))`;
+          case 'awaiting_others':
+            return pendingIds.length === 0
+              ? sql<boolean>`e.status in ('awaiting_others','sealing')`
+              : sql<boolean>`(e.status in ('awaiting_others','sealing') and e.id not in (${sql.join(pendingIds.map((x) => sql.lit(x)))}))`;
+          default:
+            return sql<boolean>`false`;
+        }
+      };
+      filtered = filtered.where(
+        sql<boolean>`(${sql.join(opts.buckets.map(bucketClause), sql` or `)})`,
+      );
+    }
+
+    let q = filtered.limit(opts.limit + 1);
 
     // Sort expression for the active key, expressed against the
     // columns available after the JOIN. `title` is lower-cased so the

--- a/apps/api/src/envelopes/envelopes.repository.ts
+++ b/apps/api/src/envelopes/envelopes.repository.ts
@@ -149,12 +149,49 @@ export interface ListCursor {
   readonly id: string;
 }
 
-export interface ListOptions {
+/**
+ * Dashboard status "buckets" — distinct from the literal
+ * `envelopes.status` column. `awaiting_you` / `awaiting_others` split
+ * `awaiting_others`/`sealing` envelopes by whether the auth'd viewer
+ * is still a pending signer; the rest map 1:1 to a column value
+ * (`sealed` ↔ `completed`).
+ */
+export const ENVELOPE_BUCKETS = [
+  'draft',
+  'awaiting_you',
+  'awaiting_others',
+  'sealed',
+  'declined',
+] as const;
+export type EnvelopeBucket = (typeof ENVELOPE_BUCKETS)[number];
+
+/** A `[from, to)` instant window for the date filter. */
+export interface DateWindow {
+  readonly from: string; // ISO
+  readonly to: string; // ISO, exclusive
+}
+
+export interface ListFilters {
+  /** Case-insensitive substring on `title` + `short_code`. */
+  readonly q?: string;
+  /** Selected status buckets — OR-combined. Empty/absent = no bucket filter. */
+  readonly buckets?: ReadonlyArray<EnvelopeBucket>;
+  /** Half-open `[from, to)` window on `updated_at`. */
+  readonly date?: DateWindow;
+  /** Lower-cased signer emails — envelope matches if it has ANY of them. */
+  readonly signerEmails?: ReadonlyArray<string>;
+  /** Lower-cased tag names — envelope matches if it has ANY of them. */
+  readonly tags?: ReadonlyArray<string>;
+}
+
+export interface ListOptions extends ListFilters {
   readonly statuses?: ReadonlyArray<EnvelopeStatus>;
   readonly limit: number; // 1..100
   readonly sort?: EnvelopeSortKey; // default 'date'
   readonly dir?: SortDir; // default 'desc'
   readonly cursor?: ListCursor | null;
+  /** Auth'd viewer's email — needed to resolve the awaiting-you bucket. */
+  readonly viewerEmail?: string | null;
 }
 
 export interface EnvelopeListSignerSnippet {

--- a/apps/api/src/envelopes/envelopes.service.ts
+++ b/apps/api/src/envelopes/envelopes.service.ts
@@ -29,6 +29,8 @@ import { SigningTokenService } from '../signing/signing-token.service';
 import { StorageService } from '../storage/storage.service';
 import type {
   CreateFieldInput,
+  DateWindow,
+  EnvelopeBucket,
   EnvelopeEvent,
   EnvelopeField,
   EnvelopeSigner,
@@ -40,6 +42,7 @@ import type {
   UpdateDraftMetadataPatch,
 } from './envelopes.repository';
 import {
+  ENVELOPE_BUCKETS,
   ENVELOPE_SORT_KEYS,
   EnvelopeSignerEmailTakenError,
   EnvelopesRepository,
@@ -136,6 +139,13 @@ export class EnvelopesService {
       cursor?: string;
       sort?: string;
       dir?: string;
+      // Dashboard filters (raw query-param strings; parsed here).
+      q?: string;
+      bucket?: string; // comma-separated EnvelopeBucket values
+      date?: string; // preset keyword or `custom:YYYY-MM-DD:YYYY-MM-DD`
+      signer?: string; // comma-separated emails
+      tags?: string; // comma-separated tag names
+      viewerEmail?: string | null;
     },
   ): Promise<ListResult> {
     const clampedLimit = Math.max(1, Math.min(100, opts.limit ?? 20));
@@ -163,6 +173,41 @@ export class EnvelopesService {
       dir = opts.dir;
     }
 
+    // ---- Dashboard filters ----
+    const q = opts.q && opts.q.trim() !== '' ? opts.q.trim() : undefined;
+
+    let buckets: ReadonlyArray<EnvelopeBucket> | undefined;
+    if (opts.bucket !== undefined && opts.bucket !== '') {
+      const parsed = opts.bucket.split(',').map((b) => b.trim());
+      for (const b of parsed) {
+        if (!(ENVELOPE_BUCKETS as readonly string[]).includes(b)) {
+          throw new BadRequestException('validation_error');
+        }
+      }
+      if (parsed.length > 0) buckets = parsed as EnvelopeBucket[];
+    }
+
+    let date: DateWindow | undefined;
+    if (opts.date !== undefined && opts.date !== '' && opts.date !== 'all') {
+      date = this.resolveDateWindow(opts.date);
+    }
+
+    const signerEmails =
+      opts.signer !== undefined && opts.signer !== ''
+        ? opts.signer
+            .split(',')
+            .map((s) => s.trim().toLowerCase())
+            .filter((s) => s.length > 0)
+        : undefined;
+
+    const tags =
+      opts.tags !== undefined && opts.tags !== ''
+        ? opts.tags
+            .split(',')
+            .map((t) => t.trim().toLowerCase())
+            .filter((t) => t.length > 0)
+        : undefined;
+
     let cursor: ListCursor | null = null;
     if (opts.cursor) {
       try {
@@ -178,8 +223,58 @@ export class EnvelopesService {
       limit: clampedLimit,
       ...(sort !== undefined ? { sort } : {}),
       ...(dir !== undefined ? { dir } : {}),
+      ...(q !== undefined ? { q } : {}),
+      ...(buckets !== undefined && buckets.length > 0 ? { buckets } : {}),
+      ...(date !== undefined ? { date } : {}),
+      ...(signerEmails !== undefined && signerEmails.length > 0 ? { signerEmails } : {}),
+      ...(tags !== undefined && tags.length > 0 ? { tags } : {}),
+      ...(opts.viewerEmail !== undefined ? { viewerEmail: opts.viewerEmail } : {}),
       cursor,
     });
+  }
+
+  /**
+   * Resolve a `date` query-param into a `[from, to)` instant window.
+   * Presets are anchored to UTC-midnight "now" (server clock is
+   * authoritative). `custom:YYYY-MM-DD:YYYY-MM-DD` is treated as a
+   * pair of UTC calendar days, inclusive on both ends. Bad input →
+   * 400 `validation_error`.
+   */
+  private resolveDateWindow(raw: string): DateWindow {
+    const utcStartOfDay = (d: Date): Date =>
+      new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+    if (raw.startsWith('custom:')) {
+      const [, from, to] = raw.split(':');
+      const dateRe = /^\d{4}-\d{2}-\d{2}$/;
+      if (!from || !to || !dateRe.test(from) || !dateRe.test(to) || from > to) {
+        throw new BadRequestException('validation_error');
+      }
+      const toExclusive = new Date(`${to}T00:00:00Z`);
+      toExclusive.setUTCDate(toExclusive.getUTCDate() + 1);
+      return { from: new Date(`${from}T00:00:00Z`).toISOString(), to: toExclusive.toISOString() };
+    }
+    const now = new Date();
+    const today = utcStartOfDay(now);
+    const plusDays = (d: Date, n: number): Date => {
+      const out = new Date(d);
+      out.setUTCDate(out.getUTCDate() + n);
+      return out;
+    };
+    if (raw === 'today') {
+      return { from: today.toISOString(), to: plusDays(today, 1).toISOString() };
+    }
+    if (raw === '7d') {
+      return { from: plusDays(today, -6).toISOString(), to: plusDays(today, 1).toISOString() };
+    }
+    if (raw === '30d') {
+      return { from: plusDays(today, -29).toISOString(), to: plusDays(today, 1).toISOString() };
+    }
+    if (raw === 'thisMonth') {
+      const from = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
+      const to = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 1));
+      return { from: from.toISOString(), to: to.toISOString() };
+    }
+    throw new BadRequestException('validation_error');
   }
 
   async patchDraft(

--- a/apps/api/src/envelopes/list-filters.ts
+++ b/apps/api/src/envelopes/list-filters.ts
@@ -1,0 +1,78 @@
+import type { Envelope } from './envelope.entity';
+import type { DateWindow, EnvelopeBucket, ListFilters } from './envelopes.repository';
+
+/**
+ * In-memory mirror of the dashboard-filter `WHERE` clauses that
+ * `EnvelopesPgRepository.listByOwner` runs in SQL. The in-memory
+ * test double and the service-spec fakes reuse this so their results
+ * match the Pg adapter byte-for-byte under the same filter inputs.
+ *
+ * Keep this in lock-step with the SQL: substring match on
+ * title+short_code, OR-of-buckets, `[from,to)` window on updated_at,
+ * any-of-signers, any-of-tags.
+ */
+
+function viewerIsPendingSigner(e: Envelope, viewerEmail: string): boolean {
+  const v = viewerEmail.toLowerCase();
+  return e.signers.some(
+    (s) => s.email.toLowerCase() === v && s.signed_at === null && s.declined_at === null,
+  );
+}
+
+function matchesBucket(e: Envelope, bucket: EnvelopeBucket, viewerEmail: string): boolean {
+  switch (bucket) {
+    case 'draft':
+      return e.status === 'draft';
+    case 'sealed':
+      return e.status === 'completed';
+    case 'declined':
+      return e.status === 'declined';
+    case 'awaiting_you':
+      return (
+        (e.status === 'awaiting_others' || e.status === 'sealing') &&
+        viewerIsPendingSigner(e, viewerEmail)
+      );
+    case 'awaiting_others':
+      return (
+        (e.status === 'awaiting_others' || e.status === 'sealing') &&
+        !viewerIsPendingSigner(e, viewerEmail)
+      );
+  }
+}
+
+function inWindow(iso: string, w: DateWindow): boolean {
+  const t = new Date(iso).getTime();
+  return t >= new Date(w.from).getTime() && t < new Date(w.to).getTime();
+}
+
+export function applyListFilters(
+  envelopes: ReadonlyArray<Envelope>,
+  filters: ListFilters & { readonly viewerEmail?: string | null },
+): Envelope[] {
+  const q = filters.q && filters.q.trim() !== '' ? filters.q.trim().toLowerCase() : null;
+  const viewer = (filters.viewerEmail ?? '').toLowerCase();
+  const signerSet =
+    filters.signerEmails && filters.signerEmails.length > 0
+      ? new Set(filters.signerEmails.map((x) => x.toLowerCase()))
+      : null;
+  const tagSet =
+    filters.tags && filters.tags.length > 0
+      ? new Set(filters.tags.map((t) => t.toLowerCase()))
+      : null;
+  const buckets = filters.buckets && filters.buckets.length > 0 ? filters.buckets : null;
+
+  return envelopes.filter((e) => {
+    if (q !== null) {
+      if (!e.title.toLowerCase().includes(q) && !e.short_code.toLowerCase().includes(q)) {
+        return false;
+      }
+    }
+    if (filters.date && !inWindow(e.updated_at, filters.date)) return false;
+    if (signerSet !== null && !e.signers.some((s) => signerSet.has(s.email.toLowerCase()))) {
+      return false;
+    }
+    if (tagSet !== null && !(e.tags ?? []).some((t) => tagSet.has(t.toLowerCase()))) return false;
+    if (buckets !== null && !buckets.some((b) => matchesBucket(e, b, viewer))) return false;
+    return true;
+  });
+}

--- a/apps/api/test/in-memory-envelopes-repository.ts
+++ b/apps/api/test/in-memory-envelopes-repository.ts
@@ -23,6 +23,7 @@ import {
   ShortCodeCollisionError,
 } from '../src/envelopes/envelopes.repository';
 import { decodeListCursor, encodeListCursor, sortValueForKey } from '../src/envelopes/list-cursor';
+import { applyListFilters } from '../src/envelopes/list-filters';
 
 /**
  * In-memory envelopes repository for e2e tests. Covers the subset of methods
@@ -122,6 +123,7 @@ export class InMemoryEnvelopesRepository extends EnvelopesRepository {
       const set = new Set(opts.statuses);
       items = items.filter((e) => set.has(e.status));
     }
+    items = applyListFilters(items, opts);
 
     const sortKey = opts.sort ?? 'date';
     const asc = (opts.dir ?? 'desc') === 'asc';

--- a/apps/api/test/pg-mem-db.ts
+++ b/apps/api/test/pg-mem-db.ts
@@ -212,6 +212,13 @@ export function createPgMemDb(): PgMemHandle {
     );
   `);
 
+  // 0016 — envelopes.tags jsonb column (dashboard tag filter). Plain
+  // additive alter; load it directly so pg-mem-backed repo specs that
+  // touch tags work the same as production.
+  mem.public.none(
+    `alter table public.envelopes add column if not exists tags jsonb not null default '[]'::jsonb;`,
+  );
+
   const { Pool } = mem.adapters.createPg();
   const pool = new Pool();
   // pg-mem inlines query parameters by serializing Buffers as utf-8

--- a/apps/web/src/features/dashboardFilters/filterEnvelopes.test.ts
+++ b/apps/web/src/features/dashboardFilters/filterEnvelopes.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { EnvelopeListItem } from 'shared';
-import { filterEnvelopes, isAwaitingYou } from './filterEnvelopes';
-import { ACTIONABLE_INBOX, type EnvelopeFilters } from './types';
+import { bucketEnvelope, isAwaitingYou } from './filterEnvelopes';
 
 function envelope(over: Partial<EnvelopeListItem> = {}): EnvelopeListItem {
   return {
@@ -20,300 +19,42 @@ function envelope(over: Partial<EnvelopeListItem> = {}): EnvelopeListItem {
   } as EnvelopeListItem;
 }
 
-const NO_FILTER: EnvelopeFilters = {
-  q: '',
-  status: [],
-  date: { kind: 'preset', preset: 'all' },
-  signer: [],
-  tags: [],
-};
-
-describe('filterEnvelopes', () => {
-  it('returns the input unchanged when every filter is in the no-op state', () => {
-    const list = [envelope({ id: '1' }), envelope({ id: '2' })];
-    expect(filterEnvelopes(list, NO_FILTER, null)).toEqual(list);
-  });
-
-  describe('search (q)', () => {
-    it('matches a substring of the document title (case-insensitive)', () => {
-      const list = [
-        envelope({ id: '1', title: 'Acme Master Service Agreement' }),
-        envelope({ id: '2', title: 'Other doc' }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, q: 'acme' }, null);
-      expect(out.map((e) => e.id)).toEqual(['1']);
-    });
-
-    it('matches a substring of the envelope short code', () => {
-      const list = [
-        envelope({ id: '1', short_code: 'm6nHh9mL7jbvx' }),
-        envelope({ id: '2', short_code: 'zzzzzz' }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, q: '7jbvx' }, null);
-      expect(out.map((e) => e.id)).toEqual(['1']);
-    });
-  });
-
-  describe('status filter', () => {
-    it('does not filter when status is the empty array (caller "select all")', () => {
-      const list = [
-        envelope({ id: '1', status: 'draft' }),
-        envelope({ id: '2', status: 'completed' }),
-      ];
-      expect(filterEnvelopes(list, { ...NO_FILTER, status: [] }, null)).toEqual(list);
-    });
-
-    it('keeps only envelopes whose status matches one of the selected options', () => {
-      const list = [
-        envelope({ id: '1', status: 'draft' }),
-        envelope({ id: '2', status: 'completed' }),
-        envelope({ id: '3', status: 'awaiting_others' }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, status: ['draft', 'sealed'] }, null);
-      expect(out.map((e) => e.id)).toEqual(['1', '2']);
-    });
-
-    it('honors the actionable-inbox default (mutual-exclusion with awaiting-you)', () => {
-      // Envelope 1: awaiting_others, viewer is a signer who hasn't acted → awaiting_you
-      // Envelope 2: awaiting_others, viewer is NOT a signer → awaiting_others
-      // Envelope 3: completed → out
-      const list = [
-        envelope({
-          id: '1',
-          status: 'awaiting_others',
-          signers: [
-            {
-              id: 's1',
-              name: 'You',
-              email: 'you@example.com',
-              status: 'awaiting',
-            },
-          ] as EnvelopeListItem['signers'],
-        }),
-        envelope({
-          id: '2',
-          status: 'awaiting_others',
-          signers: [
-            {
-              id: 's2',
-              name: 'Other',
-              email: 'other@example.com',
-              status: 'awaiting',
-            },
-          ] as EnvelopeListItem['signers'],
-        }),
-        envelope({ id: '3', status: 'completed' }),
-      ];
-      const out = filterEnvelopes(
-        list,
-        { ...NO_FILTER, status: [...ACTIONABLE_INBOX] },
-        'you@example.com',
-      );
-      expect(out.map((e) => e.id)).toEqual(['1', '2']);
-    });
-  });
-
-  describe('date filter (binds to updated_at)', () => {
-    beforeEach(() => {
-      // Pin "now" to 2026-05-10T12:00:00Z for predictable preset windows.
-      vi.useFakeTimers();
-      vi.setSystemTime(new Date('2026-05-10T12:00:00Z'));
-    });
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    it('preset "today" includes today and excludes yesterday', () => {
-      const list = [
-        envelope({ id: 'today', updated_at: '2026-05-10T03:00:00Z' }),
-        envelope({ id: 'yesterday', updated_at: '2026-05-09T23:59:00Z' }),
-      ];
-      const out = filterEnvelopes(
-        list,
-        { ...NO_FILTER, date: { kind: 'preset', preset: 'today' } },
-        null,
-      );
-      expect(out.map((e) => e.id)).toEqual(['today']);
-    });
-
-    it('preset "7d" includes the last 7 calendar days', () => {
-      const list = [
-        envelope({ id: 'fresh', updated_at: '2026-05-10T00:00:00Z' }),
-        envelope({ id: 'edge', updated_at: '2026-05-04T00:00:00Z' }),
-        envelope({ id: 'stale', updated_at: '2026-04-30T00:00:00Z' }),
-      ];
-      const out = filterEnvelopes(
-        list,
-        { ...NO_FILTER, date: { kind: 'preset', preset: '7d' } },
-        null,
-      );
-      expect(out.map((e) => e.id).sort()).toEqual(['edge', 'fresh']);
-    });
-
-    it('custom range is inclusive on both ends', () => {
-      const list = [
-        envelope({ id: 'before', updated_at: '2026-04-30T23:59:00Z' }),
-        envelope({ id: 'lower', updated_at: '2026-05-01T00:00:00Z' }),
-        envelope({ id: 'inside', updated_at: '2026-05-05T12:00:00Z' }),
-        envelope({ id: 'upper', updated_at: '2026-05-10T23:59:00Z' }),
-        envelope({ id: 'after', updated_at: '2026-05-11T00:00:00Z' }),
-      ];
-      const out = filterEnvelopes(
-        list,
-        {
-          ...NO_FILTER,
-          date: { kind: 'custom', range: { from: '2026-05-01', to: '2026-05-10' } },
-        },
-        null,
-      );
-      expect(out.map((e) => e.id).sort()).toEqual(['inside', 'lower', 'upper']);
-    });
-  });
-
-  describe('signer filter', () => {
-    it('matches envelopes whose signer email is in the selected set', () => {
-      const list = [
-        envelope({
-          id: '1',
-          signers: [
-            { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
-        envelope({
-          id: '2',
-          signers: [
-            { id: 's2', name: 'Bob', email: 'bob@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, signer: ['alice@example.com'] }, null);
-      expect(out.map((e) => e.id)).toEqual(['1']);
-    });
-
-    it('OR-matches multiple selected signers (returns envelopes containing ANY)', () => {
-      const list = [
-        envelope({
-          id: '1',
-          signers: [
-            { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
-        envelope({
-          id: '2',
-          signers: [
-            { id: 's2', name: 'Bob', email: 'bob@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
-        envelope({
-          id: '3',
-          signers: [
-            { id: 's3', name: 'Carol', email: 'carol@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
-      ];
-      const out = filterEnvelopes(
-        list,
-        { ...NO_FILTER, signer: ['alice@example.com', 'bob@example.com'] },
-        null,
-      );
-      expect(out.map((e) => e.id).sort()).toEqual(['1', '2']);
-    });
-  });
-
-  describe('tag filter', () => {
-    it('keeps envelopes whose tags intersect the selected set', () => {
-      const list = [
-        envelope({ id: '1', tags: ['urgent', 'wickliff'] }),
-        envelope({ id: '2', tags: ['tax-2026'] }),
-        envelope({ id: '3', tags: [] }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, tags: ['urgent'] }, null);
-      expect(out.map((e) => e.id)).toEqual(['1']);
-    });
-
-    it('OR-matches multiple selected tags (envelope passes if it carries ANY)', () => {
-      const list = [
-        envelope({ id: '1', tags: ['urgent'] }),
-        envelope({ id: '2', tags: ['tax-2026'] }),
-        envelope({ id: '3', tags: ['archived'] }),
-      ];
-      const out = filterEnvelopes(list, { ...NO_FILTER, tags: ['urgent', 'tax-2026'] }, null);
-      expect(out.map((e) => e.id).sort()).toEqual(['1', '2']);
-    });
-
-    it('matches case-insensitively against the envelope tag list', () => {
-      const list = [envelope({ id: '1', tags: ['Urgent'] })];
-      const out = filterEnvelopes(list, { ...NO_FILTER, tags: ['urgent'] }, null);
-      expect(out).toHaveLength(1);
-    });
-
-    it('does nothing when the tag selection is empty', () => {
-      const list = [envelope({ id: '1', tags: ['x'] }), envelope({ id: '2', tags: [] })];
-      expect(filterEnvelopes(list, { ...NO_FILTER, tags: [] }, null)).toEqual(list);
-    });
-  });
-
-  it('AND-combines every active filter', () => {
-    const list = [
-      envelope({
-        id: '1',
-        title: 'Acme Waiver',
-        status: 'draft',
-        updated_at: '2026-05-10T00:00:00Z',
-        signers: [
-          { id: 's1', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
-        ] as EnvelopeListItem['signers'],
-      }),
-      // Same status + signer + date — but title misses the search.
-      envelope({
-        id: '2',
-        title: 'Other',
-        status: 'draft',
-        updated_at: '2026-05-10T00:00:00Z',
-        signers: [
-          { id: 's2', name: 'Alice', email: 'alice@example.com', status: 'awaiting' },
-        ] as EnvelopeListItem['signers'],
-      }),
-    ];
-    const out = filterEnvelopes(
-      list,
-      {
-        q: 'acme',
-        status: ['draft'],
-        date: { kind: 'preset', preset: 'all' },
-        signer: ['alice@example.com'],
-        tags: [],
-      },
-      null,
-    );
-    expect(out.map((e) => e.id)).toEqual(['1']);
-  });
-});
+function signer(email: string, status: EnvelopeListItem['signers'][number]['status']) {
+  return { id: `s-${email}`, name: email, email, status } as EnvelopeListItem['signers'][number];
+}
 
 describe('isAwaitingYou', () => {
   it('returns false when no viewer email is supplied', () => {
     expect(
       isAwaitingYou(
-        envelope({
-          status: 'awaiting_others',
-          signers: [
-            { id: 's', name: '', email: 'you@x', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
+        envelope({ status: 'awaiting_others', signers: [signer('you@x', 'awaiting')] }),
         null,
       ),
     ).toBe(false);
   });
 
-  it('returns true when viewer is a signer that has not yet acted', () => {
+  it('returns true when the viewer is a signer that has not yet acted', () => {
     expect(
       isAwaitingYou(
-        envelope({
-          status: 'awaiting_others',
-          signers: [
-            { id: 's', name: 'You', email: 'you@example.com', status: 'awaiting' },
-          ] as EnvelopeListItem['signers'],
-        }),
+        envelope({ status: 'awaiting_others', signers: [signer('you@example.com', 'awaiting')] }),
+        'you@example.com',
+      ),
+    ).toBe(true);
+  });
+
+  it('matches the viewer email case-insensitively', () => {
+    expect(
+      isAwaitingYou(
+        envelope({ status: 'awaiting_others', signers: [signer('you@example.com', 'awaiting')] }),
+        'YOU@Example.com',
+      ),
+    ).toBe(true);
+  });
+
+  it('treats `sealing` envelopes as candidates too', () => {
+    expect(
+      isAwaitingYou(
+        envelope({ status: 'sealing', signers: [signer('you@example.com', 'awaiting')] }),
         'you@example.com',
       ),
     ).toBe(true);
@@ -322,14 +63,64 @@ describe('isAwaitingYou', () => {
   it('returns false once the viewer has signed', () => {
     expect(
       isAwaitingYou(
-        envelope({
-          status: 'awaiting_others',
-          signers: [
-            { id: 's', name: 'You', email: 'you@example.com', status: 'completed' },
-          ] as EnvelopeListItem['signers'],
-        }),
+        envelope({ status: 'awaiting_others', signers: [signer('you@example.com', 'completed')] }),
         'you@example.com',
       ),
     ).toBe(false);
+  });
+
+  it('returns false for statuses outside the awaiting window', () => {
+    expect(
+      isAwaitingYou(
+        envelope({ status: 'draft', signers: [signer('you@example.com', 'awaiting')] }),
+        'you@example.com',
+      ),
+    ).toBe(false);
+  });
+});
+
+describe('bucketEnvelope', () => {
+  it('buckets a draft envelope as `draft`', () => {
+    expect(bucketEnvelope(envelope({ status: 'draft' }), null)).toBe('draft');
+  });
+
+  it('buckets a completed envelope as `sealed`', () => {
+    expect(bucketEnvelope(envelope({ status: 'completed' }), null)).toBe('sealed');
+  });
+
+  it('buckets a declined envelope as `declined`', () => {
+    expect(bucketEnvelope(envelope({ status: 'declined' }), null)).toBe('declined');
+  });
+
+  it('buckets as `awaiting_you` when the viewer is still a pending signer', () => {
+    expect(
+      bucketEnvelope(
+        envelope({ status: 'awaiting_others', signers: [signer('you@example.com', 'awaiting')] }),
+        'you@example.com',
+      ),
+    ).toBe('awaiting_you');
+  });
+
+  it('buckets as `awaiting_others` when the viewer is not a pending signer', () => {
+    expect(
+      bucketEnvelope(
+        envelope({ status: 'awaiting_others', signers: [signer('other@example.com', 'awaiting')] }),
+        'you@example.com',
+      ),
+    ).toBe('awaiting_others');
+  });
+
+  it('buckets `sealing` as `awaiting_others` when the viewer has nothing pending', () => {
+    expect(
+      bucketEnvelope(
+        envelope({ status: 'sealing', signers: [signer('other@example.com', 'completed')] }),
+        'you@example.com',
+      ),
+    ).toBe('awaiting_others');
+  });
+
+  it('returns null for terminal-but-unsurfaced statuses (expired / canceled)', () => {
+    expect(bucketEnvelope(envelope({ status: 'expired' }), null)).toBeNull();
+    expect(bucketEnvelope(envelope({ status: 'canceled' }), null)).toBeNull();
   });
 });

--- a/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
+++ b/apps/web/src/features/dashboardFilters/filterEnvelopes.ts
@@ -1,16 +1,23 @@
 import type { EnvelopeListItem } from 'shared';
-import type { EnvelopeFilters, StatusOption } from './types';
+import type { StatusOption } from './types';
+
+/**
+ * Status-bucket helpers for the dashboard.
+ *
+ * The actual list filtering is performed server-side (`GET /envelopes`
+ * with `?q=&bucket=&date=&signer=&tags=`). These helpers are still
+ * used client-side for:
+ *   - the toolbar's per-bucket counts, computed over the unfiltered
+ *     envelope list (`bucketEnvelope`); and
+ *   - the dashboard row's "Awaiting you" badge (`isAwaitingYou`).
+ */
 
 /**
  * Returns true when the viewer is a signer on the envelope and hasn't
- * yet completed/declined. Centralizes the predicate so both the
- * status-bucketing logic and any UI badge that wants to surface
- * "your turn" agree on what that means.
- *
- * Note: the dashboard view treats `awaiting_others` AND `sealing` as
- * candidates — `sealing` only fires at the tail end of the envelope
- * lifecycle, but if the viewer's signer entry is still open (e.g.
- * co-sign races), they should still see it bucketed under awaiting-you.
+ * yet completed/declined. The dashboard view treats `awaiting_others`
+ * AND `sealing` as candidates — `sealing` only fires at the tail end
+ * of the lifecycle, but if the viewer's signer entry is still open
+ * (co-sign races) they should still see it bucketed under awaiting-you.
  */
 export function isAwaitingYou(envelope: EnvelopeListItem, viewerEmail: string | null): boolean {
   if (viewerEmail === null) return false;
@@ -24,7 +31,8 @@ export function isAwaitingYou(envelope: EnvelopeListItem, viewerEmail: string | 
 /**
  * Bucket an envelope into one of the status options surfaced in the
  * filter chip. Mutually exclusive: every envelope belongs to exactly
- * one bucket, so a status-filter intersection is well-defined.
+ * one bucket. Mirrors the server's bucket resolution so the toolbar's
+ * counts match what a `?bucket=` filter would return.
  */
 export function bucketEnvelope(
   envelope: EnvelopeListItem,
@@ -38,105 +46,4 @@ export function bucketEnvelope(
     return 'awaiting_others';
   }
   return null;
-}
-
-/**
- * Anchor every preset window to UTC midnight so the dashboard renders
- * the same buckets regardless of the user's local timezone (and so
- * the tests aren't flaky on CI runners). Server-side timestamps on
- * envelopes are stored in UTC; treating the windows the same way
- * keeps the comparison apples-to-apples.
- */
-function startOfUtcDay(d: Date): Date {
-  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
-}
-
-function dateRangeFromFilter(filter: EnvelopeFilters['date']): { from: Date; to: Date } | null {
-  if (filter.kind === 'preset') {
-    if (filter.preset === 'all') return null;
-    const now = new Date();
-    const today = startOfUtcDay(now);
-    if (filter.preset === 'today') {
-      const end = new Date(today);
-      end.setUTCDate(end.getUTCDate() + 1);
-      return { from: today, to: end };
-    }
-    if (filter.preset === '7d') {
-      const from = new Date(today);
-      from.setUTCDate(from.getUTCDate() - 6);
-      const to = new Date(today);
-      to.setUTCDate(to.getUTCDate() + 1);
-      return { from, to };
-    }
-    if (filter.preset === '30d') {
-      const from = new Date(today);
-      from.setUTCDate(from.getUTCDate() - 29);
-      const to = new Date(today);
-      to.setUTCDate(to.getUTCDate() + 1);
-      return { from, to };
-    }
-    if (filter.preset === 'thisMonth') {
-      const from = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth(), 1));
-      const to = new Date(Date.UTC(today.getUTCFullYear(), today.getUTCMonth() + 1, 1));
-      return { from, to };
-    }
-    return null;
-  }
-  // Custom range: inclusive on both ends. We treat the bounds as UTC
-  // calendar days and add 1 day to `to` so the half-open interval
-  // `[from, to)` still includes the upper-bound day.
-  const from = new Date(`${filter.range.from}T00:00:00Z`);
-  const toExclusive = new Date(`${filter.range.to}T00:00:00Z`);
-  toExclusive.setUTCDate(toExclusive.getUTCDate() + 1);
-  return { from, to: toExclusive };
-}
-
-/**
- * Apply the four dashboard filters in AND.
- *
- *   - q (search): substring match on `title` + `short_code`
- *   - status: each envelope is bucketed into exactly one option;
- *     keep when the bucket is in the selected list
- *   - date: half-open `[from, to)` window over `updated_at`
- *   - signer: substring match across each signer's name + email
- *
- * `viewerEmail` is needed to resolve the awaiting-you bucket. Pure;
- * does not mutate the input.
- */
-export function filterEnvelopes(
-  envelopes: ReadonlyArray<EnvelopeListItem>,
-  filters: EnvelopeFilters,
-  viewerEmail: string | null,
-): ReadonlyArray<EnvelopeListItem> {
-  const range = dateRangeFromFilter(filters.date);
-  const q = filters.q;
-  const signerSet = filters.signer.length > 0 ? new Set(filters.signer) : null;
-  const statusSet = filters.status.length > 0 ? new Set(filters.status) : null;
-  const tagSet = filters.tags.length > 0 ? new Set(filters.tags) : null;
-
-  return envelopes.filter((env) => {
-    if (q !== '') {
-      const title = env.title.toLowerCase();
-      const code = env.short_code.toLowerCase();
-      if (!title.includes(q) && !code.includes(q)) return false;
-    }
-    if (statusSet !== null) {
-      const bucket = bucketEnvelope(env, viewerEmail);
-      if (bucket === null || !statusSet.has(bucket)) return false;
-    }
-    if (range !== null) {
-      const updated = new Date(env.updated_at);
-      if (updated < range.from || updated >= range.to) return false;
-    }
-    if (signerSet !== null) {
-      const matched = env.signers.some((s) => signerSet.has(s.email.toLowerCase()));
-      if (!matched) return false;
-    }
-    if (tagSet !== null) {
-      const tags = env.tags ?? [];
-      const matched = tags.some((t) => tagSet.has(t.toLowerCase()));
-      if (!matched) return false;
-    }
-    return true;
-  });
 }

--- a/apps/web/src/features/dashboardFilters/filtersToQueryParams.test.ts
+++ b/apps/web/src/features/dashboardFilters/filtersToQueryParams.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { filtersToQueryParams } from './filtersToQueryParams';
+import type { EnvelopeFilters } from './types';
+
+const NO_FILTER: EnvelopeFilters = {
+  q: '',
+  status: [],
+  date: { kind: 'preset', preset: 'all' },
+  signer: [],
+  tags: [],
+};
+
+describe('filtersToQueryParams', () => {
+  it('emits an empty object when nothing is filtered', () => {
+    expect(filtersToQueryParams(NO_FILTER)).toEqual({});
+  });
+
+  it('passes the search string through as `q`', () => {
+    expect(filtersToQueryParams({ ...NO_FILTER, q: 'acme' })).toEqual({ q: 'acme' });
+  });
+
+  it('maps the status options straight to `bucket` (same vocabulary)', () => {
+    expect(filtersToQueryParams({ ...NO_FILTER, status: ['draft', 'awaiting_you'] })).toEqual({
+      bucket: ['draft', 'awaiting_you'],
+    });
+  });
+
+  it('serializes a preset date filter to the preset keyword', () => {
+    expect(filtersToQueryParams({ ...NO_FILTER, date: { kind: 'preset', preset: '7d' } })).toEqual({
+      date: '7d',
+    });
+  });
+
+  it('omits the date when the preset is `all`', () => {
+    expect(filtersToQueryParams({ ...NO_FILTER, date: { kind: 'preset', preset: 'all' } })).toEqual(
+      {},
+    );
+  });
+
+  it('serializes a custom date range to `custom:from:to`', () => {
+    expect(
+      filtersToQueryParams({
+        ...NO_FILTER,
+        date: { kind: 'custom', range: { from: '2026-04-01', to: '2026-05-10' } },
+      }),
+    ).toEqual({ date: 'custom:2026-04-01:2026-05-10' });
+  });
+
+  it('passes signer + tag selections through', () => {
+    expect(
+      filtersToQueryParams({
+        ...NO_FILTER,
+        signer: ['alice@example.com'],
+        tags: ['urgent', 'tax-2026'],
+      }),
+    ).toEqual({ signer: ['alice@example.com'], tags: ['urgent', 'tax-2026'] });
+  });
+
+  it('combines several active filters', () => {
+    expect(
+      filtersToQueryParams({
+        q: 'nda',
+        status: ['sealed'],
+        date: { kind: 'preset', preset: '30d' },
+        signer: ['bob@x.test'],
+        tags: ['legal'],
+      }),
+    ).toEqual({
+      q: 'nda',
+      bucket: ['sealed'],
+      date: '30d',
+      signer: ['bob@x.test'],
+      tags: ['legal'],
+    });
+  });
+});

--- a/apps/web/src/features/dashboardFilters/filtersToQueryParams.ts
+++ b/apps/web/src/features/dashboardFilters/filtersToQueryParams.ts
@@ -1,0 +1,49 @@
+import type { EnvelopeFilters, StatusOption } from './types';
+
+/**
+ * Shape of the dashboard filter params on `GET /envelopes`. The
+ * server reads these and pushes the filtering into SQL.
+ */
+export interface FilterQueryParams {
+  /** Substring on title + short_code. */
+  readonly q?: string;
+  /** Status buckets — comma-joined on the wire by the API client. */
+  readonly bucket?: ReadonlyArray<StatusOption>;
+  /** Date filter: a preset keyword, or `custom:YYYY-MM-DD:YYYY-MM-DD`. */
+  readonly date?: string;
+  /** Selected signer emails. */
+  readonly signer?: ReadonlyArray<string>;
+  /** Selected tag names. */
+  readonly tags?: ReadonlyArray<string>;
+}
+
+/**
+ * Map the URL-parsed `EnvelopeFilters` into the `GET /envelopes`
+ * query-param shape. Omits anything in its no-op state so the request
+ * URL stays minimal. The `DateFilter` is re-serialized to the
+ * preset / `custom:from:to` string the API expects (the server owns
+ * "now" and resolves the actual `[from,to)` window).
+ *
+ * Note: `EnvelopeFilters.status` already uses the API's `bucket`
+ * vocabulary (`draft | awaiting_you | awaiting_others | sealed |
+ * declined`), so it's a passthrough.
+ */
+export function filtersToQueryParams(filters: EnvelopeFilters): FilterQueryParams {
+  const out: {
+    q?: string;
+    bucket?: ReadonlyArray<StatusOption>;
+    date?: string;
+    signer?: ReadonlyArray<string>;
+    tags?: ReadonlyArray<string>;
+  } = {};
+  if (filters.q !== '') out.q = filters.q;
+  if (filters.status.length > 0) out.bucket = filters.status;
+  if (filters.date.kind === 'preset') {
+    if (filters.date.preset !== 'all') out.date = filters.date.preset;
+  } else {
+    out.date = `custom:${filters.date.range.from}:${filters.date.range.to}`;
+  }
+  if (filters.signer.length > 0) out.signer = filters.signer;
+  if (filters.tags.length > 0) out.tags = filters.tags;
+  return out;
+}

--- a/apps/web/src/features/dashboardFilters/index.ts
+++ b/apps/web/src/features/dashboardFilters/index.ts
@@ -1,5 +1,6 @@
 export { parseFilters, serializeFilters, type SerializeInput } from './parseFilters';
-export { filterEnvelopes, isAwaitingYou, bucketEnvelope } from './filterEnvelopes';
+export { isAwaitingYou, bucketEnvelope } from './filterEnvelopes';
+export { filtersToQueryParams, type FilterQueryParams } from './filtersToQueryParams';
 export {
   parseSort,
   DEFAULT_SORT,

--- a/apps/web/src/features/envelopes/envelopesApi.ts
+++ b/apps/web/src/features/envelopes/envelopesApi.ts
@@ -77,12 +77,22 @@ export interface EnvelopeListResponse {
 export type EnvelopeSortKey = 'date' | 'created' | 'title' | 'status' | 'signers' | 'progress';
 export type EnvelopeSortDir = 'asc' | 'desc';
 
+/** Dashboard status buckets — the `?bucket=` query-param vocabulary. */
+export type EnvelopeBucket = 'draft' | 'awaiting_you' | 'awaiting_others' | 'sealed' | 'declined';
+
 export interface ListEnvelopesParams {
   readonly statuses?: ReadonlyArray<EnvelopeStatus>;
   readonly limit?: number;
   readonly cursor?: string;
   readonly sort?: EnvelopeSortKey;
   readonly dir?: EnvelopeSortDir;
+  // Dashboard filters (server applies these in SQL).
+  readonly q?: string;
+  readonly bucket?: ReadonlyArray<EnvelopeBucket>;
+  /** Preset keyword or `custom:YYYY-MM-DD:YYYY-MM-DD`. */
+  readonly date?: string;
+  readonly signer?: ReadonlyArray<string>;
+  readonly tags?: ReadonlyArray<string>;
 }
 
 export interface FieldPlacement {
@@ -114,6 +124,11 @@ export async function listEnvelopes(
   if (params.cursor) query.set('cursor', params.cursor);
   if (params.sort) query.set('sort', params.sort);
   if (params.dir) query.set('dir', params.dir);
+  if (params.q) query.set('q', params.q);
+  if (params.bucket?.length) query.set('bucket', params.bucket.join(','));
+  if (params.date) query.set('date', params.date);
+  if (params.signer?.length) query.set('signer', params.signer.join(','));
+  if (params.tags?.length) query.set('tags', params.tags.join(','));
   const q = query.toString();
   const url = q ? `/envelopes?${q}` : '/envelopes';
   const { data } = await apiClient.get<EnvelopeListResponse>(url, configWithSignal(signal));

--- a/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -118,6 +118,18 @@ function renderDashboard(initialPath = '/documents') {
   );
 }
 
+/**
+ * The `/envelopes` URLs the mocked apiClient was called with, oldest →
+ * newest. With server-side filtering the mock can't actually narrow the
+ * list, so the contract we assert is "the request carried the right
+ * `?bucket=`/`?q=`/`?sort=` params".
+ */
+async function envelopeUrls(): Promise<readonly string[]> {
+  const { apiClient } = await import('../../lib/api/apiClient');
+  const getMock = apiClient.get as unknown as ReturnType<typeof vi.fn>;
+  return getMock.mock.calls.map((c) => String(c[0])).filter((u) => u.startsWith('/envelopes'));
+}
+
 describe('DashboardPage', () => {
   it('renders the heading and every envelope by default (no status filter)', async () => {
     renderDashboard();
@@ -130,27 +142,36 @@ describe('DashboardPage', () => {
     expect(screen.getByText(/offer letter — m\. chen/i)).toBeInTheDocument();
   });
 
-  it('narrows the table when the user picks a status from the toolbar', async () => {
+  it('pushes the picked status bucket onto the /envelopes request (server-side filter)', async () => {
     renderDashboard();
     await screen.findByText(/master services agreement/i);
     // Open the Status chip and pick ONLY "Draft" (no defaults to fight).
     fireEvent.click(screen.getByRole('button', { name: /^status filter$/i }));
     fireEvent.click(await screen.findByLabelText('Draft'));
-    expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
-    // MSA (awaiting_others) and the offer letter (sealed) are now hidden.
-    expect(screen.queryByText(/master services agreement/i)).toBeNull();
-    expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
+    await waitFor(async () => {
+      expect((await envelopeUrls()).some((u) => /bucket=draft/.test(u))).toBe(true);
+    });
+    // The toolbar's bucket counts come from a SECOND, unfiltered fetch —
+    // so a `bucket`-less request is still in flight alongside the filtered
+    // one. (When no filter is active React Query merges the two.)
+    expect((await envelopeUrls()).some((u) => !/bucket=/.test(u))).toBe(true);
+    // …and the toolbar still shows the full roster of buckets, including
+    // the "Sealed" one that the table filter excluded.
+    expect(await screen.findByLabelText('Sealed')).toBeInTheDocument();
   });
 
-  it('"Clear filters" wipes every active filter and shows the whole list again', async () => {
-    // Start narrowed via the URL, then clear.
+  it('"Clear filters" drops the bucket param from the /envelopes request', async () => {
     renderDashboard('/documents?status=draft');
     await screen.findByText(/vendor onboarding — argus/i);
-    expect(screen.queryByText(/master services agreement/i)).toBeNull();
+    // The initial fetch carried the URL's bucket.
+    expect((await envelopeUrls()).some((u) => /bucket=draft/.test(u))).toBe(true);
     fireEvent.click(screen.getByRole('button', { name: /clear all filters/i }));
+    await waitFor(async () => {
+      const urls = await envelopeUrls();
+      expect(urls[urls.length - 1]).not.toMatch(/bucket=/);
+    });
+    // Rows are still there (the mock returns the full seed regardless).
     expect(await screen.findByText(/master services agreement/i)).toBeInTheDocument();
-    expect(screen.getByText(/offer letter — m\. chen/i)).toBeInTheDocument();
-    expect(screen.getByText(/vendor onboarding — argus/i)).toBeInTheDocument();
   });
 
   it('exposes a link to start a new document', () => {
@@ -184,11 +205,16 @@ describe('DashboardPage', () => {
     expect(row?.textContent ?? '').toMatch(/1/);
   });
 
-  it('reads the initial filter from the ?status= query param', async () => {
+  it('reads the initial filter from the ?status= query param and forwards it as ?bucket=', async () => {
     renderDashboard('/documents?status=draft');
     await screen.findByText(/vendor onboarding — argus/i);
-    expect(screen.queryByText(/master services agreement/i)).toBeNull();
-    expect(screen.queryByText(/offer letter — m\. chen/i)).toBeNull();
+    expect((await envelopeUrls()).some((u) => /bucket=draft/.test(u))).toBe(true);
+  });
+
+  it('forwards the search box text as ?q= on the /envelopes request', async () => {
+    renderDashboard('/documents?q=argus');
+    await screen.findByText(/vendor onboarding — argus/i);
+    expect((await envelopeUrls()).some((u) => /[?&]q=argus/.test(u))).toBe(true);
   });
 
   it('clicking a column header cycles the server-side sort params and re-queries', async () => {

--- a/apps/web/src/pages/DashboardPage/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.tsx
@@ -22,7 +22,7 @@ import { StatCard } from '@/components/StatCard';
 import { useEnvelopesQuery } from '@/features/envelopes';
 import type { EnvelopeListItem, EnvelopeStatus } from '@/features/envelopes';
 import {
-  filterEnvelopes,
+  filtersToQueryParams,
   isAwaitingYou,
   parseFilters,
   parseSort,
@@ -282,30 +282,39 @@ export function DashboardPage() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // Click-to-sort: the sort key + direction live in the URL
-  // (`?sort=date&dir=desc`) so the view is bookmarkable. The sort is
-  // performed server-side — the list endpoint orders + keysets by
-  // these params — so the page just reflects whatever order the API
-  // returned.
+  // Sort + filters both live in the URL and are applied server-side
+  // (`GET /envelopes?sort=&dir=&q=&bucket=&date=&signer=&tags=`).
   const sort = useMemo(() => parseSort(searchParams), [searchParams]);
+  const parsedFilters = useMemo(() => parseFilters(searchParams), [searchParams]);
+  const filterParams = useMemo(() => filtersToQueryParams(parsedFilters), [parsedFilters]);
 
-  const q = useEnvelopesQuery(true, { limit: 100, sort: sort.key, dir: sort.dir });
-  const envelopes: ReadonlyArray<EnvelopeListItem> = useMemo(() => q.data?.items ?? [], [q.data]);
-  const documentsLoading = q.isPending;
-
-  // Viewer email drives the "Awaiting you" predicate so envelopes the user
-  // is themselves a signer on are bucketed correctly.
+  // Viewer email drives the "Awaiting you" predicate (toolbar counts +
+  // the row badge).
   const { user } = useAuth();
   const viewerEmail = user?.email ?? null;
 
-  // The toolbar owns filter UI and writes to the URL; the page reads
-  // the URL and applies a single combined filter pass. `filterEnvelopes`
-  // is a stable client-side narrowing (preserves input order), so the
-  // server's sort order survives it.
-  const parsedFilters = useMemo(() => parseFilters(searchParams), [searchParams]);
-  const filtered = useMemo(
-    () => filterEnvelopes(envelopes, parsedFilters, viewerEmail),
-    [envelopes, parsedFilters, viewerEmail],
+  // Table query — filtered + sorted by the server. Its `items` render
+  // directly; no client-side filter/sort pass.
+  const tableQuery = useEnvelopesQuery(true, {
+    limit: 100,
+    sort: sort.key,
+    dir: sort.dir,
+    ...filterParams,
+  });
+  const filtered: ReadonlyArray<EnvelopeListItem> = useMemo(
+    () => tableQuery.data?.items ?? [],
+    [tableQuery.data],
+  );
+  const documentsLoading = tableQuery.isPending;
+
+  // Toolbar / stats query — the *unfiltered* list, so the chips' per-
+  // bucket counts + distinct signer/tag lists stay accurate regardless
+  // of the active filter. React Query de-duplicates this against the
+  // table query whenever no filter is active (identical params).
+  const facetsQuery = useEnvelopesQuery(true, { limit: 100, sort: 'date', dir: 'desc' });
+  const allEnvelopes: ReadonlyArray<EnvelopeListItem> = useMemo(
+    () => facetsQuery.data?.items ?? [],
+    [facetsQuery.data],
   );
 
   // Header click cycle: not-active → asc; active+asc → desc;
@@ -347,14 +356,14 @@ export function DashboardPage() {
   );
 
   const stats = useMemo(() => {
-    const awaitingYou = envelopes.filter((d) => isAwaitingYou(d, viewerEmail)).length;
+    const awaitingYou = allEnvelopes.filter((d) => isAwaitingYou(d, viewerEmail)).length;
     // Mutually exclusive with awaitingYou so the totals don't double-count.
-    const awaitingOthers = envelopes.filter(
+    const awaitingOthers = allEnvelopes.filter(
       (d) =>
         (d.status === 'awaiting_others' || d.status === 'sealing') &&
         !isAwaitingYou(d, viewerEmail),
     ).length;
-    const completedThisMonth = envelopes.filter((d) => {
+    const completedThisMonth = allEnvelopes.filter((d) => {
       if (d.status !== 'completed') return false;
       const when = new Date(d.completed_at ?? d.updated_at);
       const now = new Date();
@@ -368,9 +377,9 @@ export function DashboardPage() {
         value: completedThisMonth.toString(),
         tone: 'emerald' as const,
       },
-      { label: 'Avg. turnaround', value: formatTurnaround(envelopes), tone: 'neutral' as const },
+      { label: 'Avg. turnaround', value: formatTurnaround(allEnvelopes), tone: 'neutral' as const },
     ];
-  }, [envelopes, viewerEmail]);
+  }, [allEnvelopes, viewerEmail]);
 
   return (
     <Main>
@@ -397,7 +406,7 @@ export function DashboardPage() {
           ))}
         </StatGrid>
 
-        <FilterToolbar envelopes={envelopes} viewerEmail={viewerEmail} />
+        <FilterToolbar envelopes={allEnvelopes} viewerEmail={viewerEmail} />
 
         <TableShell>
           <TableHead role="row" $grid={gridTemplate}>
@@ -431,7 +440,7 @@ export function DashboardPage() {
           </TableHead>
           {renderDocumentsBody({
             loading: documentsLoading,
-            rowsForSkeleton: envelopes.length === 0,
+            rowsForSkeleton: filtered.length === 0,
             filtered,
             navigate,
             viewerEmail,

--- a/docs/superpowers/specs/2026-05-11-dashboard-server-side-filtering-design.md
+++ b/docs/superpowers/specs/2026-05-11-dashboard-server-side-filtering-design.md
@@ -1,0 +1,129 @@
+# Dashboard server-side filtering — design
+
+**Date:** 2026-05-11
+**Scope:** Move the dashboard's table filtering (search / status-bucket /
+date / signer / tags) from the client into `GET /envelopes`'s SQL
+`WHERE`. The toolbar's facets (per-bucket counts, distinct signer /
+tag lists) keep deriving from a *second, unfiltered* fetch so they
+stay accurate. Builds on the filter toolbar (#226), tags (#227), and
+server-side sort (#230).
+
+## Goal
+
+The dashboard table reflects the active filters via a server query, so
+correctness no longer caps at the first 100 rows. The toolbar chips
+keep showing counts / option lists over the user's full envelope set
+(via the unfiltered fetch — same accuracy as today).
+
+## Non-goals
+
+- True beyond-100 facet counts (a `count(*) group by bucket` endpoint).
+  The toolbar facets stay at their current accuracy (the unfiltered
+  fetch's `limit: 100`). If that ever bites, a `/envelopes/facets`
+  endpoint is the follow-up.
+- Server-side *sort* — already done (#230); unchanged here.
+
+## API contract — `GET /envelopes` new query params
+
+| param | shape | SQL clause (all `AND`-combined; `e` = `envelopes`) |
+|---|---|---|
+| `q` | substring | `(lower(e.title) like lower('%'||:q||'%') or lower(e.short_code) like lower('%'||:q||'%'))` |
+| `bucket` | comma-separated subset of {`draft`,`awaiting_you`,`awaiting_others`,`sealed`,`declined`} | `OR` of one clause per bucket — see below |
+| `date` | `today` \| `7d` \| `30d` \| `thisMonth` \| `custom:YYYY-MM-DD:YYYY-MM-DD` | `e.updated_at >= :from and e.updated_at < :to` (server resolves the window; `now` is server-side) |
+| `signer` | comma-separated emails | `exists (select 1 from envelope_signers s where s.envelope_id = e.id and lower(s.email) in (:emails))` |
+| `tags` | comma-separated tag names | `OR` of `e.tags @> '["<tag>"]'::jsonb` per tag |
+
+**Bucket clauses** (the dashboard's status vocabulary — `awaiting_you`
+is "the auth'd user is a still-pending signer", not a column value):
+- `draft` → `e.status = 'draft'`
+- `sealed` → `e.status = 'completed'`
+- `declined` → `e.status = 'declined'`
+- `awaiting_you` → `e.status in ('awaiting_others','sealing') and exists (select 1 from envelope_signers s where s.envelope_id = e.id and lower(s.email) = lower(:viewerEmail) and s.signed_at is null and s.declined_at is null)`
+- `awaiting_others` → `e.status in ('awaiting_others','sealing') and not exists (… same exists …)`
+
+The existing literal `?status=` param (maps to `envelopes.status`
+column values, used by other callers) is left untouched — `bucket` is
+the new, dashboard-aware param.
+
+**Validation** (service layer, 400 `validation_error` on a bad value):
+unknown `bucket` token; unknown `date` preset / malformed `custom:`
+range; (no validation needed on `q` / `signer` / `tags` — any string
+is a valid substring / email-list / tag-list).
+
+**`viewerEmail`** is threaded `controller (@CurrentUser().email) →
+service → repo` — needed for the `awaiting_you` / `awaiting_others`
+buckets. When a `bucket` filter that needs it is requested but the
+auth user has no email (shouldn't happen for an authenticated
+session), the `exists` clause simply never matches → `awaiting_you`
+returns nothing, `awaiting_others` returns everything in those
+statuses (correct fallbacks).
+
+**Cursor:** unchanged. Filters are extra `AND`s; the 3-tuple keyset is
+on the sort expression, which the filters don't touch.
+
+**pg-mem note:** `like` with `lower()`, `exists` correlated
+subqueries, `in (...)` lists — all run in pg-mem (already used
+elsewhere in this repo). `jsonb @>` is the one uncertainty; if pg-mem
+chokes I'll fall back to `exists (select 1 from jsonb_array_elements_text(e.tags) t where t in (:tags))`,
+and if *that* fails, ship the other four filters server-side and keep
+the `tags` filter client-side (documented partial). The test run
+decides.
+
+## Frontend changes
+
+- `ListEnvelopesParams` gains `q?: string`, `bucket?: string[]`,
+  `date?: string`, `signer?: string[]`, `tags?: string[]`;
+  `listEnvelopes` serializes them onto the query string (joining the
+  array params with `,`).
+- New `features/dashboardFilters/filtersToQueryParams.ts` —
+  `EnvelopeFilters → ListEnvelopesParams`-shaped filter object. Mostly
+  1:1; `date: DateFilter` re-serializes to `7d` / `custom:from:to` /
+  (omitted when `all`). The dashboard's `StatusOption` vocabulary
+  already equals the API's `bucket` vocabulary, so `status[] →
+  bucket[]` is a passthrough.
+- `DashboardPage`:
+  - **Table query** — `useEnvelopesQuery(true, { limit: 100, sort,
+    dir, ...filtersToQueryParams(parsedFilters) })`. Its `items` are
+    rendered directly; no client-side `filterEnvelopes` pass.
+  - **Toolbar/stats query** — `useEnvelopesQuery(true, { limit: 100,
+    sort: 'date', dir: 'desc' })` (no filter params). React Query
+    dedups it with the table query whenever no filter is active.
+    `FilterToolbar` and the stat cards consume *this* list.
+  - `filterEnvelopes` is removed from the page. `bucketEnvelope` /
+    `isAwaitingYou` stay exported — `FilterToolbar` still uses
+    `bucketEnvelope` for the per-bucket counts over the unfiltered
+    list, and the dashboard's "Awaiting you" row badge still uses
+    `isAwaitingYou`.
+  - Loading state: the table shows skeletons while the *table* query
+    is pending; the empty-envelope-illustration shows when the table
+    query resolves with `items.length === 0`.
+
+## Tests
+
+| Layer | Asserts |
+|---|---|
+| `envelopes.service.spec.ts` | `list` filters the fake-repo results by `q` / `bucket` (incl. `awaiting_you` honoring `viewerEmail`) / `date` / `signer` / `tags`; rejects an unknown `bucket` token and a malformed `date`. (The fake repo's `listByOwner` gains the filter logic, mirroring the in-memory repo.) |
+| in-memory repo | `listByOwner` applies all five filters in JS. |
+| `filtersToQueryParams.test.ts` | `EnvelopeFilters → ListEnvelopesParams` mapping; `date` re-serialization (preset, custom, all-omitted); empty arrays omitted. |
+| `DashboardPage.test.tsx` | Applying a status filter sends `?bucket=draft` (or whatever) on the `/envelopes` request; a search sends `?q=`; the toolbar still shows non-zero counts (they come from the unfiltered fetch); the table reflects the filtered response. |
+
+`filterEnvelopes.test.ts` is **deleted** along with `filterEnvelopes`
+(its OR/AND/predicate behavior moves to the repo + is covered by the
+service spec). `bucketEnvelope` / `isAwaitingYou` keep their existing
+coverage via `filterEnvelopes.test.ts`'s `bucketEnvelope` cases —
+those move to a small `bucketEnvelope.test.ts`.
+
+## Risk + rollback
+
+- Two `/envelopes` fetches per dashboard load when a filter is active
+  (deduped to one otherwise). Both are `limit: 100` per-owner queries
+  on an indexed `owner_id` — negligible.
+- `jsonb @>` is the SQL risk; mitigated by the fallback ladder above.
+- Reverting the PR: drop the new query params (server ignores unknown
+  ones), re-add the client-side `filterEnvelopes` pass. No data
+  migration.
+
+## Local review checkpoint
+
+Default cadence; ships through CI like the recent PRs given the
+session velocity. Dev server on :5173 picks it up via HMR.


### PR DESCRIPTION
## Summary

The dashboard table's filters (search `q`, status bucket, date range,
signer, tags) now run **server-side in SQL** inside `GET /envelopes`
instead of a client-side pass over the fetched page — so a filter's
correctness no longer caps at the 100-row fetch limit.

- **API** — `GET /envelopes` gains `q` / `bucket` / `date` / `signer` /
  `tags` query params. `EnvelopesService.list` parses + validates them
  (`400 validation_error` on a bad bucket token / malformed date) and
  threads typed `ListFilters` + `viewerEmail` to the repository.
  `resolveDateWindow` turns a preset keyword or
  `custom:YYYY-MM-DD:YYYY-MM-DD` into a UTC `[from,to)` instant window.
- **Pg adapter** — `listByOwner` adds the filter `WHERE` clauses. The
  awaiting-you / signer-email filters pre-resolve their envelope-id sets
  in standalone queries (pg-mem can't correlate a raw-SQL `exists`
  subquery to the outer table alias), tags use `jsonb @>`.
  `list-filters.ts` mirrors the same predicates so the in-memory test
  double + service-spec fakes return identical results.
- **Web** — the table fetches the filtered+sorted rows; the toolbar
  derives its per-bucket counts + distinct signer/tag lists from a
  **second, unfiltered** `/envelopes` fetch (React Query merges the two
  when no filter is active). `filterEnvelopes` is deleted; new
  `filtersToQueryParams` maps the URL-parsed filters onto the wire shape.
- **Fix** — `test/pg-mem-db.ts` was missing the `tags` column on
  `envelopes` (PR #227 never updated it); added so the Pg repo specs run.

Spec: `docs/superpowers/specs/2026-05-11-dashboard-server-side-filtering-design.md`

## Test plan
- [x] `pnpm -r typecheck` / `pnpm -r lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — 198 files / 1553 tests green
- [x] `pnpm --filter api test` — 946 tests green (new `list — dashboard filters` cases + Pg repo filter cases)
- [x] `pnpm --filter api test:e2e` — 150 passed (2 env-flaky skips, unrelated)
- [ ] Post-deploy: spot-check the dashboard filter toolbar on https://seald.nromomentum.com (counts vs. filtered rows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)