### PR TITLE
fix(web): tighten DownloadMenu proportions

### DIFF
--- a/apps/web/src/components/DownloadMenu/DownloadMenu.styles.ts
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.styles.ts
@@ -90,20 +90,20 @@ export const Menu = styled.div`
   top: calc(100% + 6px);
   right: 0;
   z-index: 50;
-  width: 360px;
+  width: 320px;
   background: ${({ theme }) => theme.color.bg.surface};
   border: 1px solid ${({ theme }) => theme.color.border[1]};
-  border-radius: 14px;
+  border-radius: 12px;
   box-shadow: ${({ theme }) => theme.shadow.lg};
-  padding: ${({ theme }) => theme.space[2]};
+  padding: 6px;
   animation: ${menuIn} 160ms cubic-bezier(0.2, 0.8, 0.2, 1);
   font-family: ${({ theme }) => theme.font.sans};
 `;
 
 export const MenuHeading = styled.div`
-  padding: 8px 10px 6px;
+  padding: 6px 8px 4px;
   font-family: ${({ theme }) => theme.font.mono};
-  font-size: 11px;
+  font-size: 10px;
   font-weight: ${({ theme }) => theme.font.weight.semibold};
   letter-spacing: 0.08em;
   color: ${({ theme }) => theme.color.fg[3]};
@@ -114,11 +114,11 @@ export const Item = styled.button<{ $active: boolean }>`
   all: unset;
   box-sizing: border-box;
   display: flex;
-  gap: ${({ theme }) => theme.space[3]};
+  gap: ${({ theme }) => theme.space[2]};
   align-items: flex-start;
   width: 100%;
-  padding: 10px;
-  border-radius: 10px;
+  padding: 7px 8px;
+  border-radius: 8px;
   text-align: left;
   cursor: pointer;
   font-family: ${({ theme }) => theme.font.sans};
@@ -137,9 +137,9 @@ export const Item = styled.button<{ $active: boolean }>`
 `;
 
 export const ItemIcon = styled.div<{ $recommended: boolean }>`
-  width: 36px;
-  height: 36px;
-  border-radius: 9px;
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
   flex-shrink: 0;
   display: flex;
   align-items: center;
@@ -202,30 +202,30 @@ export const LockedPill = styled.span`
 `;
 
 export const ItemDesc = styled.div`
-  font-size: 12px;
+  font-size: 11px;
   color: ${({ theme }) => theme.color.fg[3]};
-  margin-top: 2px;
-  line-height: 1.45;
+  margin-top: 1px;
+  line-height: 1.35;
 `;
 
 export const ItemMeta = styled.div`
   font-family: ${({ theme }) => theme.font.mono};
-  font-size: 11px;
+  font-size: 10px;
   color: ${({ theme }) => theme.color.fg[4]};
-  margin-top: 4px;
+  margin-top: 2px;
 `;
 
 export const Divider = styled.div`
   height: 1px;
-  margin: 6px 8px;
+  margin: 4px 8px;
   background: ${({ theme }) => theme.color.border[1]};
 `;
 
 export const Footer = styled.div`
-  padding: 10px 10px 4px;
+  padding: 8px 8px 2px;
   border-top: 1px solid ${({ theme }) => theme.color.border[1]};
-  margin-top: 6px;
-  font-size: 11px;
+  margin-top: 4px;
+  font-size: 10px;
   color: ${({ theme }) => theme.color.fg[4]};
   line-height: 1.5;
   display: flex;

--- a/apps/web/src/components/DownloadMenu/DownloadMenu.tsx
+++ b/apps/web/src/components/DownloadMenu/DownloadMenu.tsx
@@ -77,10 +77,10 @@ function renderItem(
       <ItemIcon $recommended={it.recommended === true}>
         {isLoading ? (
           <ItemIconSpinning>
-            <Loader2 size={16} aria-hidden />
+            <Loader2 size={14} aria-hidden />
           </ItemIconSpinning>
         ) : (
-          <Icon size={16} aria-hidden />
+          <Icon size={14} aria-hidden />
         )}
       </ItemIcon>
       <ItemBody>


### PR DESCRIPTION
## Summary
The envelope download dropdown reads as oversized once all five rows are visible (Original / Sealed / Audit / Full package / Save to Google Drive). The icon tiles, padding, and type sizes were tuned for a 4-row menu — scaling them down so the menu reads as a compact list instead of a stack of cards.

- Menu width **360 → 320 px**; corner radius 14 → 12 px; padding 8 → 6 px.
- Item padding **10 → 7px/8px**; row gap 12 → 8 px; row corner 10 → 8 px.
- Icon tile **36×36 → 28×28**; inner Lucide/SVG `size` **16 → 14**.
- `ItemDesc` 12 → 11 px, line-height 1.45 → 1.35.
- `ItemMeta` 11 → 10 px; `MenuHeading` 11 → 10 px; `Footer` 11 → 10 px.
- Divider + Footer vertical margins trimmed a couple of pixels each.

No structural changes — purely sizing. Vitest + Chromatic catch the visual delta.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm --filter web lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — 1582/1582
- [ ] Post-deploy: open the dropdown on a sealed envelope on prod and eyeball that the rows feel proportional

🤖 Generated with [Claude Code](https://claude.com/claude-code)