### PR TITLE
fix: settings/integrations audit batch — mobile crash, reconnect-required UI, tokens

### DIFF
--- a/apps/api/src/integrations/gdrive/__tests__/gdrive.controller.spec.ts
+++ b/apps/api/src/integrations/gdrive/__tests__/gdrive.controller.spec.ts
@@ -283,6 +283,62 @@ describe('GDriveController', () => {
     expect(out[0]).not.toHaveProperty('refreshTokenKmsKeyArn');
   });
 
+  // Slice C audit finding #4 (HIGH): the listing endpoint must surface
+  // a `tokenStatus` flag so the SPA can render a "Reconnect required"
+  // badge + primary Reconnect button when the stored refresh token has
+  // been revoked. The service exposes a cheap in-memory read populated
+  // by the existing `getAccessToken` refresh path — no extra Google
+  // round-trip per page load.
+  it('GET /accounts surfaces tokenStatus: live for an account whose refresh has not (yet) failed', async () => {
+    const { ctrl, state } = makeController();
+    const started = state.start('user-1');
+    await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+    const out = await ctrl.listAccounts(USER_1);
+    expect(out[0]?.tokenStatus).toBe('live');
+  });
+
+  it('GET /accounts surfaces tokenStatus: reconnect_required after a refresh call returned invalid_grant', async () => {
+    const { ctrl, state, google } = makeController();
+    const started = state.start('user-1');
+    await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+    const [acc] = await ctrl.listAccounts(USER_1);
+    if (!acc) throw new Error('no acc');
+    // Simulate Google revoking the refresh token at some later point.
+    google.refreshAccessToken = async (): Promise<never> => {
+      const err = new Error('invalid_grant: refresh token revoked') as Error & {
+        code?: string;
+      };
+      err.code = 'invalid_grant';
+      throw err;
+    };
+    // Trigger the refresh path so the service marks the account
+    // revoked (this is what /files or /picker-credentials would do in
+    // prod when Google declines a refresh).
+    await expect(ctrl.pickerCredentials(USER_1, acc.id)).rejects.toMatchObject({ status: 401 });
+    const after = await ctrl.listAccounts(USER_1);
+    expect(after[0]?.tokenStatus).toBe('reconnect_required');
+  });
+
+  it('GET /accounts flips tokenStatus back to live after the user reconnects', async () => {
+    const { ctrl, state, google } = makeController();
+    const started = state.start('user-1');
+    await ctrl.oauthCallback('the-code', started.state, undefined, fakeRes());
+    const [acc] = await ctrl.listAccounts(USER_1);
+    if (!acc) throw new Error('no acc');
+    google.refreshAccessToken = async (): Promise<never> => {
+      const err = new Error('invalid_grant') as Error & { code?: string };
+      err.code = 'invalid_grant';
+      throw err;
+    };
+    await expect(ctrl.pickerCredentials(USER_1, acc.id)).rejects.toMatchObject({ status: 401 });
+    expect((await ctrl.listAccounts(USER_1))[0]?.tokenStatus).toBe('reconnect_required');
+
+    // User reconnects via the OAuth flow — this should clear the marker.
+    const started2 = state.start('user-1');
+    await ctrl.oauthCallback('new-code', started2.state, undefined, fakeRes());
+    expect((await ctrl.listAccounts(USER_1))[0]?.tokenStatus).toBe('live');
+  });
+
   it('DELETE /accounts/:id soft-deletes the row', async () => {
     const { ctrl, state, repo } = makeController();
     const started = state.start('user-1');

--- a/apps/api/src/integrations/gdrive/dto/account.dto.ts
+++ b/apps/api/src/integrations/gdrive/dto/account.dto.ts
@@ -9,4 +9,15 @@ export interface GDriveAccountView {
   readonly email: string;
   readonly connectedAt: string;
   readonly lastUsedAt: string | null;
+  /**
+   * Health of the stored refresh token. `live` means the most recent
+   * refresh attempt succeeded (or the account is fresh and we have no
+   * negative signal yet); `reconnect_required` means we observed an
+   * `invalid_grant` from Google and the SPA must surface a primary
+   * Reconnect button instead of letting the user keep clicking through
+   * to a broken Drive picker. Audit slice C #4 (HIGH).
+   */
+  readonly tokenStatus: GDriveTokenStatus;
 }
+
+export type GDriveTokenStatus = 'live' | 'reconnect_required';

--- a/apps/api/src/integrations/gdrive/gdrive.controller.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.controller.ts
@@ -246,15 +246,19 @@ export class GDriveController {
   @Get('accounts')
   async listAccounts(@CurrentUser() user: AuthUser): Promise<ReadonlyArray<GDriveAccountView>> {
     this.requireFlag();
-    const rows = await this.svc.listAccounts(user.id);
-    return rows
-      .filter((r) => !r.deletedAt)
-      .map((r) => ({
-        id: r.id,
-        email: r.googleEmail,
-        connectedAt: r.connectedAt,
-        lastUsedAt: r.lastUsedAt,
-      }));
+    const rows = (await this.svc.listAccounts(user.id)).filter((r) => !r.deletedAt);
+    // `tokenStatus` is a CHEAP in-memory read of the most recent refresh
+    // outcome (no extra Google round-trip per page load). The flag goes
+    // hot when `getAccessToken` (called by /files, /picker-credentials,
+    // the export service) trips `invalid_grant` and clears on the next
+    // successful refresh or `completeOAuth`. Audit slice C #4 (HIGH).
+    return rows.map((r) => ({
+      id: r.id,
+      email: r.googleEmail,
+      connectedAt: r.connectedAt,
+      lastUsedAt: r.lastUsedAt,
+      tokenStatus: this.svc.getTokenStatus(r.id),
+    }));
   }
 
   @Delete('accounts/:id')

--- a/apps/api/src/integrations/gdrive/gdrive.service.ts
+++ b/apps/api/src/integrations/gdrive/gdrive.service.ts
@@ -3,6 +3,7 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { GDriveKmsService } from './gdrive-kms.service';
 import { GDRIVE_REPOSITORY, type GDriveAccount, type GDriveRepository } from './gdrive.repository';
 import { TokenExpiredError } from './dto/error-codes';
+import type { GDriveTokenStatus } from './dto/account.dto';
 
 /**
  * Adapter over the Google OAuth + token-refresh endpoints. Kept behind a
@@ -46,6 +47,16 @@ interface CachedToken {
 export class GDriveService {
   private readonly cache = new Map<string, CachedToken>();
   private readonly inflight = new Map<string, Promise<CachedToken>>();
+  /**
+   * Tracks accounts whose most recent refresh attempt returned
+   * `invalid_grant` (revoked / expired refresh token). Populated by
+   * `refreshToken` (the only call site that contacts Google's `/token`
+   * endpoint) and consumed by `getTokenStatus`. Audit slice C #4 (HIGH):
+   * the listing endpoint reads this map so the SPA can surface a
+   * primary Reconnect button without us paying for an extra round-trip
+   * to Google on every page load.
+   */
+  private readonly revoked = new Set<string>();
 
   constructor(
     @Inject(GDRIVE_REPOSITORY) private readonly repo: GDriveRepository,
@@ -85,14 +96,51 @@ export class GDriveService {
     );
     try {
       const out = await this.google.refreshAccessToken(refreshToken, signal);
+      // Recovery: a successful refresh clears any prior revoked-state
+      // signal — e.g. the user just reconnected at Google and the new
+      // refresh token is live again. Without this, a one-time
+      // invalid_grant would stick the row in "reconnect_required" until
+      // the api restarted.
+      this.revoked.delete(account.id);
       await this.repo.touchLastUsed(account.id);
       return out;
     } catch (err) {
       if (isInvalidGrant(err)) {
+        this.revoked.add(account.id);
         throw new TokenExpiredError('refresh_token_invalid_or_revoked');
       }
       throw err;
     }
+  }
+
+  /**
+   * Synchronous read of an account's token health. Returns
+   * `'reconnect_required'` when the most recent refresh attempt (if any)
+   * rejected with `invalid_grant`; `'live'` otherwise. Cheap by design —
+   * the listing endpoint surfaces this without paying for an extra
+   * Google round-trip on every page load. Audit slice C #4 (HIGH).
+   */
+  getTokenStatus(accountId: string): GDriveTokenStatus {
+    return this.revoked.has(accountId) ? 'reconnect_required' : 'live';
+  }
+
+  /**
+   * Best-effort probe: triggers one refreshAccessToken() call for the
+   * given account so `getTokenStatus` can report a fresh signal. Swallows
+   * non-`invalid_grant` failures — the probe must never propagate a
+   * transient upstream blip up the listing call (audit slice C #4).
+   * Used only by callers that explicitly want an *up-to-date* status
+   * (e.g. integration tests). The listing endpoint relies on the cheap
+   * `getTokenStatus` read instead.
+   */
+  async probeRefresh(account: GDriveAccount): Promise<GDriveTokenStatus> {
+    try {
+      await this.refreshToken(account);
+    } catch {
+      // refreshToken already populated `revoked` on invalid_grant;
+      // non-invalid_grant errors leave the prior status unchanged.
+    }
+    return this.getTokenStatus(account.id);
   }
 
   async listAccounts(userId: string): Promise<ReadonlyArray<GDriveAccount>> {
@@ -133,6 +181,10 @@ export class GDriveService {
       // Drop any cached access token tied to the old refresh token so the
       // next getAccessToken() pulls a fresh one.
       this.cache.delete(existing.id);
+      // A new refresh token was just minted — clear any prior
+      // reconnect-required marker so the SPA flips back to the green
+      // Connected state without waiting for an explicit refresh call.
+      this.revoked.delete(existing.id);
       return existing.id;
     }
     const id = newUuid();
@@ -163,6 +215,7 @@ export class GDriveService {
     await this.google.revokeToken(refreshToken).catch(() => undefined);
     await this.repo.softDelete(accountId, userId);
     this.cache.delete(accountId);
+    this.revoked.delete(accountId);
   }
 
   private async requireOwnedAccount(id: string, userId: string): Promise<GDriveAccount> {

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -1,5 +1,5 @@
 import { Suspense, lazy } from 'react';
-import { Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { AppShell } from './layout/AppShell';
 import { AuthLoadingScreen } from './layout/AuthLoadingScreen';
 import { RequireAuth } from './layout/RequireAuth';
@@ -231,6 +231,13 @@ export function AppRoutes() {
               </Suspense>
             }
           />
+          {/* Stub Settings index — until a real Settings landing
+              page lands, `/settings` redirects to the only settings
+              surface that exists (Integrations). Audit slice C #4
+              (MEDIUM): the Integrations breadcrumb now points back to
+              `/settings`, so this route MUST exist for the link to
+              navigate anywhere useful. */}
+          <Route path="/settings" element={<Navigate to="/settings/integrations" replace />} />
           <Route
             path="/settings/integrations"
             element={

--- a/apps/web/src/routes/settings/integrations/DisconnectModal.tsx
+++ b/apps/web/src/routes/settings/integrations/DisconnectModal.tsx
@@ -27,7 +27,11 @@ const FOCUSABLE_SELECTOR =
 const Backdrop = styled.div`
   position: fixed;
   inset: 0;
-  background: rgba(15, 23, 42, 0.45);
+  /* Audit slice C #6 (MEDIUM): pulled from inline rgba(15,23,42,0.45)
+     to the shared theme.color.overlay token (driven by --overlay in
+     globalStyles + tokens.css) so every future overlay shares the same
+     scrim treatment. */
+  background: ${({ theme }) => theme.color.overlay};
   z-index: ${({ theme }) => theme.z.modal};
   display: flex;
   align-items: center;

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.stories.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.stories.tsx
@@ -85,6 +85,22 @@ export const ConnectedMultiAccount: Story = {
   ),
 };
 
+// Audit slice C #4 (HIGH): visual surface for the expired-token row —
+// primary Reconnect button + amber "Reconnect required" badge + card
+// header pill flips from emerald to amber.
+const SEED_RECONNECT: GDriveAccount = {
+  ...SEED_ONE,
+  tokenStatus: 'reconnect_required',
+};
+export const ConnectedReconnectRequired: Story = {
+  name: 'Connected — token expired (Reconnect required)',
+  render: () => (
+    <Wrap accounts={[SEED_RECONNECT]}>
+      <IntegrationsPage />
+    </Wrap>
+  ),
+};
+
 // Standalone story for the modal so the destructive state can be diffed
 // in Chromatic without driving the full page through a click.
 export const DisconnectModalOpen: StoryObj<typeof DisconnectModal> = {

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.test.tsx
@@ -385,4 +385,112 @@ describe('IntegrationsPage', () => {
     // Dialog closes after the mutation resolves.
     await waitFor(() => expect(dialog).not.toBeInTheDocument());
   });
+
+  // ────────────────────────────────────────────────────────────────────
+  // Slice C audit findings — added 2026-05-14
+  // ────────────────────────────────────────────────────────────────────
+
+  // Issue #7 (LOW): CardTitle must render as <h2> so screen readers get
+  // landmark structure. Pre-fix it was a <div> styled like a heading.
+  it('renders the Google Drive card title as a level-2 heading (a11y landmark)', async () => {
+    mockedGet.mockResolvedValueOnce({ data: [], status: 200 });
+    renderPage();
+    expect(
+      await screen.findByRole('heading', { level: 2, name: /google drive/i }),
+    ).toBeInTheDocument();
+  });
+
+  // Issue #4 (MEDIUM): the "Settings" breadcrumb crumb was a <span>; must
+  // be a real link back to /settings so users can return to a settings
+  // index. The /settings stub redirects to /settings/integrations until
+  // the proper index lands.
+  it('renders the Settings breadcrumb as a real link to /settings', async () => {
+    mockedGet.mockResolvedValueOnce({ data: [], status: 200 });
+    renderPage();
+    const link = await screen.findByRole('link', { name: /^settings$/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
+  // Issue #2 (HIGH): expired tokens must surface a Reconnect required
+  // badge + primary Reconnect button instead of the green "Connected"
+  // chip. Pre-fix the row rendered identically regardless of token
+  // health, hiding the reconnect path behind a download-only error.
+  it('renders a Reconnect required badge + primary Reconnect button when tokenStatus is reconnect_required', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'acc-1',
+          email: 'eliran@example.com',
+          connectedAt: '2026-05-03T10:00:00Z',
+          lastUsedAt: '2026-05-03T11:00:00Z',
+          tokenStatus: 'reconnect_required',
+        },
+      ],
+      status: 200,
+    });
+    renderPage();
+    // The badge surfaces twice — once on the card header (so an admin
+    // scanning the integrations stack sees the warning) and once at
+    // the row level for multi-account installs. Both must be present.
+    const badges = await screen.findAllByText(/^reconnect required$/i);
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+    expect(
+      screen.getByRole('button', { name: /^reconnect eliran@example\.com$/i }),
+    ).toBeInTheDocument();
+    // The green "Connected" status pill must NOT show alongside it.
+    expect(screen.queryByText(/^connected$/i)).toBeNull();
+  });
+
+  it('clicking Reconnect opens the consent URL with prompt=consent forced', async () => {
+    mockedGet.mockImplementation((url: string) => {
+      if (url === '/integrations/gdrive/accounts') {
+        return Promise.resolve({
+          data: [
+            {
+              id: 'acc-1',
+              email: 'eliran@example.com',
+              connectedAt: '2026-05-03T10:00:00Z',
+              lastUsedAt: null,
+              tokenStatus: 'reconnect_required',
+            },
+          ],
+          status: 200,
+        });
+      }
+      if (url === '/integrations/gdrive/oauth/url') {
+        return Promise.resolve({
+          data: { url: 'https://accounts.google.com/o/oauth2/v2/auth?fake=1' },
+          status: 200,
+        });
+      }
+      return Promise.resolve({ data: {}, status: 200 });
+    });
+    renderPage();
+    const reconnect = await screen.findByRole('button', {
+      name: /^reconnect eliran@example\.com$/i,
+    });
+    await userEvent.click(reconnect);
+    await waitFor(() => {
+      const opened = String(openSpy.mock.calls[0]?.[0] ?? '');
+      expect(opened).toMatch(/[?&]prompt=consent\b/);
+    });
+  });
+
+  // Issue #5 (MEDIUM): on narrow widths the "What we ask for" permissions
+  // block must appear ABOVE the CTA button in the DOM, not beside/below.
+  // Pre-fix the grid kept the CTA in column 1 and permissions in column 2
+  // even at narrow widths, so on narrow column widths the left text became
+  // unreadably narrow.
+  it('places the permissions block ABOVE the connect CTA in the DOM (so narrow viewports stack correctly)', async () => {
+    mockedGet.mockResolvedValueOnce({ data: [], status: 200 });
+    renderPage();
+    const ctaButton = await screen.findByRole('button', { name: /connect google drive/i });
+    const permissionsHeading = screen.getByText(/what we ask for/i);
+    // Check DOM order: permissionsHeading must precede the CTA button.
+    const ctaPos = ctaButton.compareDocumentPosition(permissionsHeading);
+    // Node.DOCUMENT_POSITION_PRECEDING === 2; we want permissions to PRECEDE ctaButton.
+    // eslint-disable-next-line no-bitwise
+    expect(ctaPos & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy();
+  });
 });

--- a/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
+++ b/apps/web/src/routes/settings/integrations/IntegrationsPage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Link, Navigate, useSearchParams } from 'react-router-dom';
 import {
   Link as LinkIcon,
   ChevronRight,
@@ -18,10 +18,12 @@ import { Badge } from '@/components/Badge';
 import { Button } from '@/components/Button';
 import { Card } from '@/components/Card';
 import { Icon } from '@/components/Icon';
+import { readIsMobileViewport } from '@/hooks/useIsMobileViewport';
 import {
   useGDriveAccounts,
   useConnectGDrive,
   useDisconnectGDrive,
+  useReconnectGDrive,
   useGDriveOAuthCallbackBridge,
   useGDriveOAuthMessageListener,
   type GDriveAccount,
@@ -36,15 +38,31 @@ const Page = styled.div`
   width: 100%;
   max-width: 960px;
   margin: 0 auto;
-  padding: 24px 32px 80px;
+  padding: ${({ theme }) => `${theme.space[6]} ${theme.space[8]} ${theme.space[20]}`};
 `;
 
 const BreadcrumbNav = styled.nav`
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: ${({ theme }) => theme.space[2]};
   font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[3]};
+`;
+
+const BreadcrumbLink = styled(Link)`
+  color: ${({ theme }) => theme.color.fg[3]};
+  text-decoration: none;
+  border-radius: ${({ theme }) => theme.radius.xs};
+
+  &:hover {
+    color: ${({ theme }) => theme.color.fg[1]};
+    text-decoration: underline;
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.color.indigo[500]};
+    outline-offset: 2px;
+  }
 `;
 
 const BreadcrumbCurrent = styled.span`
@@ -53,7 +71,7 @@ const BreadcrumbCurrent = styled.span`
 `;
 
 const Hero = styled.header`
-  margin: 14px 0 28px;
+  margin: ${({ theme }) => `${theme.space[4]} 0 ${theme.space[8]}`};
 `;
 
 const Title = styled.h1`
@@ -67,7 +85,7 @@ const Title = styled.h1`
 `;
 
 const Subtitle = styled.p`
-  margin: 8px 0 0;
+  margin: ${({ theme }) => `${theme.space[2]} 0 0`};
   font-size: ${({ theme }) => theme.font.size.body};
   color: ${({ theme }) => theme.color.fg[3]};
   line-height: ${({ theme }) => theme.font.lineHeight.relaxed};
@@ -81,7 +99,7 @@ const CardStack = styled.div`
 `;
 
 const CardHeader = styled.div`
-  padding: 20px 24px;
+  padding: ${({ theme }) => `${theme.space[5]} ${theme.space[6]}`};
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.space[3]};
@@ -89,17 +107,23 @@ const CardHeader = styled.div`
 `;
 
 const CardBody = styled.div`
-  padding: 20px 24px;
+  padding: ${({ theme }) => `${theme.space[5]} ${theme.space[6]}`};
 `;
 
-const CardTitle = styled.div`
-  font-size: 16px;
+/**
+ * Visual card title. Rendered as `<h2>` so screen readers pick it up as
+ * a landmark (audit slice C #7 — LOW). Styled identically to the prior
+ * `<div>` so the visual treatment is unchanged.
+ */
+const CardTitle = styled.h2`
+  margin: 0;
+  font-size: ${({ theme }) => theme.font.size.body};
   font-weight: ${({ theme }) => theme.font.weight.semibold};
   color: ${({ theme }) => theme.color.fg[1]};
 `;
 
 const CardSubtitle = styled.div`
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[3]};
   margin-top: 2px;
 `;
@@ -109,27 +133,50 @@ const CardHeaderText = styled.div`
   min-width: 0;
 `;
 
+/**
+ * Empty-state grid. Audit slice C #5 (MEDIUM):
+ *  - Breakpoint bumped 720 → 880 px so the "What we ask for" column
+ *    doesn't get cramped at 720–960 px.
+ *  - Gap → `theme.space[8]`.
+ *  - At narrow widths the permissions block is placed ABOVE the CTA
+ *    via grid-template-areas: the permissions column moves to row 1 and
+ *    the CTA stack drops to row 2. This is purely a DOM/order change
+ *    (no flex-direction: column-reverse hack) so a11y/reading order
+ *    stays consistent for screen readers at every width.
+ */
 const EmptyGrid = styled.div`
   display: grid;
   grid-template-columns: 1fr 280px;
-  gap: 32px;
+  grid-template-areas: 'cta perms';
+  gap: ${({ theme }) => theme.space[8]};
   align-items: flex-start;
 
-  @media (max-width: 720px) {
+  @media (max-width: 880px) {
     grid-template-columns: 1fr;
+    grid-template-areas:
+      'perms'
+      'cta';
   }
 `;
 
+const EmptyGridCta = styled.div`
+  grid-area: cta;
+`;
+
+const EmptyGridPerms = styled.div`
+  grid-area: perms;
+`;
+
 const EmptyCopy = styled.div`
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[3]};
-  margin-bottom: 14px;
+  margin-bottom: ${({ theme }) => theme.space[4]};
 `;
 
 const ConnectHint = styled.div`
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.font.size.micro};
   color: ${({ theme }) => theme.color.fg[4]};
-  margin-top: 10px;
+  margin-top: ${({ theme }) => theme.space[2]};
 `;
 
 const Eyebrow = styled.div`
@@ -139,7 +186,7 @@ const Eyebrow = styled.div`
   letter-spacing: ${({ theme }) => theme.font.tracking.wider};
   text-transform: uppercase;
   color: ${({ theme }) => theme.color.fg[3]};
-  margin-bottom: 12px;
+  margin-bottom: ${({ theme }) => theme.space[3]};
 `;
 
 const PermissionUl = styled.ul`
@@ -148,14 +195,14 @@ const PermissionUl = styled.ul`
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: ${({ theme }) => theme.space[2]};
 `;
 
 const PermissionLi = styled.li`
   display: flex;
   align-items: flex-start;
-  gap: 10px;
-  font-size: 13px;
+  gap: ${({ theme }) => theme.space[2]};
+  font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[2]};
   line-height: ${({ theme }) => theme.font.lineHeight.normal};
 `;
@@ -163,7 +210,7 @@ const PermissionLi = styled.li`
 const PermissionIconWrap = styled.span`
   width: 24px;
   height: 24px;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.radius.sm};
   background: ${({ theme }) => theme.color.ink[100]};
   color: ${({ theme }) => theme.color.fg[3]};
   display: inline-flex;
@@ -176,7 +223,7 @@ const AccountRow = styled.div`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.space[3]};
-  padding: 14px 16px;
+  padding: ${({ theme }) => `${theme.space[3]} ${theme.space[4]}`};
   border: 1px solid ${({ theme }) => theme.color.border[1]};
   border-radius: ${({ theme }) => theme.radius.md};
   background: ${({ theme }) => theme.color.bg.sunken};
@@ -188,13 +235,22 @@ const AccountMeta = styled.div`
 `;
 
 const AccountEmail = styled.div`
-  font-size: 14px;
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[2]};
+  font-size: ${({ theme }) => theme.font.size.bodySm};
   font-weight: ${({ theme }) => theme.font.weight.semibold};
   color: ${({ theme }) => theme.color.fg[1]};
 `;
 
+const AccountActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${({ theme }) => theme.space[2]};
+`;
+
 const AccountSub = styled.div`
-  font-size: 12px;
+  font-size: ${({ theme }) => theme.font.size.micro};
   color: ${({ theme }) => theme.color.fg[3]};
   margin-top: 2px;
 `;
@@ -203,25 +259,25 @@ const MultiAccountRow = styled.div`
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.space[2]};
-  margin-top: 14px;
-  font-size: 12px;
+  margin-top: ${({ theme }) => theme.space[4]};
+  font-size: ${({ theme }) => theme.font.size.micro};
   color: ${({ theme }) => theme.color.fg[4]};
 `;
 
 const ComingSoonChip = styled.span`
-  margin-left: 4px;
-  padding: 2px 8px;
-  border-radius: 999px;
+  margin-left: ${({ theme }) => theme.space[1]};
+  padding: ${({ theme }) => `2px ${theme.space[2]}`};
+  border-radius: ${({ theme }) => theme.radius.pill};
   background: ${({ theme }) => theme.color.ink[100]};
   color: ${({ theme }) => theme.color.fg[3]};
-  font-size: 10px;
+  font-size: ${({ theme }) => theme.font.size.micro};
   font-weight: ${({ theme }) => theme.font.weight.semibold};
   letter-spacing: ${({ theme }) => theme.font.tracking.wide};
   text-transform: uppercase;
 `;
 
 const ComingSoonHeader = styled.div`
-  padding: 20px 24px;
+  padding: ${({ theme }) => `${theme.space[5]} ${theme.space[6]}`};
   display: flex;
   align-items: center;
   gap: ${({ theme }) => theme.space[3]};
@@ -231,9 +287,9 @@ const ComingSoonHeader = styled.div`
 const ConfigAlert = styled.div`
   display: flex;
   align-items: flex-start;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding: 14px 16px;
+  gap: ${({ theme }) => theme.space[3]};
+  margin-bottom: ${({ theme }) => theme.space[4]};
+  padding: ${({ theme }) => `${theme.space[3]} ${theme.space[4]}`};
   border: 1px solid ${({ theme }) => theme.color.border[1]};
   border-radius: ${({ theme }) => theme.radius.md};
   background: ${({ theme }) => theme.color.bg.sunken};
@@ -242,7 +298,7 @@ const ConfigAlert = styled.div`
 const ConfigAlertIconWrap = styled.span`
   width: 28px;
   height: 28px;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.radius.sm};
   background: ${({ theme }) => theme.color.ink[100]};
   color: ${({ theme }) => theme.color.fg[2]};
   display: inline-flex;
@@ -253,7 +309,7 @@ const ConfigAlertIconWrap = styled.span`
 
 const ConfigAlertCopy = styled.div`
   flex: 1;
-  font-size: 13px;
+  font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[2]};
   line-height: ${({ theme }) => theme.font.lineHeight.normal};
 `;
@@ -261,7 +317,7 @@ const ConfigAlertCopy = styled.div`
 const ConfigAlertDismiss = styled.button`
   border: 0;
   background: transparent;
-  padding: 4px;
+  padding: ${({ theme }) => theme.space[1]};
   border-radius: ${({ theme }) => theme.radius.sm};
   color: ${({ theme }) => theme.color.fg[3]};
   cursor: pointer;
@@ -290,7 +346,7 @@ const ConfigAlertTitle = styled.div`
 const ComingSoonIconWrap = styled.div`
   width: 32px;
   height: 32px;
-  border-radius: 8px;
+  border-radius: ${({ theme }) => theme.radius.sm};
   background: ${({ theme }) => theme.color.ink[100]};
   display: inline-flex;
   align-items: center;
@@ -330,6 +386,10 @@ const PERMISSIONS = [
   { icon: XCircle, text: 'Revoke access any time — disconnecting deletes the tokens.' },
 ] as const;
 
+const PermissionText = styled.span`
+  padding-top: 3px;
+`;
+
 function PermissionList() {
   return (
     <PermissionUl>
@@ -338,7 +398,7 @@ function PermissionList() {
           <PermissionIconWrap>
             <Icon icon={p.icon} size={13} />
           </PermissionIconWrap>
-          <span style={{ paddingTop: 3 }}>{p.text}</span>
+          <PermissionText>{p.text}</PermissionText>
         </PermissionLi>
       ))}
     </PermissionUl>
@@ -381,13 +441,40 @@ function ComingSoonCard({ name, description }: ComingSoonCardProps) {
 interface GDriveCardProps {
   readonly accounts: ReadonlyArray<GDriveAccount>;
   readonly onConnect: () => void;
+  readonly onReconnect: () => void;
   readonly onDisconnect: (account: GDriveAccount) => void;
   readonly connecting: boolean;
+  readonly reconnecting: boolean;
 }
 
-function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCardProps) {
+/**
+ * Health summary shown next to the card title. If any connected
+ * account's token is in `reconnect_required`, the whole card surfaces a
+ * warning badge — at the row level we surface a per-email badge too so
+ * multi-account installs (`gdriveMultiAccount` feature flag) make it
+ * obvious which account needs attention. Audit slice C #4 (HIGH).
+ */
+function deriveCardBadge(accounts: ReadonlyArray<GDriveAccount>): {
+  readonly tone: 'emerald' | 'amber';
+  readonly label: string;
+} | null {
+  if (accounts.length === 0) return null;
+  const anyExpired = accounts.some((a) => a.tokenStatus === 'reconnect_required');
+  if (anyExpired) return { tone: 'amber', label: 'Reconnect required' };
+  return { tone: 'emerald', label: 'Connected' };
+}
+
+function GDriveCard({
+  accounts,
+  onConnect,
+  onReconnect,
+  onDisconnect,
+  connecting,
+  reconnecting,
+}: GDriveCardProps) {
   const isConnected = accounts.length > 0;
   const showMultiAccount = isFeatureEnabled('gdriveMultiAccount');
+  const cardBadge = deriveCardBadge(accounts);
   return (
     <Card padding={1} style={{ overflow: 'hidden', padding: 0 }}>
       <CardHeader>
@@ -399,31 +486,63 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
             template.
           </CardSubtitle>
         </CardHeaderText>
-        {isConnected ? <Badge tone="emerald">Connected</Badge> : null}
+        {cardBadge ? <Badge tone={cardBadge.tone}>{cardBadge.label}</Badge> : null}
       </CardHeader>
       <CardBody>
         {isConnected ? (
           <>
-            {accounts.map((account) => (
-              <AccountRow key={account.id}>
-                <Avatar name={account.email} size={40} />
-                <AccountMeta>
-                  <AccountEmail>{account.email}</AccountEmail>
-                  <AccountSub>
-                    Connected {formatDate(account.connectedAt)} · Last used{' '}
-                    {formatDate(account.lastUsedAt)}
-                  </AccountSub>
-                </AccountMeta>
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => onDisconnect(account)}
-                  aria-label={`Disconnect ${account.email}`}
-                >
-                  Disconnect
-                </Button>
-              </AccountRow>
-            ))}
+            {accounts.map((account) => {
+              const needsReconnect = account.tokenStatus === 'reconnect_required';
+              return (
+                <AccountRow key={account.id}>
+                  <Avatar name={account.email} size={40} />
+                  <AccountMeta>
+                    <AccountEmail>
+                      {account.email}
+                      {needsReconnect ? <Badge tone="amber">Reconnect required</Badge> : null}
+                    </AccountEmail>
+                    <AccountSub>
+                      Connected {formatDate(account.connectedAt)} · Last used{' '}
+                      {formatDate(account.lastUsedAt)}
+                    </AccountSub>
+                  </AccountMeta>
+                  <AccountActions>
+                    {needsReconnect ? (
+                      <>
+                        <Button
+                          variant="primary"
+                          size="sm"
+                          iconLeft={LinkIcon}
+                          onClick={onReconnect}
+                          loading={reconnecting}
+                          disabled={reconnecting}
+                          aria-label={`Reconnect ${account.email}`}
+                        >
+                          Reconnect
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onDisconnect(account)}
+                          aria-label={`Disconnect ${account.email}`}
+                        >
+                          Disconnect
+                        </Button>
+                      </>
+                    ) : (
+                      <Button
+                        variant="danger"
+                        size="sm"
+                        onClick={() => onDisconnect(account)}
+                        aria-label={`Disconnect ${account.email}`}
+                      >
+                        Disconnect
+                      </Button>
+                    )}
+                  </AccountActions>
+                </AccountRow>
+              );
+            })}
             {showMultiAccount ? (
               <MultiAccountRow>
                 <Button variant="ghost" size="sm" iconLeft={LinkIcon} onClick={onConnect}>
@@ -439,7 +558,11 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
           </>
         ) : (
           <EmptyGrid>
-            <div>
+            <EmptyGridPerms>
+              <Eyebrow>What we ask for</Eyebrow>
+              <PermissionList />
+            </EmptyGridPerms>
+            <EmptyGridCta>
               <EmptyCopy>No accounts connected.</EmptyCopy>
               <Button
                 variant="primary"
@@ -453,11 +576,7 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
               <ConnectHint>
                 Opens Google&apos;s sign-in window. You&apos;ll choose what to share.
               </ConnectHint>
-            </div>
-            <div>
-              <Eyebrow>What we ask for</Eyebrow>
-              <PermissionList />
-            </div>
+            </EmptyGridCta>
           </EmptyGrid>
         )}
       </CardBody>
@@ -471,13 +590,18 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
 
 /**
  * L4 page — `/settings/integrations`. Standalone surface (no left rail
- * — Phase 3 watchpoint #5): a `<Breadcrumb>` carries the user back to a
- * future Settings index, and the Integrations index itself is just a
- * stack of provider cards (Drive, then two coming-soon stubs).
+ * — Phase 3 watchpoint #5): a `<Breadcrumb>` carries the user back to
+ * the Settings index, and the Integrations index itself is just a stack
+ * of provider cards (Drive, then two coming-soon stubs).
  *
  * The mobile-redirect rule lives in `AppShell` — every route mounted
- * under it bounces to `/m/send` on viewports ≤ 640 px. A regression
- * test in `mobile-redirect.test.tsx` pins that contract for this route.
+ * under it bounces to `/m/send` on viewports ≤ 640 px. As a defence-
+ * in-depth fix for audit slice C #1 (HIGH) — the deployed mobile build
+ * was observed surfacing the ErrorBoundary fallback BEFORE AppShell's
+ * guard fired — the wrapper component below also short-circuits the
+ * hook chain via `readIsMobileViewport()` so any future hook-chain
+ * regression in `IntegrationsPageInner` cannot crash on a 390 px
+ * viewport. Pinned by `mobile-render.test.tsx`.
  *
  * The page is rendered behind `feature.gdriveIntegration` at the
  * router level — when the flag is OFF, the API also 404s every
@@ -486,6 +610,13 @@ function GDriveCard({ accounts, onConnect, onDisconnect, connecting }: GDriveCar
  * page still renders cleanly in dev when the flag is off.
  */
 export function IntegrationsPage() {
+  if (readIsMobileViewport()) {
+    return <Navigate to="/m/send" replace />;
+  }
+  return <IntegrationsPageInner />;
+}
+
+function IntegrationsPageInner() {
   const [searchParams] = useSearchParams();
   const isCallbackReturn = searchParams.has('connected');
 
@@ -506,6 +637,7 @@ export function IntegrationsPage() {
 
   const accountsQuery = useGDriveAccounts();
   const connect = useConnectGDrive();
+  const reconnect = useReconnectGDrive();
   const disconnect = useDisconnectGDrive();
 
   const [pendingDisconnect, setPendingDisconnect] = useState<GDriveAccount | null>(null);
@@ -513,6 +645,10 @@ export function IntegrationsPage() {
   const handleConnect = useCallback((): void => {
     connect.mutate();
   }, [connect]);
+
+  const handleReconnect = useCallback((): void => {
+    reconnect.mutate();
+  }, [reconnect]);
 
   const dismissConfigAlert = useCallback((): void => {
     // Reset the connect mutation so its `error` clears + the alert
@@ -569,7 +705,7 @@ export function IntegrationsPage() {
   return (
     <Page>
       <BreadcrumbNav aria-label="Breadcrumb">
-        <span>Settings</span>
+        <BreadcrumbLink to="/settings">Settings</BreadcrumbLink>
         <Icon icon={ChevronRight} size={12} />
         <BreadcrumbCurrent aria-current="page">Integrations</BreadcrumbCurrent>
       </BreadcrumbNav>
@@ -609,8 +745,10 @@ export function IntegrationsPage() {
         <GDriveCard
           accounts={accounts}
           onConnect={handleConnect}
+          onReconnect={handleReconnect}
           onDisconnect={openDisconnect}
           connecting={connect.isPending}
+          reconnecting={reconnect.isPending}
         />
         <ComingSoonCard
           name="Dropbox"

--- a/apps/web/src/routes/settings/integrations/mobile-render.test.tsx
+++ b/apps/web/src/routes/settings/integrations/mobile-render.test.tsx
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { renderWithProviders } from '../../../test/renderWithProviders';
+import { AppShell } from '../../../layout/AppShell';
+import { IntegrationsPage } from './IntegrationsPage';
+
+// Slice C audit finding #1 (HIGH): the deployed mobile build shows the
+// ErrorBoundary fallback ("Something went wrong") on /settings/integrations
+// instead of redirecting to /m/send. The existing mobile-redirect test
+// uses a stub <h1>, so it never exercises the real IntegrationsPage
+// chunk. This regression test mounts the REAL IntegrationsPage inside the
+// real <AppShell /> at viewport 390 px and asserts:
+//   (a) the page never crashes the ErrorBoundary on the very first
+//       render of the mobile chunk, and
+//   (b) the AppShell redirect lands the user on /m/send rather than
+//       leaving them parked on the desktop IntegrationsPage chrome.
+//
+// We use the REAL useIsMobileViewport hook (no vi.mock layer) so the
+// test reproduces the same first-render-before-effect timing the audit
+// caught in production — matchMedia is stubbed at the window level so
+// we control the breakpoint.
+
+vi.mock('@/features/account', () => ({
+  useAccountActions: () => ({
+    exportData: vi.fn(),
+    deleteAccount: vi.fn(),
+    isExporting: false,
+    isDeleting: false,
+  }),
+}));
+
+vi.mock('../../../lib/api/apiClient', () => ({
+  apiClient: {
+    get: vi.fn().mockResolvedValue({ data: [], status: 200 }),
+    delete: vi.fn(),
+  },
+}));
+
+vi.mock('../../../lib/observability', () => ({
+  reportError: vi.fn(),
+  initSentry: vi.fn(),
+}));
+
+function installMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn().mockReturnValue(false),
+    })),
+  });
+}
+
+let consoleSpy: ReturnType<typeof vi.spyOn>;
+beforeEach(() => {
+  // Suppress React's error log when an error boundary catches — without
+  // this, the test stack trace gets buried in noise.
+  consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleSpy.mockRestore();
+});
+
+function renderAt(path: string) {
+  return renderWithProviders(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route element={<AppShell />}>
+          {/* Mount the real IntegrationsPage (not a stub) so its hooks,
+              suspense + lazy scaffolding all run end-to-end. */}
+          <Route path="/settings/integrations" element={<IntegrationsPage />} />
+        </Route>
+        <Route path="/m/send" element={<h1>mobile sender</h1>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe('IntegrationsPage mobile render (audit slice C #1 — HIGH)', () => {
+  it('lands on /m/send (NOT the ErrorBoundary fallback) when mounted at 390 px', async () => {
+    installMatchMedia(true);
+    renderAt('/settings/integrations');
+    // The mobile sender stub renders — proving the redirect fired.
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /mobile sender/i })).toBeInTheDocument(),
+    );
+    // The ErrorBoundary fallback MUST NOT appear; if it does, the
+    // page's first render threw before AppShell's mobile-guard could
+    // bounce the user.
+    expect(screen.queryByRole('heading', { name: /something went wrong/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
+    // Neither must the desktop IntegrationsPage chrome — the page MUST
+    // NOT have rendered its h1 even briefly (the bug was that the page
+    // rendered, crashed the ErrorBoundary, and then the redirect never
+    // happened).
+    expect(screen.queryByRole('heading', { level: 1, name: /^integrations$/i })).toBeNull();
+  });
+
+  it('renders the desktop IntegrationsPage normally on a desktop viewport', async () => {
+    installMatchMedia(false);
+    renderAt('/settings/integrations');
+    expect(
+      await screen.findByRole('heading', { level: 1, name: /^integrations$/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /mobile sender/i })).toBeNull();
+    expect(screen.queryByRole('heading', { name: /something went wrong/i })).toBeNull();
+  });
+
+  // Defence in depth: even if a future refactor pulls IntegrationsPage
+  // out from under AppShell (or the AppShell mobile-guard regresses),
+  // the page itself MUST NOT render its desktop chrome on a mobile
+  // viewport — at minimum return a `<Navigate to="/m/send">`. Audit
+  // slice C #1 (HIGH): a deployed mobile crash whose root cause was
+  // exactly this — the page rendered before any mobile guard fired.
+  it('does NOT render the desktop chrome when mounted outside AppShell on a mobile viewport', async () => {
+    installMatchMedia(true);
+    renderWithProviders(
+      <MemoryRouter initialEntries={['/settings/integrations']}>
+        <Routes>
+          <Route path="/settings/integrations" element={<IntegrationsPage />} />
+          <Route path="/m/send" element={<h1>mobile sender</h1>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: /mobile sender/i })).toBeInTheDocument(),
+    );
+    expect(screen.queryByRole('heading', { level: 1, name: /^integrations$/i })).toBeNull();
+    expect(screen.queryByRole('heading', { name: /something went wrong/i })).toBeNull();
+  });
+});

--- a/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
+++ b/apps/web/src/routes/settings/integrations/useGDriveAccounts.ts
@@ -32,16 +32,31 @@ function isOAuthCompleteMessage(data: unknown): data is GdriveOAuthCompleteMessa
 }
 
 /**
+ * Health of the stored refresh token. Mirrors the API
+ * `GDriveTokenStatus` type — `live` means the most recent refresh
+ * attempt succeeded (or no refresh has been attempted yet);
+ * `reconnect_required` means we observed an `invalid_grant` from
+ * Google and the SPA must surface a Reconnect button instead of the
+ * default Disconnect-only row. Audit slice C #4 (HIGH).
+ */
+export type GDriveTokenStatus = 'live' | 'reconnect_required';
+
+/**
  * View model for a connected Google Drive account, mirroring the API
  * `GDriveAccountView` shape from `apps/api/src/integrations/gdrive/dto/account.dto.ts`.
  * Refresh tokens / KMS metadata never cross the wire — the backend
  * scrubs them before serializing.
+ *
+ * `tokenStatus` is optional on the wire only for forward-compat with
+ * older API responses; consumers should default to `'live'` when the
+ * field is missing.
  */
 export interface GDriveAccount {
   readonly id: string;
   readonly email: string;
   readonly connectedAt: string;
   readonly lastUsedAt: string | null;
+  readonly tokenStatus?: GDriveTokenStatus | undefined;
 }
 
 export const GDRIVE_ACCOUNTS_KEY = ['integrations', 'gdrive', 'accounts'] as const;

--- a/apps/web/src/styles/theme.ts
+++ b/apps/web/src/styles/theme.ts
@@ -51,6 +51,14 @@ export const seald = {
       subtle: 'var(--accent-subtle)',
       ink: '#FFFFFF',
     },
+    /**
+     * Modal backdrop / scrim token. Audit slice C #6 (MEDIUM) — promotes
+     * the previously inline `rgba(15,23,42,0.45)` literal that lived in
+     * DisconnectModal to a single source of truth shared by every
+     * future overlay (drawer scrims, confirmation dialogs, image
+     * lightboxes).
+     */
+    overlay: 'var(--overlay)',
   },
   font: {
     sans: "'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif",

--- a/apps/web/src/styles/tokens.css
+++ b/apps/web/src/styles/tokens.css
@@ -52,12 +52,17 @@
   --accent-press: var(--indigo-800);
   --accent-subtle: var(--indigo-50);
 
+  /* Modal backdrop / scrim — audit slice C #6 (MEDIUM). Single token
+     consumed by every overlay (DisconnectModal, future drawers, etc). */
+  --overlay: rgba(15, 23, 42, 0.45);
+
   --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
   --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.04), 0 2px 4px rgba(15, 23, 42, 0.04);
   --shadow-md: 0 2px 4px rgba(15, 23, 42, 0.04), 0 6px 16px rgba(15, 23, 42, 0.06);
   --shadow-lg: 0 4px 8px rgba(15, 23, 42, 0.04), 0 12px 28px rgba(15, 23, 42, 0.08);
   --shadow-xl: 0 8px 16px rgba(15, 23, 42, 0.06), 0 24px 56px rgba(15, 23, 42, 0.12);
   --shadow-focus: 0 0 0 4px rgba(79, 70, 229, 0.18);
-  --shadow-paper: 0 1px 0 rgba(15, 23, 42, 0.04), 0 10px 30px rgba(15, 23, 42, 0.08),
+  --shadow-paper:
+    0 1px 0 rgba(15, 23, 42, 0.04), 0 10px 30px rgba(15, 23, 42, 0.08),
     0 0 0 1px rgba(15, 23, 42, 0.04);
 }


### PR DESCRIPTION
## Summary
Implements every HIGH/MEDIUM item from the Slice-C audit's Settings/IntegrationsPage section. Each behavioral fix lands with a regression test that was RED against current code before the fix.

### Highest-impact
- **Mobile error-boundary crash fixed** — `IntegrationsPage` wrapped so a synchronous `readIsMobileViewport()` short-circuits before any sub-render can throw. Mobile (≤640 px) lands on `/m/send` instead of "Something went wrong". Inner component now `IntegrationsPageInner`; pinned by a regression test that mounts the page inside `AppShell` at 390 px and asserts the redirect (NOT the fallback).
- **"Reconnect required" UI for expired Drive tokens** — `tokenStatus: 'live' | 'reconnect_required'` added end-to-end (API `GDriveAccountView` + web `GDriveAccount` types; service tracks a `revoked` set populated by the existing refresh path so no extra Google round-trip on list). Card flips to amber "Reconnect required" badge; row shows email-level badge + **primary Reconnect button** wired to `useReconnectGDrive`; Disconnect demoted to a ghost button.

### Other items
- Breadcrumb `<span>Settings</span>` → real `<Link to="/settings">`; added `/settings` stub route redirecting to `/settings/integrations`.
- `IntegrationsPage` raw px → `theme.space[*]` / `radius.*` / `font.size.*` (remaining px are border widths / fixed icon sizes / one max-width).
- `EmptyGrid` breakpoint 720 → 880 px, gap → `theme.space[8]`, re-flowed via grid-template-areas so the permissions block sits ABOVE the CTA on narrow widths.
- `theme.color.overlay` token + `--overlay: rgba(15,23,42,0.45)` CSS var; `DisconnectModal` backdrop now consumes the token.
- `CardTitle` rendered as `<h2>` (landmark heading) — visual treatment unchanged.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm -r lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter api test` — **972/972** (3 new controller tests for the `tokenStatus` field + transitions)
- [x] `pnpm --filter web exec vitest run` — **1604/1604** (5 new IntegrationsPage tests + 3 new mobile-render tests)
- [x] React PR review walked the diff — zero MUST-FIX
- [ ] Post-deploy: open `/settings/integrations` on a 390-px mobile — should redirect to `/m/send`, NOT show the Error Boundary. On desktop with a revoked Drive token, the amber "Reconnect required" badge + primary Reconnect button should surface.

## Deviations from the brief
- "Promote `ConfigAlert` to a shared component" — **skipped per the brief's escape hatch** ("skip if too disruptive"); diff stays focused. Filed implicitly for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)