### PR TITLE
feat(web): clickable dashboard KPI tiles as filter shortcuts

### DIFF
--- a/apps/web/src/components/StatCard/StatCard.styles.ts
+++ b/apps/web/src/components/StatCard/StatCard.styles.ts
@@ -1,11 +1,39 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import type { BadgeTone } from '../Badge/Badge.types';
 
-export const Root = styled.div`
+const cardSurface = css`
+  display: block;
+  width: 100%;
   background: ${({ theme }) => theme.color.bg.surface};
   border: 1px solid ${({ theme }) => theme.color.border[1]};
   border-radius: ${({ theme }) => theme.radius.lg};
   padding: ${({ theme }) => `${theme.space[5]} ${theme.space[5]}`};
+`;
+
+export const Root = styled.div`
+  ${cardSurface}
+`;
+
+/** Clickable variant — a real <button> that maps a stat tile to a filter. */
+export const InteractiveRoot = styled.button`
+  ${cardSurface}
+  appearance: none;
+  margin: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  transition:
+    border-color ${({ theme }) => theme.motion.durFast} ${({ theme }) => theme.motion.easeStandard},
+    box-shadow ${({ theme }) => theme.motion.durFast} ${({ theme }) => theme.motion.easeStandard};
+
+  &:hover {
+    border-color: ${({ theme }) => theme.color.indigo[300]};
+  }
+  &[aria-pressed='true'] {
+    border-color: ${({ theme }) => theme.color.indigo[600]};
+    box-shadow: inset 0 0 0 1px ${({ theme }) => theme.color.indigo[600]};
+  }
 `;
 
 export const Label = styled.div`

--- a/apps/web/src/components/StatCard/StatCard.test.tsx
+++ b/apps/web/src/components/StatCard/StatCard.test.tsx
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 import { renderWithTheme } from '../../test/renderWithTheme';
 import { StatCard } from './StatCard';
@@ -28,5 +29,43 @@ describe('StatCard', () => {
       <StatCard label="Awaiting you" value="12" tone="indigo" />,
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  describe('interactive variant', () => {
+    it('renders a button and calls onActivate on click', () => {
+      const onActivate = vi.fn();
+      const { getByRole } = renderWithTheme(
+        <StatCard label="Awaiting you" value="3" tone="indigo" onActivate={onActivate} />,
+      );
+      const btn = getByRole('button', { name: /awaiting you/i });
+      fireEvent.click(btn);
+      expect(onActivate).toHaveBeenCalledTimes(1);
+    });
+
+    it('reflects the pressed state via aria-pressed', () => {
+      const { getByRole, rerender } = renderWithTheme(
+        <StatCard label="Sealed this month" value="1" tone="emerald" onActivate={vi.fn()} />,
+      );
+      expect(getByRole('button')).toHaveAttribute('aria-pressed', 'false');
+      rerender(
+        <StatCard label="Sealed this month" value="1" tone="emerald" active onActivate={vi.fn()} />,
+      );
+      expect(getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('stays a plain (non-button) tile when onActivate is omitted', () => {
+      const { queryByRole, getByText } = renderWithTheme(
+        <StatCard label="Avg. turnaround" value="4h" tone="neutral" />,
+      );
+      expect(queryByRole('button')).toBeNull();
+      expect(getByText('Avg. turnaround')).toBeInTheDocument();
+    });
+
+    it('has no axe violations as a button', async () => {
+      const { container } = renderWithTheme(
+        <StatCard label="Awaiting others" value="2" tone="amber" active onActivate={vi.fn()} />,
+      );
+      expect(await axe(container)).toHaveNoViolations();
+    });
   });
 });

--- a/apps/web/src/components/StatCard/StatCard.tsx
+++ b/apps/web/src/components/StatCard/StatCard.tsx
@@ -1,17 +1,35 @@
 import { forwardRef } from 'react';
 import type { StatCardProps } from './StatCard.types';
-import { Label, Root, Value } from './StatCard.styles';
+import { InteractiveRoot, Label, Root, Value } from './StatCard.styles';
 
 /**
  * L1 primitive — displays a single KPI tile with a muted label above a large
  * tone-colored value. Used in the dashboard stat grid.
+ *
+ * Pass `onActivate` to make the tile a real `<button>` that toggles a
+ * filter; `active` paints the pressed state.
  */
 export const StatCard = forwardRef<HTMLDivElement, StatCardProps>((props, ref) => {
-  const { label, value, tone, ...rest } = props;
-  return (
-    <Root ref={ref} {...rest}>
+  const { label, value, tone, onActivate, active, ...rest } = props;
+  const body = (
+    <>
       <Label>{label}</Label>
       <Value $tone={tone}>{value}</Value>
+    </>
+  );
+  if (onActivate) {
+    // The div ref + `...rest` (typed for a div) aren't forwarded here —
+    // no consumer needs either on an interactive tile, and forwarding
+    // div-typed handlers onto a <button> doesn't type-check.
+    return (
+      <InteractiveRoot type="button" aria-pressed={active ?? false} onClick={onActivate}>
+        {body}
+      </InteractiveRoot>
+    );
+  }
+  return (
+    <Root ref={ref} {...rest}>
+      {body}
     </Root>
   );
 });

--- a/apps/web/src/components/StatCard/StatCard.types.ts
+++ b/apps/web/src/components/StatCard/StatCard.types.ts
@@ -5,4 +5,14 @@ export interface StatCardProps extends HTMLAttributes<HTMLDivElement> {
   readonly label: string;
   readonly value: string;
   readonly tone: BadgeTone;
+  /**
+   * When provided, the card renders as a `<button>` and calls this on
+   * click / Enter / Space. Use it to wire a stat tile to a filter.
+   */
+  readonly onActivate?: () => void;
+  /**
+   * Pressed state for an interactive card — set when the filter this
+   * tile maps to is currently active. Ignored unless `onActivate` is set.
+   */
+  readonly active?: boolean;
 }

--- a/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.test.tsx
@@ -217,6 +217,42 @@ describe('DashboardPage', () => {
     expect((await envelopeUrls()).some((u) => /[?&]q=argus/.test(u))).toBe(true);
   });
 
+  it('clicking the "Awaiting others" stat tile toggles its filter (pressed state + bucket query)', async () => {
+    renderDashboard();
+    await screen.findByText(/master services agreement/i);
+    const tile = () => screen.getByRole('button', { name: /awaiting others/i });
+    expect(tile()).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(tile());
+    await waitFor(() => expect(tile()).toHaveAttribute('aria-pressed', 'true'));
+    expect((await envelopeUrls()).some((u) => /bucket=awaiting_others/.test(u))).toBe(true);
+
+    // Clicking the already-active tile clears every filter.
+    fireEvent.click(tile());
+    await waitFor(() => expect(tile()).toHaveAttribute('aria-pressed', 'false'));
+  });
+
+  it('the "Sealed this month" stat tile maps to bucket=sealed + date=thisMonth', async () => {
+    renderDashboard();
+    await screen.findByText(/master services agreement/i);
+    fireEvent.click(screen.getByRole('button', { name: /sealed this month/i }));
+    await waitFor(async () => {
+      const u = (await envelopeUrls()).at(-1) ?? '';
+      expect(u).toMatch(/bucket=sealed/);
+      expect(u).toMatch(/date=thisMonth/);
+    });
+    expect(screen.getByRole('button', { name: /sealed this month/i })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
+  });
+
+  it('the "Avg. turnaround" stat tile is not clickable', async () => {
+    renderDashboard();
+    await screen.findByText(/master services agreement/i);
+    expect(screen.queryByRole('button', { name: /avg\. turnaround/i })).toBeNull();
+  });
+
   it('clicking a column header cycles the server-side sort params and re-queries', async () => {
     // Resolve the mocked apiClient so we can inspect the URLs it was
     // called with — the server does the sort, so the contract we test

--- a/apps/web/src/pages/DashboardPage/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.tsx
@@ -26,6 +26,8 @@ import {
   isAwaitingYou,
   parseFilters,
   parseSort,
+  serializeFilters,
+  type EnvelopeFilters,
   type SortKey,
 } from '@/features/dashboardFilters';
 import { formatShortDate } from '@/lib/dateFormat';
@@ -77,6 +79,30 @@ const COLUMN_SPECS = COLUMN_KEYS.map((k) => ({
   min: COLUMN_MIN_WIDTHS[k],
 }));
 const COLUMN_WIDTHS_STORAGE_KEY = 'seald.dashboard.columns.v1';
+
+/** The "no filter at all" state — what `Clear filters` resets to. */
+const EMPTY_FILTERS: EnvelopeFilters = {
+  q: '',
+  status: [],
+  date: { kind: 'preset', preset: 'all' },
+  signer: [],
+  tags: [],
+};
+
+/**
+ * The filter each clickable stat tile maps to. Clicking applies it
+ * (replacing the current filter set); clicking the already-applied
+ * tile clears every filter.
+ */
+const STAT_FILTERS = {
+  awaitingYou: { ...EMPTY_FILTERS, status: ['awaiting_you'] },
+  awaitingOthers: { ...EMPTY_FILTERS, status: ['awaiting_others'] },
+  sealedThisMonth: {
+    ...EMPTY_FILTERS,
+    status: ['sealed'],
+    date: { kind: 'preset', preset: 'thisMonth' },
+  },
+} as const satisfies Record<string, EnvelopeFilters>;
 
 const STATUS_LABEL: Record<EnvelopeStatus, string> = {
   draft: 'Draft',
@@ -344,6 +370,25 @@ export function DashboardPage() {
     [setSearchParams],
   );
 
+  // Stat-tile click → replace the filter facets with `next` (keeping
+  // whatever sort is active). Used by the clickable KPI tiles below.
+  const applyStatFilter = useCallback(
+    (next: EnvelopeFilters): void => {
+      setSearchParams(
+        (prev) => {
+          const params = new URLSearchParams(serializeFilters(next));
+          const sortKey = prev.get('sort');
+          const sortDir = prev.get('dir');
+          if (sortKey) params.set('sort', sortKey);
+          if (sortDir) params.set('dir', sortDir);
+          return params;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
   // Per-user column widths persisted in localStorage (piece 3 of the
   // single-screen-with-filters request). The hook gives us the live
   // map + a setter the resize handles call on every pointer-move;
@@ -355,7 +400,15 @@ export function DashboardPage() {
     [widths],
   );
 
-  const stats = useMemo(() => {
+  const stats = useMemo<
+    ReadonlyArray<{
+      readonly label: string;
+      readonly value: string;
+      readonly tone: BadgeTone;
+      /** Set on the tiles that act as filter shortcuts. */
+      readonly filter?: EnvelopeFilters;
+    }>
+  >(() => {
     const awaitingYou = allEnvelopes.filter((d) => isAwaitingYou(d, viewerEmail)).length;
     // Mutually exclusive with awaitingYou so the totals don't double-count.
     const awaitingOthers = allEnvelopes.filter(
@@ -370,14 +423,25 @@ export function DashboardPage() {
       return when.getFullYear() === now.getFullYear() && when.getMonth() === now.getMonth();
     }).length;
     return [
-      { label: 'Awaiting you', value: awaitingYou.toString(), tone: 'indigo' as const },
-      { label: 'Awaiting others', value: awaitingOthers.toString(), tone: 'amber' as const },
+      {
+        label: 'Awaiting you',
+        value: awaitingYou.toString(),
+        tone: 'indigo',
+        filter: STAT_FILTERS.awaitingYou,
+      },
+      {
+        label: 'Awaiting others',
+        value: awaitingOthers.toString(),
+        tone: 'amber',
+        filter: STAT_FILTERS.awaitingOthers,
+      },
       {
         label: 'Sealed this month',
         value: completedThisMonth.toString(),
-        tone: 'emerald' as const,
+        tone: 'emerald',
+        filter: STAT_FILTERS.sealedThisMonth,
       },
-      { label: 'Avg. turnaround', value: formatTurnaround(allEnvelopes), tone: 'neutral' as const },
+      { label: 'Avg. turnaround', value: formatTurnaround(allEnvelopes), tone: 'neutral' },
     ];
   }, [allEnvelopes, viewerEmail]);
 
@@ -401,9 +465,23 @@ export function DashboardPage() {
         </HeaderSlot>
 
         <StatGrid>
-          {stats.map((s) => (
-            <StatCard key={s.label} label={s.label} value={s.value} tone={s.tone} />
-          ))}
+          {stats.map((s) => {
+            if (!s.filter) {
+              return <StatCard key={s.label} label={s.label} value={s.value} tone={s.tone} />;
+            }
+            const target = s.filter;
+            const active = serializeFilters(parsedFilters) === serializeFilters(target);
+            return (
+              <StatCard
+                key={s.label}
+                label={s.label}
+                value={s.value}
+                tone={s.tone}
+                active={active}
+                onActivate={() => applyStatFilter(active ? EMPTY_FILTERS : target)}
+              />
+            );
+          })}
         </StatGrid>
 
         <FilterToolbar envelopes={allEnvelopes} viewerEmail={viewerEmail} />


### PR DESCRIPTION
## Summary

The dashboard stat tiles — **Awaiting you**, **Awaiting others**,
**Sealed this month** — are now one-click filter shortcuts. Clicking a
tile replaces the active filter set with its target; clicking the
already-applied tile clears every filter. **Avg. turnaround** stays a
plain, non-interactive tile.

| Tile | Filter applied |
|---|---|
| Awaiting you | `status=awaiting_you` |
| Awaiting others | `status=awaiting_others` |
| Sealed this month | `status=sealed` + `date=thisMonth` |

- `StatCard` gains an optional `onActivate` prop — when set, the tile
  renders as a real `<button type="button">` with `aria-pressed` for
  the toggle state. The shared surface CSS is extracted to a `css`
  block so the button + div variants can't drift. axe-clean in both
  forms.
- `DashboardPage` maps each clickable tile to an `EnvelopeFilters`
  target, derives the pressed state by comparing the serialized current
  filters, and writes the new facets to the URL via `serializeFilters`
  (preserving whatever sort is active). The table refetches with the
  corresponding `?bucket=` / `?date=` automatically.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm -r lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — 198 files / 1560 tests green
  - new `StatCard` interactive-variant tests (button role, `aria-pressed`, click, non-interactive fallback, axe)
  - new `DashboardPage` tests: tile click toggles its filter + re-queries with `?bucket=`; "Sealed this month" maps to `bucket=sealed&date=thisMonth`; "Avg. turnaround" is not a button
- [x] React PR review walk-through — no MUST-FIX
- [ ] Post-deploy: click each tile on https://seald.nromomentum.com and confirm the toolbar chips + table update

🤖 Generated with [Claude Code](https://claude.com/claude-code)