### PR TITLE
fix(web): handle 401 from picker-credentials by re-opening OAuth consent

### DIFF
--- a/apps/web/src/pages/MobileSendPage/screens/MWIntegrations.test.tsx
+++ b/apps/web/src/pages/MobileSendPage/screens/MWIntegrations.test.tsx
@@ -11,6 +11,7 @@ vi.mock('@/routes/settings/integrations/useGDriveAccounts', () => ({
   useGDriveAccounts: vi.fn(),
   GDRIVE_ACCOUNTS_KEY: ['integrations', 'gdrive', 'accounts'],
   useConnectGDrive: () => ({ mutate: vi.fn() }),
+  useReconnectGDrive: () => ({ mutate: vi.fn() }),
   useDisconnectGDrive: () => ({
     mutate: disconnectMutateMock,
     isPending: false,

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.gdrive.test.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.gdrive.test.tsx
@@ -8,12 +8,16 @@ import { SAMPLE_TEMPLATES as TEMPLATES } from '../../test/templateFixtures';
 import * as flagsModule from 'shared';
 
 const connectMutateMock = vi.fn();
+const reconnectMutateMock = vi.fn();
 vi.mock('../../routes/settings/integrations/useGDriveAccounts', () => ({
   useGDriveAccounts: vi.fn(),
   GDRIVE_ACCOUNTS_KEY: ['integrations', 'gdrive', 'accounts'],
   // The disconnected-state CTA wires to `useConnectGDrive().mutate()`
   // so the OAuth popup opens within the user gesture.
   useConnectGDrive: () => ({ mutate: connectMutateMock }),
+  // `<DrivePicker onReconnect>` fires `useReconnectGDrive().mutate()`
+  // when picker-credentials returns 401 token-expired.
+  useReconnectGDrive: () => ({ mutate: reconnectMutateMock }),
   useDisconnectGDrive: vi.fn(),
   useGDriveOAuthMessageListener: vi.fn(),
 }));

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.layout.test.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.layout.test.tsx
@@ -12,6 +12,7 @@ vi.mock('../../routes/settings/integrations/useGDriveAccounts', () => ({
   useGDriveAccounts: vi.fn(),
   GDRIVE_ACCOUNTS_KEY: ['integrations', 'gdrive', 'accounts'],
   useConnectGDrive: () => ({ mutate: connectMutateMock }),
+  useReconnectGDrive: () => ({ mutate: vi.fn() }),
   useDisconnectGDrive: vi.fn(),
   useGDriveOAuthMessageListener: vi.fn(),
 }));

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.tsx
@@ -19,6 +19,7 @@ import { UploadPage } from '@/pages/UploadPage';
 import {
   useConnectGDrive,
   useGDriveAccounts,
+  useReconnectGDrive,
 } from '@/routes/settings/integrations/useGDriveAccounts';
 import {
   findTemplateById,
@@ -193,9 +194,15 @@ export function UseTemplatePage() {
   const accounts = gdriveOn ? (accountsQuery.data ?? []) : [];
   const driveAccountId = accounts[0]?.id ?? null;
   const connectDrive = useConnectGDrive();
+  const reconnectDrive = useReconnectGDrive();
   const handleConnectDrive = useCallback((): void => {
     connectDrive.mutate();
   }, [connectDrive]);
+  // Wired into <DrivePicker onReconnect>; see UploadRoute for the
+  // rationale (401 token-expired → silently closed picker without this).
+  const handleReconnectDrive = useCallback((): void => {
+    reconnectDrive.mutate();
+  }, [reconnectDrive]);
   const [drivePickerOpen, setDrivePickerOpen] = useState(false);
   const driveImport = useDriveImport({
     accountId: driveAccountId ?? '',
@@ -596,6 +603,7 @@ export function UseTemplatePage() {
           open={drivePickerOpen}
           accountId={driveAccountId}
           onClose={() => setDrivePickerOpen(false)}
+          onReconnect={handleReconnectDrive}
           onPick={(file) => {
             setDrivePickerOpen(false);
             driveImport.beginImport(file);

--- a/apps/web/src/routes/UploadRoute.gdrive.test.tsx
+++ b/apps/web/src/routes/UploadRoute.gdrive.test.tsx
@@ -6,6 +6,7 @@ import { renderWithProviders } from '../test/renderWithProviders';
 import * as flagsModule from 'shared';
 
 const connectMutateMock = vi.fn();
+const reconnectMutateMock = vi.fn();
 vi.mock('./settings/integrations/useGDriveAccounts', () => ({
   useGDriveAccounts: vi.fn(),
   GDRIVE_ACCOUNTS_KEY: ['integrations', 'gdrive', 'accounts'],
@@ -13,6 +14,9 @@ vi.mock('./settings/integrations/useGDriveAccounts', () => ({
   // — return a minimal mutation shape so the inline-popup connect path
   // doesn't blow up under test.
   useConnectGDrive: () => ({ mutate: connectMutateMock }),
+  // `<DrivePicker onReconnect>` wires to `useReconnectGDrive().mutate()`
+  // — fires when picker-credentials returns 401 token-expired.
+  useReconnectGDrive: () => ({ mutate: reconnectMutateMock }),
   useDisconnectGDrive: vi.fn(),
   useGDriveOAuthMessageListener: vi.fn(),
 }));
@@ -29,6 +33,7 @@ vi.mock('../components/drive-picker', () => ({
     open: boolean;
     onClose: () => void;
     onPick: (file: { id: string; name: string; mimeType: string }) => void;
+    onReconnect?: () => void;
   }): JSX.Element | null => {
     if (!props.open) return null;
     return (
@@ -48,6 +53,11 @@ vi.mock('../components/drive-picker', () => ({
         <button type="button" onClick={props.onClose}>
           Close picker
         </button>
+        {props.onReconnect ? (
+          <button type="button" onClick={props.onReconnect}>
+            Trigger reconnect
+          </button>
+        ) : null}
       </div>
     );
   },
@@ -74,6 +84,8 @@ describe('UploadRoute Drive integration (WT-E)', () => {
   beforeEach(() => {
     isFeatureEnabledSpy = vi.spyOn(flagsModule, 'isFeatureEnabled');
     useGDriveAccountsMock.mockReset();
+    connectMutateMock.mockClear();
+    reconnectMutateMock.mockClear();
   });
   afterEach(() => {
     isFeatureEnabledSpy.mockRestore();
@@ -140,5 +152,20 @@ describe('UploadRoute Drive integration (WT-E)', () => {
     expect(screen.queryByTestId('drive-picker-stub')).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /pick from google drive/i }));
     expect(screen.getByTestId('drive-picker-stub')).toBeInTheDocument();
+  });
+
+  // Regression: a revoked Drive refresh token causes
+  // `GET /integrations/gdrive/picker-credentials` to 401. The DrivePicker
+  // forwards that signal to `onReconnect`. UploadRoute previously did
+  // not wire the prop, so the picker silently closed and the user saw
+  // nothing in the UI — only the 401 in DevTools (Bug, 2026-05-14).
+  it('wires onReconnect to fire the reconnect-OAuth mutation', () => {
+    isFeatureEnabledSpy.mockReturnValue(true);
+    mockAccounts(true);
+    renderRoute();
+    fireEvent.click(screen.getByRole('button', { name: /pick from google drive/i }));
+    expect(reconnectMutateMock).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole('button', { name: /trigger reconnect/i }));
+    expect(reconnectMutateMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/routes/UploadRoute.tsx
+++ b/apps/web/src/routes/UploadRoute.tsx
@@ -14,7 +14,11 @@ import { pickAvailableColor } from '../features/signers/pickAvailableColor';
 import { usePdfDocument } from '../lib/pdf';
 import { ConversionFailedDialog, ImportOverlay, useDriveImport } from '../features/gdriveImport';
 import type { ImportPhase } from '../features/gdriveImport';
-import { useConnectGDrive, useGDriveAccounts } from './settings/integrations/useGDriveAccounts';
+import {
+  useConnectGDrive,
+  useGDriveAccounts,
+  useReconnectGDrive,
+} from './settings/integrations/useGDriveAccounts';
 import {
   findTemplateById,
   getTemplates,
@@ -139,9 +143,19 @@ export function UploadRoute() {
   const accounts = gdriveOn ? (accountsQuery.data ?? []) : [];
   const driveAccountId = accounts[0]?.id ?? null;
   const connectDrive = useConnectGDrive();
+  const reconnectDrive = useReconnectGDrive();
   const handleConnectDrive = useCallback((): void => {
     connectDrive.mutate();
   }, [connectDrive]);
+  // Wired into <DrivePicker onReconnect>. Picker-credentials returns 401
+  // `token-expired` when the stored refresh token was revoked; without
+  // this handler the picker silently opens + closes (Bug — user sees
+  // the 401 in DevTools and nothing in the UI). With it, the OAuth
+  // popup opens with prompt=consent so Google mints a fresh refresh
+  // token; the user can retry the picker after authorizing.
+  const handleReconnectDrive = useCallback((): void => {
+    reconnectDrive.mutate();
+  }, [reconnectDrive]);
   const [drivePickerOpen, setDrivePickerOpen] = useState(false);
   const [driveImportPhase, setDriveImportPhase] = useState<ImportPhase | null>(null);
   const [driveImportFileName, setDriveImportFileName] = useState('');
@@ -469,6 +483,7 @@ export function UploadRoute() {
           open={drivePickerOpen}
           accountId={driveAccountId}
           onClose={() => setDrivePickerOpen(false)}
+          onReconnect={handleReconnectDrive}
           onPick={(file) => {
             setDrivePickerOpen(false);
             driveImport.beginImport(file);

--- a/apps/web/src/routes/settings/integrations/useGDriveAccounts.test.tsx
+++ b/apps/web/src/routes/settings/integrations/useGDriveAccounts.test.tsx
@@ -2,7 +2,12 @@ import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { useGDriveAccounts, useConnectGDrive, useDisconnectGDrive } from './useGDriveAccounts';
+import {
+  useGDriveAccounts,
+  useConnectGDrive,
+  useDisconnectGDrive,
+  useReconnectGDrive,
+} from './useGDriveAccounts';
 
 // Mock the shared apiClient — every test owns its own response set.
 vi.mock('../../../lib/api/apiClient', () => ({
@@ -85,6 +90,44 @@ describe('useConnectGDrive', () => {
       'gdrive-oauth',
       expect.stringContaining('width='),
     );
+  });
+});
+
+describe('useReconnectGDrive', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    openSpy.mockReset();
+  });
+
+  it('opens the consent URL with prompt=consent forced', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { url: 'https://accounts.google.com/o/oauth2/v2/auth?client_id=x' },
+      status: 200,
+    });
+    const { result } = renderHook(() => useReconnectGDrive(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(mockedGet).toHaveBeenCalledWith('/integrations/gdrive/oauth/url');
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const opened = String(openSpy.mock.calls[0]?.[0] ?? '');
+    expect(opened).toMatch(/[?&]prompt=consent\b/);
+    expect(opened).toMatch(/client_id=x/);
+    expect(openSpy.mock.calls[0]?.[1]).toBe('gdrive-oauth');
+  });
+
+  it('overrides any pre-existing prompt param on the URL', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { url: 'https://accounts.google.com/o/oauth2/v2/auth?prompt=none&client_id=x' },
+      status: 200,
+    });
+    const { result } = renderHook(() => useReconnectGDrive(), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    const opened = String(openSpy.mock.calls[0]?.[0] ?? '');
+    expect(opened).toMatch(/[?&]prompt=consent\b/);
+    expect(opened).not.toMatch(/[?&]prompt=none\b/);
   });
 });
 

--- a/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
+++ b/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
@@ -95,6 +95,29 @@ export function useConnectGDrive() {
 }
 
 /**
+ * Re-runs the Google OAuth consent flow with `prompt=consent` forced.
+ *
+ * Used as the `<DrivePicker onReconnect={…}>` handler when the picker's
+ * credentials request comes back `401 token-expired` — i.e. the stored
+ * refresh token was revoked at Google (user disconnected at Google's
+ * account settings, scope change forced a re-grant, the token expired
+ * after long inactivity, etc.). Without `prompt=consent` Google often
+ * silently re-grants without minting a fresh refresh token, leaving us
+ * stuck in the same 401 loop. Mirrors the mobile route's
+ * `reauthorizeDrive` which forces the same prompt for the same reason.
+ */
+export function useReconnectGDrive() {
+  return useMutation<void, Error, void>({
+    mutationFn: async () => {
+      const res = await apiClient.get<{ url: string }>('/integrations/gdrive/oauth/url');
+      const url = new URL(res.data.url);
+      url.searchParams.set('prompt', 'consent');
+      window.open(url.toString(), 'gdrive-oauth', POPUP_FEATURES);
+    },
+  });
+}
+
+/**
  * Bridge effect for the OAuth-callback popup landing page. The API
  * redirects the popup to `/settings/integrations?connected=1` after a
  * successful token exchange. This hook detects that landing and either:


### PR DESCRIPTION
## Bug
On the new-document / use-template flows, clicking "Pick from Google Drive" did nothing visible — `GET /integrations/gdrive/picker-credentials` returned **401** in DevTools, and the UI just collapsed back to the file-upload form.

## Root cause
`DrivePicker` already handles the 401 path correctly: it fires `onReconnect?.()` then `onClose()`. But **`UploadRoute.tsx`** and **`UseTemplatePage.tsx`** rendered `<DrivePicker>` **without an `onReconnect` prop**, so the optional chain was a no-op — the picker silently opened and closed. The 401 was the *correct* response (the user's stored refresh token had been revoked at Google's side), but the desktop routes didn't surface a "reconnect" prompt.

`MobileSendPage` already wired `onReconnect={reauthorizeDrive}` — that's why the bug only surfaced on desktop.

## Fix
- New **`useReconnectGDrive`** hook in `useGDriveAccounts.ts` — mirrors `useConnectGDrive` but **forces `prompt=consent`** on the OAuth URL so Google re-mints a fresh refresh token instead of silently re-granting the revoked one.
- `UploadRoute` + `UseTemplatePage` now pass `onReconnect={() => reconnectDrive.mutate()}` to `<DrivePicker>`. When picker-credentials hits 401, the OAuth popup opens immediately; on authorize success the popup-bridge `postMessage` (already in place) invalidates the accounts query, and a retry click on "Pick from Google Drive" works.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm --filter web lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — **1596/1596** (3 new regression tests)
  - `useReconnectGDrive`: opens the consent URL with `prompt=consent` forced
  - `useReconnectGDrive`: overrides any pre-existing `prompt` param (e.g. `prompt=none`)
  - `UploadRoute`: forwards the picker's `onReconnect` call onto the mutation
- [ ] Post-deploy: revoke the Drive token at Google (or wait for it to expire), click "Pick from Google Drive" on the new-document page — the OAuth popup should appear with the consent screen; after authorizing, the picker should open on the next click.

## Notes
- No backend changes — the 401 contract was already correct (`{ code: 'token-expired', message: 'reconnect_required' }`); only the desktop FE handling was missing.
- `UseTemplatePage.gdrive.test.tsx`, `UseTemplatePage.layout.test.tsx`, and `MWIntegrations.test.tsx` got the new hook added to their `vi.mock` module shapes so `useReconnectGDrive` resolves under test — pure mock-completeness, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)