### PR TITLE
feat(web): tri-color Drive mark on the "Save to Google Drive" menu row

### DIFF
--- a/apps/web/src/components/DownloadMenu/DownloadMenu.types.ts
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.types.ts
@@ -1,5 +1,19 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { ComponentType, HTMLAttributes, ReactNode } from 'react';
 import type { LucideIcon } from 'lucide-react';
+
+/**
+ * Minimum contract for an icon component the menu can render: it must
+ * accept a numeric `size` and an optional `aria-hidden` (the menu treats
+ * the icon as decorative — the row title carries the label). `LucideIcon`
+ * satisfies this, as does any small SVG component built for the seald
+ * design system (e.g. `GDriveLogo` for the "Save to Google Drive" row).
+ */
+export type DownloadMenuIcon =
+  | LucideIcon
+  | ComponentType<{
+      readonly size?: number;
+      readonly 'aria-hidden'?: boolean | 'true' | 'false';
+    }>;
 
 /**
  * One row in the dropdown. `kind` is the opaque tag handed back via
@@ -13,7 +27,7 @@ import type { LucideIcon } from 'lucide-react';
  */
 export interface DownloadMenuItem {
   readonly kind: string;
-  readonly icon: LucideIcon;
+  readonly icon: DownloadMenuIcon;
   readonly title: string;
   readonly description: ReactNode;
   /** Mono meta line ("4 pages · 214 KB" / "Available once sealed"). */

--- a/apps/web/src/features/gdriveImport/GDriveLogo.tsx
+++ b/apps/web/src/features/gdriveImport/GDriveLogo.tsx
@@ -4,18 +4,28 @@
  * surfaces don't pull in the entire IntegrationsPage chunk just for a
  * 50-byte SVG. Both copies render identical pixel output; sync them if
  * the brand asset ever changes.
+ *
+ * Pass `aria-hidden` to render the mark decoratively (no `role`,
+ * `aria-label`, or `<title>` — the surrounding label carries the
+ * meaning). Used by the envelope download dropdown's "Save to Google
+ * Drive" row, where the row's title already says "Google Drive".
  */
-export function GDriveLogo({ size = 32 }: { readonly size?: number }) {
+export interface GDriveLogoProps {
+  readonly size?: number;
+  readonly 'aria-hidden'?: boolean | 'true' | 'false';
+}
+
+export function GDriveLogo({ size = 32, 'aria-hidden': ariaHidden }: GDriveLogoProps) {
+  const decorative = ariaHidden === true || ariaHidden === 'true';
   return (
     <svg
       width={size}
       height={size}
       viewBox="0 0 32 32"
-      role="img"
-      aria-label="Google Drive"
+      {...(decorative ? { 'aria-hidden': true } : { role: 'img', 'aria-label': 'Google Drive' })}
       style={{ flexShrink: 0 }}
     >
-      <title>Google Drive</title>
+      {decorative ? null : <title>Google Drive</title>}
       <path d="M11 4 L21 4 L31 21 L26 30 L16 13 Z" fill="#FBBC04" />
       <path d="M11 4 L1 21 L6 30 L16 13 Z" fill="#1FA463" />
       <path d="M6 30 L26 30 L31 21 L11 21 Z" fill="#4285F4" />

--- a/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
+++ b/apps/web/src/pages/EnvelopeDetailPage/EnvelopeDetailPage.tsx
@@ -9,7 +9,6 @@ import {
   FileCheck2,
   FileText,
   FilePlus,
-  HardDriveUpload,
   Package,
   PencilRuler,
   PenTool,
@@ -46,6 +45,7 @@ import {
   useDeleteEnvelopeMutation,
 } from '@/features/envelopes/useEnvelopes';
 import { useSaveEnvelopeToGdrive } from '@/features/gdriveExport';
+import { GDriveLogo } from '@/features/gdriveImport/GDriveLogo';
 import type { Envelope, EnvelopeEvent, EnvelopeStatus, SignerUiStatus } from '@/features/envelopes';
 import {
   Actions,
@@ -741,7 +741,7 @@ export function EnvelopeDetailPage() {
       ? [
           {
             kind: 'gdrive',
-            icon: HardDriveUpload,
+            icon: GDriveLogo,
             title: 'Save to Google Drive',
             description: 'Push the sealed PDF + audit trail into a Drive folder you pick.',
             meta: envelope.gdriveExport?.lastPushedAt


### PR DESCRIPTION
## Summary
Swap the monochrome `HardDriveUpload` lucide icon on the envelope download dropdown's "Save to Google Drive" row for the existing tri-color `GDriveLogo` SVG (Google brand colors).

- `GDriveLogo` gains an optional `aria-hidden` prop — when set it renders decoratively (no `role`/`aria-label`/`<title>`), since the row's title already says "Google Drive". Existing consumers (Settings, Import overlay, Upload page, Mobile send) don't pass the flag and keep the labeled mark.
- `DownloadMenuItem.icon` widens to a `DownloadMenuIcon` union of `LucideIcon | ComponentType<{ size?; 'aria-hidden'? }>` so both Lucide icons (other rows) and the brand SVG fit.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm --filter web lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — 1582/1582 green
- [ ] Post-deploy: open the dropdown on a sealed envelope on prod and confirm the row now shows the colored Drive mark

🤖 Generated with [Claude Code](https://claude.com/claude-code)