### PR TITLE
fix(web): auth + onboarding audit batch — consent click-through, error banners, DebugAuth gate, mobile auth

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -17,7 +17,10 @@
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png" />
     <link rel="icon" href="/favicon-16.png" sizes="16x16" type="image/png" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" sizes="180x180" />
-    <meta name="theme-color" content="#4F46E5" />
+    <!-- Matches the app's ink-50 background so Safari's URL bar fuses
+         into the page chrome on auth + dashboard surfaces (audit D §10
+         + audit C item 26). -->
+    <meta name="theme-color" content="#F8FAFC" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/src/AppRoutes.tsx
+++ b/apps/web/src/AppRoutes.tsx
@@ -129,7 +129,12 @@ export function AppRoutes() {
       </Route>
 
       <Route path="/auth/callback" element={<AuthCallbackPage />} />
-      <Route path="/debug/auth" element={<DebugAuthPage />} />
+      {/* Audit C: DebugAuthPage #4 — the /debug/auth surface is gated to
+          DEV-only builds. In production builds the route is unmounted so
+          a direct URL navigation falls through to the catch-all landing.
+          /me is auth-guarded so this isn't a credential leak, but a
+          publicly mountable debug page is a SAST finding regardless. */}
+      {import.meta.env.DEV ? <Route path="/debug/auth" element={<DebugAuthPage />} /> : null}
 
       {/* Drive OAuth popup-bridge — MUST live OUTSIDE <AppShell /> so the
           mobile-redirect rule (≤ 640 px → /m/send) does NOT fire on the

--- a/apps/web/src/components/AuthForm/AuthForm.stories.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.stories.tsx
@@ -24,6 +24,7 @@ const fakeAuth: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/components/AuthForm/AuthForm.styles.ts
+++ b/apps/web/src/components/AuthForm/AuthForm.styles.ts
@@ -13,6 +13,14 @@ export const Title = styled.h1`
   letter-spacing: -0.02em;
   line-height: 1.1;
   margin: 0;
+
+  /* On 320-px phones the desktop 36px would push "Create your account"
+     to two lines and dominate a third of the screen; taper down to keep
+     the form-first hierarchy on mobile. Matches VerifyPage's heading
+     taper (audit slice D §10). */
+  @media (max-width: 640px) {
+    font-size: 28px;
+  }
 `;
 
 export const Subtitle = styled.p`
@@ -37,15 +45,40 @@ export const CheckboxRow = styled.label`
   user-select: none;
 `;
 
-export const TosRow = styled.label`
+/**
+ * Consent row. Rendered as a plain <div> so the inner Terms / Privacy
+ * anchors don't act as label-children that re-fire a click on the
+ * checkbox (audit C: SignUp #2). The checkbox itself is paired with the
+ * <label> emitted by `TosRowLabel` below so a click on the prefix text
+ * still toggles the box.
+ */
+export const TosRow = styled.div`
   display: flex;
   align-items: flex-start;
   gap: ${({ theme }) => theme.space[2]};
-  margin: ${({ theme }) => theme.space[2]} 0 ${({ theme }) => theme.space[5]};
+  /* Tightened from space[2] 0 space[5] to space[3] 0 space[3] so the
+     combined-attestation row (audit C: 2 rows -> 1) keeps the Create-account
+     CTA above the cookie banner on 720px laptops. */
+  margin: ${({ theme }) => theme.space[3]} 0 ${({ theme }) => theme.space[3]};
   font-size: ${({ theme }) => theme.font.size.caption};
   color: ${({ theme }) => theme.color.fg[2]};
-  cursor: pointer;
   line-height: 1.5;
+`;
+
+/**
+ * Wraps the prefix text + anchors of the combined attestation. The text
+ * before the anchors is rendered through a labeled <span> association
+ * (htmlFor) so the click-target there toggles the checkbox; the anchors
+ * are siblings of the <label>, never children, so a click on a legal
+ * link never bubbles into a label-activation that would silently
+ * un-toggle consent.
+ */
+export const TosText = styled.span`
+  flex: 1;
+`;
+
+export const TosLabel = styled.label`
+  cursor: pointer;
 `;
 
 export const Checkbox = styled.input`
@@ -115,8 +148,12 @@ export const SkipRow = styled.div`
 export const SkipButton = styled.button`
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: ${({ theme }) => theme.space[2]};
-  padding: 8px 14px;
+  /* WCAG 2.5.5 AAA target — 44 px min on touch. The previous 8 px vertical
+     padding rendered ~30 px tall, below the mobile-tap threshold. */
+  min-height: 44px;
+  padding: 12px 16px;
   background: transparent;
   border: none;
   font-size: ${({ theme }) => theme.font.size.caption};
@@ -142,4 +179,35 @@ export const SkipHint = styled.div`
   margin-top: ${({ theme }) => theme.space[2]};
   font-size: ${({ theme }) => theme.font.size.micro};
   color: ${({ theme }) => theme.color.fg[4]};
+`;
+
+/**
+ * Tight link button that sits inside the password-field label slot. Used
+ * by the "Forgot?" affordance in signin mode. Previously this was an
+ * inline-styled <button> with `color: inherit` — invisible against fg[3]
+ * and no `:focus-visible` indicator. The styled-component uses
+ * `indigo[600]` for a calling-card link tone and `theme.shadow.focus`
+ * for keyboard discoverability (audit C: SignIn #8).
+ */
+export const LabelLink = styled.button`
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.indigo[600]};
+  cursor: pointer;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+    border-radius: ${({ theme }) => theme.radius.xs};
+  }
 `;

--- a/apps/web/src/components/AuthForm/AuthForm.test.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.test.tsx
@@ -17,6 +17,7 @@ const auth = {
   signUpWithPassword: vi.fn(async () => ({ needsEmailConfirmation: false })),
   signInWithGoogle: vi.fn(async () => undefined),
   resetPassword: vi.fn(async () => undefined),
+  resendSignUpConfirmation: vi.fn(async () => undefined),
   signOut: vi.fn(async () => undefined),
   enterGuestMode: vi.fn(async () => undefined),
   exitGuestMode: vi.fn(),
@@ -35,14 +36,20 @@ describe('AuthForm', () => {
     auth.resetPassword.mockClear();
   });
 
-  it('disables submit until valid in signin mode', async () => {
+  it('keeps the signin submit enabled and only short-circuits when invalid', async () => {
     const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signin" />);
     const submit = getByRole('button', { name: /sign in/i });
-    expect(submit).toBeDisabled();
-
+    // Per audit C: SignUp #3 — disabled affordance is for `busy` only.
+    expect(submit).not.toBeDisabled();
+    // Submitting with empty fields short-circuits without calling the
+    // sign-in action.
+    await userEvent.click(submit);
+    expect(auth.signInWithPassword).not.toHaveBeenCalled();
+    // Once the user fills the form, the same submit click goes through.
     await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
     await userEvent.type(getByLabelText(/^password$/i), 'hunter2');
-    expect(submit).not.toBeDisabled();
+    await userEvent.click(submit);
+    expect(auth.signInWithPassword).toHaveBeenCalledTimes(1);
   });
 
   it('calls signInWithPassword on submit with keep-signed-in', async () => {
@@ -66,28 +73,40 @@ describe('AuthForm', () => {
     expect(auth.signInWithPassword).toHaveBeenCalledWith('ada@example.com', 'hunter2', false);
   });
 
-  it('gates signup submit on ToS + age-gate checkboxes', async () => {
+  // SignUp #3 (audit C 2026-05-02): the Create-account CTA is no longer
+  // disabled on `!valid` — disabled CTAs with no explanation are a worse
+  // UX than an enabled one that surfaces inline field errors on click.
+  // The CTA only disables while in-flight (`busy`). Submit short-circuits
+  // when the form is invalid, marks each failing field, and the assertion
+  // here is that `signUpWithPassword` was NOT called.
+  it('does not call signUpWithPassword on submit when signup is invalid', async () => {
     const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
     const submit = getByRole('button', { name: /create account/i });
+    // CTA is enabled even with empty fields.
+    expect(submit).not.toBeDisabled();
     await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
     await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
     await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
-    expect(submit).toBeDisabled();
-    // ToS alone isn't enough — age gate must also be ticked.
-    await userEvent.click(getByLabelText(/agree to terms/i));
-    expect(submit).toBeDisabled();
-    await userEvent.click(getByLabelText(/legal age/i));
-    expect(submit).not.toBeDisabled();
+    // Combined ESIGN attestation NOT ticked — submit must short-circuit.
+    await userEvent.click(submit);
+    expect(auth.signUpWithPassword).not.toHaveBeenCalled();
+    // After ticking the combined attestation, the same submit click goes through.
+    await userEvent.click(getByLabelText(/legal age and agree/i));
+    await userEvent.click(submit);
+    expect(auth.signUpWithPassword).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps signup submit disabled when age gate is unchecked even if ToS is checked', async () => {
-    const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
-    const submit = getByRole('button', { name: /create account/i });
-    await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
-    await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
-    await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
-    await userEvent.click(getByLabelText(/agree to terms/i));
-    expect(submit).toBeDisabled();
+  // SignUp #3 — the submit-when-invalid path also surfaces inline error
+  // copy on each failing field so users know what to fix.
+  it('renders inline field errors when submit fires on an invalid signup form', async () => {
+    const { getByRole, findAllByRole, findByText } = renderWithTheme(<AuthForm mode="signup" />);
+    await userEvent.click(getByRole('button', { name: /create account/i }));
+    // Each failing field gets an explicit error via TextField's
+    // `error="…"` slot, which renders `<ErrorText role="alert">`. Four
+    // failing fields (name, email, password, agreed) => four alerts.
+    const alerts = await findAllByRole('alert');
+    expect(alerts.length).toBeGreaterThanOrEqual(1);
+    expect(await findByText(/please enter your name/i)).toBeInTheDocument();
   });
 
   it('links the ToS row to the Terms of Service and Privacy Policy pages', () => {
@@ -118,8 +137,8 @@ describe('AuthForm', () => {
     await userEvent.type(getByLabelText(/full name/i), 'Ada Lovelace');
     await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
     await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
-    await userEvent.click(getByLabelText(/legal age/i));
-    await userEvent.click(getByLabelText(/agree to terms/i));
+    // Combined ESIGN attestation (audit C: SignUp #10).
+    await userEvent.click(getByLabelText(/legal age and agree/i));
     await userEvent.click(getByRole('button', { name: /create account/i }));
     expect(onNeeds).toHaveBeenCalledWith('ada@example.com');
   });
@@ -155,13 +174,11 @@ describe('AuthForm', () => {
   // bypass the password form, but on signup mode they still create / claim
   // an account on our side, so the age-gate + ToS/Privacy attestation must
   // gate them too. Signin mode is unaffected — the user accepted at signup.
-  it('disables "Sign up with Google" until both signup checkboxes are ticked', async () => {
+  it('disables "Sign up with Google" until the combined signup attestation is ticked', async () => {
     const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
     const google = getByRole('button', { name: /sign up with google/i });
     expect(google).toBeDisabled();
-    await userEvent.click(getByLabelText(/agree to terms/i));
-    expect(google).toBeDisabled();
-    await userEvent.click(getByLabelText(/legal age/i));
+    await userEvent.click(getByLabelText(/legal age and agree/i));
     expect(google).not.toBeDisabled();
     await userEvent.click(google);
     expect(auth.signInWithGoogle).toHaveBeenCalledTimes(1);
@@ -172,16 +189,14 @@ describe('AuthForm', () => {
     expect(getByRole('button', { name: /continue with google/i })).not.toBeDisabled();
   });
 
-  it('disables Skip in signup mode until both checkboxes are ticked', async () => {
+  it('disables Skip in signup mode until the combined signup attestation is ticked', async () => {
     const onSkip = vi.fn();
     const { getByRole, getByLabelText } = renderWithTheme(
       <AuthForm mode="signup" onSkip={onSkip} />,
     );
     const skip = getByRole('button', { name: /skip — try it/i });
     expect(skip).toBeDisabled();
-    await userEvent.click(getByLabelText(/agree to terms/i));
-    expect(skip).toBeDisabled();
-    await userEvent.click(getByLabelText(/legal age/i));
+    await userEvent.click(getByLabelText(/legal age and agree/i));
     expect(skip).not.toBeDisabled();
     await userEvent.click(skip);
     expect(onSkip).toHaveBeenCalledTimes(1);
@@ -199,5 +214,84 @@ describe('AuthForm', () => {
   it('renders without axe violations', async () => {
     const { container } = renderWithTheme(<AuthForm mode="signin" />);
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  // Audit C: SignUp #2 — clicking the inner Terms/Privacy anchors inside
+  // the consent <label> previously toggled the checkbox. The anchors now
+  // stop event propagation so the checkbox state is preserved.
+  it('clicking an inner Terms/Privacy anchor does NOT toggle the consent checkbox', async () => {
+    const { getByLabelText, getByRole } = renderWithTheme(<AuthForm mode="signup" />);
+    const checkbox = getByLabelText(/legal age and agree/i) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    // Click the Terms anchor — should NOT toggle the box.
+    const tos = getByRole('link', { name: /terms of service/i });
+    await userEvent.click(tos);
+    expect(checkbox.checked).toBe(false);
+    // Click the Privacy anchor — same.
+    const privacy = getByRole('link', { name: /privacy policy/i });
+    await userEvent.click(privacy);
+    expect(checkbox.checked).toBe(false);
+  });
+
+  // Audit C: SignUp #9 — strength meter is wrapped in a polite live region
+  // so screen readers announce changes as the user types.
+  it('wraps the password strength meter in a polite live region', async () => {
+    const { getByLabelText, getByRole } = renderWithTheme(<AuthForm mode="signup" />);
+    await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
+    // The wrapping <div role="status"> exposes the meter to assistive tech.
+    const status = getByRole('status');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(status).toHaveAttribute('aria-atomic', 'true');
+    expect(status).toContainElement(getByRole('progressbar'));
+  });
+
+  // Audit C: SignUp #10 — combined attestation: ONE checkbox instead of two.
+  it('renders a single combined consent checkbox in signup mode', () => {
+    const { getAllByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
+    // The mode-specific checkboxes are the consent attestation only —
+    // signup mode has no Keep-me-signed-in.
+    expect(getAllByRole('checkbox')).toHaveLength(1);
+    expect(getByLabelText(/legal age and agree.*terms.*privacy/i)).toBeInTheDocument();
+  });
+
+  // Audit C: SignUp #3 — focus the first failing field on submit so
+  // keyboard / screen-reader users land on what to fix.
+  it('focuses the first failing field when submit fires on an invalid signup form', async () => {
+    const { getByRole, getByLabelText } = renderWithTheme(<AuthForm mode="signup" />);
+    // Email is the first invalid field because Name is required first;
+    // leave Name empty so it focuses Name.
+    await userEvent.click(getByRole('button', { name: /create account/i }));
+    expect(getByLabelText(/full name/i)).toHaveFocus();
+  });
+
+  // Audit C: ForgotPassword #11 — label text is "Email address" not "Your work email".
+  it('uses "Email address" as the label in forgot mode', () => {
+    const { getByLabelText } = renderWithTheme(<AuthForm mode="forgot" />);
+    expect(getByLabelText(/email address/i)).toBeInTheDocument();
+  });
+
+  // Audit C: AuthForm #19 — single-character name is invalid even after trim.
+  it('rejects a single-character name in signup validation', async () => {
+    const { getByRole, getByLabelText, findByText } = renderWithTheme(<AuthForm mode="signup" />);
+    await userEvent.type(getByLabelText(/full name/i), 'A');
+    await userEvent.type(getByLabelText(/email/i), 'ada@example.com');
+    await userEvent.type(getByLabelText(/^password$/i), 'hunter2!!');
+    await userEvent.click(getByLabelText(/legal age and agree/i));
+    await userEvent.click(getByRole('button', { name: /create account/i }));
+    expect(auth.signUpWithPassword).not.toHaveBeenCalled();
+    expect(await findByText(/please enter your name/i)).toBeInTheDocument();
+  });
+
+  // Audit C: SignIn #8 — Forgot? link uses theme.shadow.focus on focus.
+  it('Forgot? link receives a visible focus indicator on keyboard focus', () => {
+    const { getByRole } = renderWithTheme(
+      <AuthForm mode="signin" onForgotPassword={() => undefined} />,
+    );
+    const forgot = getByRole('button', { name: /forgot\?/i });
+    forgot.focus();
+    // styled-components inserts a `box-shadow` via `&:focus-visible`. In
+    // jsdom focus-visible is satisfied by programmatic focus on a button.
+    const style = window.getComputedStyle(forgot);
+    expect(style.boxShadow ?? '').not.toBe('none');
   });
 });

--- a/apps/web/src/components/AuthForm/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm/AuthForm.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo, useState } from 'react';
+import { forwardRef, useCallback, useId, useMemo, useRef, useState } from 'react';
 import type { FormEvent } from 'react';
 import { ArrowRight } from 'lucide-react';
 import { useAuth } from '@/providers/AuthProvider';
@@ -17,13 +17,16 @@ import {
   Footer,
   Form,
   Heading,
+  LabelLink,
   SkipButton,
   SkipHint,
   SkipRow,
   Submit,
   Subtitle,
   Title,
+  TosLabel,
   TosRow,
+  TosText,
 } from './AuthForm.styles';
 
 const COPY = {
@@ -66,30 +69,45 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [keep, setKeep] = useState(true);
+  // Combined ESIGN/GDPR attestation (audit C: SignUp #10). One checkbox
+  // attests BOTH that the user is of legal age (T-24) AND that they
+  // agree to Seald's Terms + Privacy Policy. ESIGN-valid for a single
+  // affirmative consent covering multiple disclosures.
   const [agreed, setAgreed] = useState(false);
-  // Age gate (T-24). Our Terms require signers to be at least 18, or
-  // 16 in jurisdictions that permit a 16-year-old to enter into binding
-  // electronic contracts (see /legal/terms §2). We capture an explicit
-  // attestation here; the legal limit lives in the Terms, not the UI.
-  const [ofAge, setOfAge] = useState(false);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Field-level errors surfaced by submit when `disabled` was lifted —
+  // the user clicks the button to find out what's missing instead of
+  // staring at a half-grey CTA (audit C: SignUp #3).
+  const [fieldErrors, setFieldErrors] = useState<{
+    readonly name?: string;
+    readonly email?: string;
+    readonly password?: string;
+    readonly agreed?: string;
+  }>({});
+
+  const nameRef = useRef<HTMLInputElement | null>(null);
+  const emailRef = useRef<HTMLInputElement | null>(null);
+  const passwordRef = useRef<HTMLInputElement | null>(null);
+  const agreedRef = useRef<HTMLInputElement | null>(null);
+
+  const agreedId = useId();
 
   const strength = useMemo(() => (isSignup ? scorePassword(password) : 0), [isSignup, password]);
 
-  // The age-gate + ToS/Privacy attestation gates the password Submit. It
-  // ALSO gates Google + Skip in signup mode — both create an account on
-  // our side (Google = OAuth-claimed user, Skip = guest session bound to
-  // our Privacy Policy) so the affirmative ESIGN/GDPR consent must
-  // happen before either flow starts. Signin mode shows no checkboxes
-  // and is unaffected.
-  const signupConsented = agreed && ofAge;
+  // The combined attestation gates the password Submit. It ALSO gates
+  // Google + Skip in signup mode — both create an account on our side
+  // (Google = OAuth-claimed user, Skip = guest session bound to our
+  // Privacy Policy) so the affirmative ESIGN/GDPR consent must happen
+  // before either flow starts. Signin mode shows no checkbox and is
+  // unaffected.
+  const signupConsented = agreed;
 
   const valid = useMemo(() => {
     if (isForgot) return EMAIL_RE.test(email);
     if (isSignup) {
       return (
-        name.trim().length > 1 && EMAIL_RE.test(email) && password.length >= 8 && signupConsented
+        name.trim().length >= 2 && EMAIL_RE.test(email) && password.length >= 8 && signupConsented
       );
     }
     return EMAIL_RE.test(email) && password.length >= 1;
@@ -114,9 +132,61 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
     onSkip?.();
   };
 
+  // Validate every signup field eagerly on submit and mark each failure
+  // with an inline error (audit C: SignUp #3). The first failing field is
+  // focused so keyboard + screen-reader users land on what to fix instead
+  // of guessing why the disabled CTA didn't fire.
+  const collectSignupErrors = useCallback((): {
+    readonly errors: {
+      readonly name?: string;
+      readonly email?: string;
+      readonly password?: string;
+      readonly agreed?: string;
+    };
+    readonly firstFailing: 'name' | 'email' | 'password' | 'agreed' | null;
+  } => {
+    const errors: {
+      name?: string;
+      email?: string;
+      password?: string;
+      agreed?: string;
+    } = {};
+    let firstFailing: 'name' | 'email' | 'password' | 'agreed' | null = null;
+    if (name.trim().length < 2) {
+      errors.name = 'Please enter your name (2 characters or more).';
+      firstFailing ??= 'name';
+    }
+    if (!EMAIL_RE.test(email)) {
+      errors.email = 'Enter a valid email address.';
+      firstFailing ??= 'email';
+    }
+    if (password.length < 8) {
+      errors.password = 'Use at least 8 characters.';
+      firstFailing ??= 'password';
+    }
+    if (!signupConsented) {
+      errors.agreed = 'Please confirm age and accept the Terms + Privacy Policy.';
+      firstFailing ??= 'agreed';
+    }
+    return { errors, firstFailing };
+  }, [name, email, password, signupConsented]);
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
-    if (!valid || busy) return;
+    if (busy) return;
+
+    if (isSignup && !valid) {
+      const { errors, firstFailing } = collectSignupErrors();
+      setFieldErrors(errors);
+      if (firstFailing === 'name') nameRef.current?.focus();
+      else if (firstFailing === 'email') emailRef.current?.focus();
+      else if (firstFailing === 'password') passwordRef.current?.focus();
+      else if (firstFailing === 'agreed') agreedRef.current?.focus();
+      return;
+    }
+    if (!valid) return;
+
+    setFieldErrors({});
     setError(null);
     setBusy(true);
     try {
@@ -169,77 +239,73 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
       <Form ref={ref} {...rest} noValidate onSubmit={handleSubmit}>
         {isSignup && (
           <TextField
+            ref={nameRef}
             label="Full name"
             autoComplete="name"
             placeholder="Ada Lovelace"
             value={name}
             onChange={(v) => setName(v)}
+            error={fieldErrors.name}
           />
         )}
         <TextField
-          label={isForgot ? 'Your work email' : 'Email'}
+          ref={emailRef}
+          label={isForgot ? 'Email address' : 'Email'}
           type="email"
           autoComplete="email"
           placeholder="you@company.com"
           value={email}
           onChange={(v) => setEmail(v)}
+          error={fieldErrors.email}
         />
 
         {!isForgot && (
           <>
             <PasswordField
+              ref={passwordRef}
               label="Password"
               autoComplete={isSignup ? 'new-password' : 'current-password'}
-              placeholder={isSignup ? 'At least 8 characters' : '••••••••'}
+              placeholder={isSignup ? 'At least 8 characters' : 'Enter your password'}
               value={password}
               onChange={(v) => setPassword(v)}
+              error={fieldErrors.password}
               labelRight={
                 !isSignup && onForgotPassword ? (
-                  <button
-                    type="button"
-                    className="link"
-                    onClick={onForgotPassword}
-                    style={{
-                      background: 'none',
-                      border: 'none',
-                      padding: 0,
-                      color: 'inherit',
-                      font: 'inherit',
-                      cursor: 'pointer',
-                    }}
-                  >
+                  <LabelLink type="button" onClick={onForgotPassword}>
                     Forgot?
-                  </button>
+                  </LabelLink>
                 ) : null
               }
             />
-            {isSignup && password.length > 0 ? <PasswordStrengthMeter level={strength} /> : null}
+            {isSignup && password.length > 0 ? (
+              <div role="status" aria-live="polite" aria-atomic="true">
+                <PasswordStrengthMeter level={strength} />
+              </div>
+            ) : null}
           </>
         )}
 
         {isSignup && (
           <>
             <TosRow>
+              {/* The anchors live OUTSIDE the <label> (audit C: SignUp #2 —
+                  option A) so a click on Terms/Privacy never re-fires a
+                  click on the labeled checkbox via label activation. The
+                  prefix attestation text remains inside a <label htmlFor>
+                  so clicking the words still toggles consent. */}
               <Checkbox
-                type="checkbox"
-                checked={ofAge}
-                onChange={(e) => setOfAge(e.target.checked)}
-                aria-label="Confirm I am of legal age to sign electronically"
-              />
-              <span>
-                I confirm I am at least 18 years old (or the legal age in my jurisdiction to enter
-                into binding electronic contracts).
-              </span>
-            </TosRow>
-            <TosRow>
-              <Checkbox
+                ref={agreedRef}
+                id={agreedId}
                 type="checkbox"
                 checked={agreed}
                 onChange={(e) => setAgreed(e.target.checked)}
-                aria-label="Agree to Terms of Service and Privacy Policy"
+                aria-label="Confirm I am of legal age and agree to Seald's Terms of Service and Privacy Policy"
+                aria-invalid={fieldErrors.agreed ? true : undefined}
               />
-              <span>
-                I agree to Seald&apos;s{' '}
+              <TosText>
+                <TosLabel htmlFor={agreedId}>
+                  I confirm I&apos;m of legal age and agree to Seald&apos;s{' '}
+                </TosLabel>
                 <a href="/legal/terms" target="_blank" rel="noopener noreferrer">
                   Terms of Service
                 </a>{' '}
@@ -248,8 +314,11 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
                   Privacy Policy
                 </a>
                 .
-              </span>
+              </TosText>
             </TosRow>
+            {fieldErrors.agreed ? (
+              <ErrorBanner role="alert">{fieldErrors.agreed}</ErrorBanner>
+            ) : null}
           </>
         )}
 
@@ -267,7 +336,11 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
 
         {error ? <ErrorBanner role="alert">{error}</ErrorBanner> : null}
 
-        <Submit type="submit" disabled={!valid || busy}>
+        {/* Disabled only while busy. When fields are invalid we let the
+            user click and surface inline errors per field — disabled CTAs
+            with no explanation are a worse UX than an enabled CTA that
+            tells you what's wrong (audit C: SignUp #3). */}
+        <Submit type="submit" disabled={busy}>
           {submitLabel}
         </Submit>
       </Form>
@@ -305,7 +378,9 @@ export const AuthForm = forwardRef<HTMLFormElement, AuthFormProps>((props, ref) 
             Skip — try it without an account
             <Icon icon={ArrowRight} size={14} />
           </SkipButton>
-          <SkipHint>You can sign up later to save your documents.</SkipHint>
+          <SkipHint>
+            Documents you create as a guest stay on this device. Sign up to access them anywhere.
+          </SkipHint>
         </SkipRow>
       ) : null}
     </div>

--- a/apps/web/src/components/AuthShell/AuthMobileHeader.tsx
+++ b/apps/web/src/components/AuthShell/AuthMobileHeader.tsx
@@ -1,0 +1,62 @@
+import { forwardRef } from 'react';
+import styled from 'styled-components';
+
+/**
+ * Slim wordmark rendered ABOVE the `FormSide` form column when the
+ * `AuthBrandPanel` is collapsed (i.e. viewports `<= 960px`). Without this,
+ * tablets / foldables in the 641-960 px band saw a logo-less form on the
+ * `ink-50` background and the page read as a generic sign-in form.
+ *
+ * Mirrors the wordmark + mark styling used in `AuthBrandPanel.styles.ts`
+ * but inverted for the light form column (ink-900 text on light bg).
+ * Deliberately hidden above 960 px because the brand panel already
+ * carries the wordmark on the desktop split layout.
+ */
+const Row = styled.div`
+  display: none;
+  align-items: center;
+  gap: 10px;
+  margin: 0 0 ${({ theme }) => theme.space[6]};
+  font-family: ${({ theme }) => theme.font.serif};
+  font-size: 20px;
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.fg[1]};
+  letter-spacing: -0.01em;
+
+  @media (max-width: 960px) {
+    display: inline-flex;
+  }
+`;
+
+const Mark = styled.span`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: ${({ theme }) => theme.radius.sm};
+  background: ${({ theme }) => theme.color.indigo[500]};
+  color: ${({ theme }) => theme.color.paper};
+`;
+
+export const AuthMobileHeader = forwardRef<HTMLDivElement>((_, ref) => (
+  <Row ref={ref} role="img" aria-label="Seald">
+    <Mark aria-hidden="true">
+      <svg viewBox="0 0 40 40" width="16" height="16" fill="none" aria-hidden="true">
+        <g transform="translate(6, 6)">
+          <path
+            d="M2 22 C 6 20, 10 14, 14 12 L 22 4 L 26 8 L 18 16 C 16 20, 10 24, 4 26 Z"
+            fill="currentColor"
+          />
+          <path
+            d="M22 4 L 24 2 C 25 1, 26.5 1, 27.5 2 L 28 2.5 C 29 3.5, 29 5, 28 6 L 26 8 Z"
+            fill="currentColor"
+            opacity="0.7"
+          />
+        </g>
+      </svg>
+    </Mark>
+    <span>Seald</span>
+  </Row>
+));
+AuthMobileHeader.displayName = 'AuthMobileHeader';

--- a/apps/web/src/components/AuthShell/AuthShell.styles.ts
+++ b/apps/web/src/components/AuthShell/AuthShell.styles.ts
@@ -1,7 +1,10 @@
 import styled from 'styled-components';
 
 export const Root = styled.div`
-  min-height: 100vh;
+  /* 100dvh (dynamic viewport height) so iOS Safari doesn't trap the form
+     under the dynamic toolbar -- 100vh measures the largest viewport
+     and the soft keyboard would push the password input below the fold. */
+  min-height: 100dvh;
   background: ${({ theme }) => theme.color.ink[50]};
   display: flex;
   font-family: ${({ theme }) => theme.font.sans};
@@ -16,6 +19,14 @@ export const FormSide = styled.div`
   justify-content: center;
   padding: 40px 24px;
   min-width: 0;
+
+  /* On phones the soft keyboard re-covers a vertically-centered form;
+     anchor to the top so the focused input reveals above the keyboard
+     and leaves the form's helper text visible. */
+  @media (max-width: 640px) {
+    justify-content: flex-start;
+    padding-top: 64px;
+  }
 `;
 
 export const FormWrap = styled.div`
@@ -26,6 +37,9 @@ export const FormWrap = styled.div`
 export const FootRow = styled.footer`
   margin-top: 32px;
   width: 100%;
+  @media (max-width: 640px) {
+    margin-top: 24px;
+  }
   max-width: 420px;
   display: flex;
   flex-wrap: wrap;

--- a/apps/web/src/components/AuthShell/AuthShell.test.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.test.tsx
@@ -108,4 +108,37 @@ describe('AuthShell', () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  // Audit D §10 — mobile/tablet (≤ 960 px) collapses the brand panel,
+  // leaving the form column logo-less. The AuthMobileHeader injects a
+  // slim wordmark above the form so the page identifies as Seald on
+  // foldable / tablet viewports. The mobile header lives inside the
+  // FormSide (the form column) — the brand panel's wordmark sits inside
+  // the <aside> on the desktop side.
+  it('renders a wordmark inside the FormSide for tablet/phone viewports', () => {
+    const { container } = renderWithTheme(
+      <AuthShell>
+        <h1>Sign in</h1>
+      </AuthShell>,
+    );
+    // The mobile-only header sets role=img + aria-label="Seald" and lives
+    // outside the brand-panel <aside>. Counting both occurrences detects
+    // the regression where the FormSide-side wordmark is missing — the
+    // desktop AuthBrandPanel always contributes one "Seald" wordmark.
+    const wordmarks = container.querySelectorAll('[role="img"][aria-label="Seald"]');
+    expect(wordmarks.length).toBeGreaterThanOrEqual(1);
+    // And the mobile header lives OUTSIDE the brand <aside>.
+    const aside = container.querySelector('aside');
+    const outsideAside = Array.from(wordmarks).filter((el) => !aside?.contains(el));
+    expect(outsideAside.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('omits the slim mobile wordmark in compact mode', () => {
+    const { container } = renderWithTheme(
+      <AuthShell compact>
+        <h1>Sign in</h1>
+      </AuthShell>,
+    );
+    expect(container.querySelectorAll('[role="img"][aria-label="Seald"]').length).toBe(0);
+  });
 });

--- a/apps/web/src/components/AuthShell/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell/AuthShell.tsx
@@ -1,5 +1,6 @@
 import { forwardRef } from 'react';
 import { AuthBrandPanel } from '../AuthBrandPanel';
+import { AuthMobileHeader } from './AuthMobileHeader';
 import type { AuthShellProps } from './AuthShell.types';
 import { FootLinkButton, FootRow, FormSide, FormWrap, Root } from './AuthShell.styles';
 
@@ -24,7 +25,10 @@ export const AuthShell = forwardRef<HTMLDivElement, AuthShellProps>((props, ref)
     <Root ref={ref} {...rest}>
       {compact ? null : <AuthBrandPanel />}
       <FormSide>
-        <FormWrap>{children}</FormWrap>
+        <FormWrap>
+          {compact ? null : <AuthMobileHeader />}
+          {children}
+        </FormWrap>
         <FootRow aria-label="Legal and accessibility">
           <a href="/legal/privacy">Privacy</a>
           <a href="/legal/terms">Terms</a>

--- a/apps/web/src/components/AuthShell/index.ts
+++ b/apps/web/src/components/AuthShell/index.ts
@@ -1,2 +1,3 @@
 export { AuthShell } from './AuthShell';
+export { AuthMobileHeader } from './AuthMobileHeader';
 export type { AuthShellProps } from './AuthShell.types';

--- a/apps/web/src/layout/RedirectWhenAuthed.test.tsx
+++ b/apps/web/src/layout/RedirectWhenAuthed.test.tsx
@@ -14,6 +14,7 @@ const baseAuth: AuthContextValue = {
   signUpWithPassword: vi.fn(async () => ({ needsEmailConfirmation: false })),
   signInWithGoogle: vi.fn(async () => undefined),
   resetPassword: vi.fn(async () => undefined),
+  resendSignUpConfirmation: vi.fn(async () => undefined),
   signOut: vi.fn(async () => undefined),
   enterGuestMode: vi.fn(async () => undefined),
   exitGuestMode: vi.fn(),

--- a/apps/web/src/layout/RootLanding.test.tsx
+++ b/apps/web/src/layout/RootLanding.test.tsx
@@ -14,6 +14,7 @@ const baseAuth: AuthContextValue = {
   signUpWithPassword: vi.fn(async () => ({ needsEmailConfirmation: false })),
   signInWithGoogle: vi.fn(async () => undefined),
   resetPassword: vi.fn(async () => undefined),
+  resendSignUpConfirmation: vi.fn(async () => undefined),
   signOut: vi.fn(async () => undefined),
   enterGuestMode: vi.fn(async () => undefined),
   exitGuestMode: vi.fn(),

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.redirects.test.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.redirects.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { screen, act } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { renderWithProviders } from '../../test/renderWithProviders';
 import { AuthCallbackPage } from './AuthCallbackPage';
@@ -55,6 +55,56 @@ describe('AuthCallbackPage — provider redirects', () => {
     // No redirect yet — loading screen visible.
     expect(screen.getByRole('status')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /sign-in|documents/i })).not.toBeInTheDocument();
+  });
+
+  // Audit C: AuthCallback #20 — 10-second watchdog so a never-settling
+  // Supabase flow doesn't trap users on the loading screen. We fake
+  // setTimeout/clearTimeout so the test doesn't sleep 10s wall-clock;
+  // `waitFor` uses queueMicrotask + Promise.resolve under the hood, so
+  // a hand-cranked polling loop here resolves without competing with
+  // the faked timer.
+  describe('watchdog (10-second timeout)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('redirects to /signin?error=oauth_timeout when loading does not settle within 10s', async () => {
+      renderAt('/auth/callback', { auth: { user: null, loading: true } });
+      expect(screen.getByRole('status')).toBeInTheDocument();
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+        // Flush any queued microtasks from the navigate() call.
+        await Promise.resolve();
+      });
+      // Synchronous DOM probe — the timer's navigate already committed
+      // inside the wrapping act() above, so the new route is visible.
+      expect(screen.getByRole('heading', { name: /sign-in landing/i })).toBeInTheDocument();
+    });
+
+    it('clears the watchdog when loading settles before the 10s mark', async () => {
+      await act(async () => {
+        renderAt('/auth/callback', {
+          auth: {
+            user: { id: 'u1', email: 'ada@example.com', name: 'Ada' },
+            loading: false,
+          },
+        });
+        // Flush the useEffect navigation pass.
+        await Promise.resolve();
+      });
+      // Auth-resolved path lands on /documents synchronously.
+      expect(screen.getByRole('heading', { name: /documents dashboard/i })).toBeInTheDocument();
+      await act(async () => {
+        vi.advanceTimersByTime(20_000);
+        await Promise.resolve();
+      });
+      // Still on /documents — the watchdog never armed because loading
+      // was false on first render.
+      expect(screen.queryByRole('heading', { name: /sign-in landing/i })).not.toBeInTheDocument();
+    });
   });
 
   it('error redirect wins over the user redirect when both could fire (defence in depth)', async () => {

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.stories.tsx
@@ -24,6 +24,7 @@ const LOADING_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.tsx
+++ b/apps/web/src/pages/AuthCallbackPage/AuthCallbackPage.tsx
@@ -4,6 +4,14 @@ import { AuthLoadingScreen } from '@/layout/AuthLoadingScreen';
 import { useAuth } from '@/providers/AuthProvider';
 
 /**
+ * 10-second watchdog before bouncing to `/signin?error=oauth_timeout`
+ * (audit C: AuthCallback #20). Without this, a Supabase failure mode
+ * where `detectSessionInUrl` never settles would leave the user staring
+ * at the loading screen forever.
+ */
+const OAUTH_WATCHDOG_MS = 10_000;
+
+/**
  * L4 page — `/auth/callback`. Supabase redirects back here after an OAuth
  * flow with session tokens in the URL. The Supabase client picks them up
  * automatically (`detectSessionInUrl: true`); we just have to wait for the
@@ -31,6 +39,21 @@ export function AuthCallbackPage() {
       navigate('/documents', { replace: true });
     }
   }, [params, loading, user, navigate]);
+
+  // Watchdog — bound to `loading` only so the timer is set once per
+  // loading window and torn down once the provider has settled, whether
+  // or not a user materialized. If 10 seconds elapse with `loading`
+  // still true we bounce to /signin so the user gets an actionable
+  // error instead of an indefinite spinner.
+  useEffect(() => {
+    if (!loading) return undefined;
+    const timer = setTimeout(() => {
+      navigate('/signin?error=oauth_timeout', { replace: true });
+    }, OAUTH_WATCHDOG_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [loading, navigate]);
 
   return <AuthLoadingScreen />;
 }

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.stories.tsx
@@ -24,6 +24,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.styles.ts
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.styles.ts
@@ -1,7 +1,16 @@
 import styled from 'styled-components';
 
+/**
+ * Center-align the entire confirmation stack inside the centered
+ * `FormSide` (audit C: CheckEmail #6). The badge + heading + body all
+ * collapse to a vertical, center-aligned column so the page reads as a
+ * canonical "we sent you something" confirmation screen.
+ */
 export const Wrap = styled.div`
-  text-align: left;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 export const IconBadge = styled.div`
@@ -18,10 +27,13 @@ export const IconBadge = styled.div`
 
 export const Title = styled.h1`
   font-family: ${({ theme }) => theme.font.serif};
-  font-size: 32px;
+  /* Theme tokens replace raw px / em literals (audit C: CheckEmail #5).
+     The h2 token (36px) and tracking.tight (-0.02em) match the
+     editorial scale used by other auth headings. */
+  font-size: ${({ theme }) => theme.font.size.h2};
   font-weight: ${({ theme }) => theme.font.weight.medium};
   color: ${({ theme }) => theme.color.fg[1]};
-  letter-spacing: -0.01em;
+  letter-spacing: ${({ theme }) => theme.font.tracking.tight};
   line-height: 1.15;
   margin: 0;
 `;
@@ -30,18 +42,29 @@ export const Body = styled.p`
   font-size: ${({ theme }) => theme.font.size.bodySm};
   color: ${({ theme }) => theme.color.fg[3]};
   margin: ${({ theme }) => theme.space[3]} 0 0;
-  line-height: 1.6;
+  /* theme.font.lineHeight.relaxed (1.65) replaces the raw 1.6 (audit C
+     CheckEmail #5). Adjacent confirmation paragraphs share the value. */
+  line-height: ${({ theme }) => theme.font.lineHeight.relaxed};
 `;
 
 export const Actions = styled.div`
   margin-top: ${({ theme }) => theme.space[8]};
   display: flex;
   gap: ${({ theme }) => theme.space[3]};
+  width: 100%;
+  /* On narrow phones (< 400 px), stack vertically with the Primary CTA
+     on top — column-reverse so DOM order (Secondary, Primary) renders as
+     (Primary, Secondary) on mobile (audit C: CheckEmail #13). */
+  @media (max-width: 400px) {
+    flex-direction: column-reverse;
+  }
 `;
 
+/* Both buttons share the same min-height (48px) so they tower-align across
+   the row and clear WCAG 2.5.5 AAA (audit C: CheckEmail #13). */
 export const Secondary = styled.button`
   flex: 1;
-  height: 44px;
+  min-height: 48px;
   border-radius: ${({ theme }) => theme.radius.md};
   border: 1px solid ${({ theme }) => theme.color.border[2]};
   background: ${({ theme }) => theme.color.paper};
@@ -53,7 +76,7 @@ export const Secondary = styled.button`
 
 export const Primary = styled.button`
   flex: 1;
-  height: 44px;
+  min-height: 48px;
   border-radius: ${({ theme }) => theme.radius.md};
   border: none;
   background: ${({ theme }) => theme.color.ink[900]};

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.test.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.test.tsx
@@ -29,10 +29,24 @@ describe('CheckEmailPage', () => {
     expect(screen.getByRole('button', { name: /resend link/i })).toBeInTheDocument();
   });
 
-  it('hides the resend button in signup confirmation mode', () => {
+  // Audit C: CheckEmail #14 — signup mode also surfaces a resend button so
+  // users can self-recover from a lost / delayed confirmation email.
+  it('shows a "Resend confirmation email" CTA in signup mode alongside "Back to sign in"', () => {
     renderAt('/check-email?email=jamie%40seald.app&mode=signup');
-    expect(screen.queryByRole('button', { name: /resend link/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /resend confirmation email/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /back to sign in/i })).toBeInTheDocument();
+    // The reset-mode label is NOT used in signup mode.
+    expect(screen.queryByRole('button', { name: /^resend link$/i })).not.toBeInTheDocument();
+  });
+
+  it('Resend confirmation email calls resendSignUpConfirmation in signup mode', async () => {
+    const user = userEvent.setup();
+    const resendSignUpConfirmation = vi.fn(async () => undefined);
+    renderAt('/check-email?email=jamie%40seald.app&mode=signup', {
+      auth: { resendSignUpConfirmation },
+    });
+    await user.click(screen.getByRole('button', { name: /resend confirmation email/i }));
+    expect(resendSignUpConfirmation).toHaveBeenCalledWith('jamie@seald.app');
   });
 
   it('falls back to "your inbox" copy when no email query param is present', () => {

--- a/apps/web/src/pages/CheckEmailPage/CheckEmailPage.tsx
+++ b/apps/web/src/pages/CheckEmailPage/CheckEmailPage.tsx
@@ -15,7 +15,7 @@ import { Actions, Body, IconBadge, Primary, Secondary, Title, Wrap } from './Che
 export function CheckEmailPage() {
   const [params] = useSearchParams();
   const navigate = useNavigate();
-  const { resetPassword } = useAuth();
+  const { resetPassword, resendSignUpConfirmation } = useAuth();
   const email = params.get('email') ?? '';
   const mode = params.get('mode') === 'signup' ? 'signup' : 'reset';
   const [resendBusy, setResendBusy] = useState(false);
@@ -24,15 +24,22 @@ export function CheckEmailPage() {
     navigate('/signin');
   }, [navigate]);
 
+  // Reset mode resends the password-reset link; signup mode resends the
+  // confirmation email (audit C: CheckEmail #14). Both share the busy /
+  // disabled affordance so a click while pending is a no-op.
   const handleResend = useCallback(async (): Promise<void> => {
     if (!email || resendBusy) return;
     setResendBusy(true);
     try {
-      await resetPassword(email);
+      if (mode === 'signup') {
+        await resendSignUpConfirmation(email);
+      } else {
+        await resetPassword(email);
+      }
     } finally {
       setResendBusy(false);
     }
-  }, [email, resendBusy, resetPassword]);
+  }, [email, mode, resendBusy, resetPassword, resendSignUpConfirmation]);
 
   const body =
     mode === 'signup' ? (
@@ -72,11 +79,13 @@ export function CheckEmailPage() {
           <Secondary type="button" onClick={handleBack}>
             Back to sign in
           </Secondary>
-          {mode === 'reset' ? (
-            <Primary type="button" onClick={handleResend} disabled={resendBusy || !email}>
-              {resendBusy ? 'Sending…' : 'Resend link'}
-            </Primary>
-          ) : null}
+          <Primary type="button" onClick={handleResend} disabled={resendBusy || !email}>
+            {resendBusy
+              ? 'Sending…'
+              : mode === 'signup'
+                ? 'Resend confirmation email'
+                : 'Resend link'}
+          </Primary>
         </Actions>
       </Wrap>
     </AuthShell>

--- a/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
+++ b/apps/web/src/pages/ContactsPage/ContactsPage.stories.tsx
@@ -26,6 +26,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
+++ b/apps/web/src/pages/DashboardPage/DashboardPage.stories.tsx
@@ -26,6 +26,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/DebugAuthPage/DebugAuthPage.prod-gate.test.tsx
+++ b/apps/web/src/pages/DebugAuthPage/DebugAuthPage.prod-gate.test.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import { seald } from '../../styles/theme';
+
+/**
+ * Audit C: DebugAuthPage #4 — `/debug/auth` previously mounted
+ * unconditionally. The route is now gated behind `import.meta.env.DEV`
+ * so a production build never registers it; navigation to `/debug/auth`
+ * falls through to the catch-all landing.
+ *
+ * We exercise the route-registration logic in isolation (rather than
+ * importing the full `<AppRoutes />` tree, which pulls in the full
+ * Supabase + apiClient + lazy chunks). The page-level test
+ * `DebugAuthPage.test.tsx` already covers the inner content; this test
+ * proves only the env-gate registration contract.
+ */
+function DebugStub(): ReactElement {
+  return <h1>Debug auth surface</h1>;
+}
+
+function LandingStub(): ReactElement {
+  return <h1>Landing fallback</h1>;
+}
+
+function renderAt(initialPath: string): void {
+  render(
+    <ThemeProvider theme={seald}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <Routes>
+          {import.meta.env.DEV ? <Route path="/debug/auth" element={<DebugStub />} /> : null}
+          <Route path="*" element={<LandingStub />} />
+        </Routes>
+      </MemoryRouter>
+    </ThemeProvider>,
+  );
+}
+
+describe('DebugAuthPage — production route gate', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('mounts the /debug/auth route in DEV builds', () => {
+    vi.stubEnv('DEV', true);
+    renderAt('/debug/auth');
+    expect(screen.getByRole('heading', { name: /debug auth surface/i })).toBeInTheDocument();
+  });
+
+  it('does NOT mount /debug/auth in production builds — falls through to the catch-all', () => {
+    vi.stubEnv('DEV', false);
+    renderAt('/debug/auth');
+    expect(screen.queryByRole('heading', { name: /debug auth surface/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /landing fallback/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/DebugAuthPage/DebugAuthPage.styles.ts
+++ b/apps/web/src/pages/DebugAuthPage/DebugAuthPage.styles.ts
@@ -42,6 +42,21 @@ export const Actions = styled.div`
   flex-wrap: wrap;
 `;
 
+/**
+ * Audit C: DebugAuthPage #15 — banner that flags this page as a
+ * developer-only diagnostic surface. Uses `warn[50] / warn[700]` tones
+ * so it's distinguishable from the regular product chrome.
+ */
+export const DevBanner = styled.div`
+  padding: ${({ theme }) => theme.space[3]} ${({ theme }) => theme.space[4]};
+  background: ${({ theme }) => theme.color.warn[50]};
+  border: 1px solid ${({ theme }) => theme.color.warn[500]};
+  color: ${({ theme }) => theme.color.warn[700]};
+  border-radius: ${({ theme }) => theme.radius.md};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
+`;
+
 export const Result = styled.pre`
   margin: 0;
   padding: ${({ theme }) => theme.space[4]};

--- a/apps/web/src/pages/DebugAuthPage/DebugAuthPage.test.tsx
+++ b/apps/web/src/pages/DebugAuthPage/DebugAuthPage.test.tsx
@@ -90,6 +90,13 @@ describe('DebugAuthPage', () => {
     expect(screen.getByText(/signed in as: \(none\)/i)).toBeInTheDocument();
   });
 
+  // Audit C: DebugAuthPage #15 — top banner that flags the page as a
+  // developer-only diagnostic surface.
+  it('renders the developer-only diagnostic banner', async () => {
+    renderPage();
+    expect(await screen.findByText(/developer-only diagnostic page/i)).toBeInTheDocument();
+  });
+
   it('renders the email + Sign-out CTA when getSession returns a session', async () => {
     supabaseAuth.getSession.mockResolvedValueOnce({
       data: { session: makeSession('jamie@seald.app') },

--- a/apps/web/src/pages/DebugAuthPage/DebugAuthPage.tsx
+++ b/apps/web/src/pages/DebugAuthPage/DebugAuthPage.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/Button';
 import { apiClient } from '@/lib/api/apiClient';
 import { supabase } from '@/lib/supabase/supabaseClient';
-import { Actions, Card, Result, Status, Title, Wrap } from './DebugAuthPage.styles';
+import { Actions, Card, DevBanner, Result, Status, Title, Wrap } from './DebugAuthPage.styles';
 
 /**
  * L4 page — developer-only surface for exercising the Supabase → `/me` path
@@ -65,6 +65,9 @@ export function DebugAuthPage() {
   return (
     <Wrap>
       <Card>
+        <DevBanner role="note">
+          Developer-only diagnostic page. Not intended for end users.
+        </DevBanner>
         <Title>Auth debug</Title>
         <Status>Signed in as: {email ?? '(none)'}</Status>
         <Actions>

--- a/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.stories.tsx
@@ -24,6 +24,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.test.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.test.tsx
@@ -57,7 +57,7 @@ describe('ForgotPasswordPage', () => {
       { auth: { resetPassword } },
     );
 
-    await user.type(screen.getByLabelText(/work email/i), 'jamie@seald.app');
+    await user.type(screen.getByLabelText(/email address/i), 'jamie@seald.app');
     await user.click(screen.getByRole('button', { name: /send reset link/i }));
 
     expect(resetPassword).toHaveBeenCalledWith('jamie@seald.app');

--- a/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
+++ b/apps/web/src/pages/ForgotPasswordPage/ForgotPasswordPage.tsx
@@ -1,9 +1,29 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
 import { AuthShell } from '@/components/AuthShell';
 import { AuthForm } from '@/components/AuthForm';
 import type { AuthFormMode } from '@/components/AuthForm/AuthForm.types';
 import { pathForAuthMode } from '@/layout/authPaths';
+
+/**
+ * Audit C: ForgotPassword #12 — without `GoogleButton`+`Divider` above
+ * the heading the forgot-password heading anchors lower than Sign-in,
+ * breaking the visual continuity SignIn → "Forgot?" → Forgot. A
+ * ~110 px spacer compensates for the missing affordances above the
+ * heading without retrofitting the form's vertical centering rule.
+ *
+ * Hidden on phones — `FormSide` already anchors to the top via the
+ * mobile media-query in `AuthShell.styles.ts` (audit D §10), so an
+ * additional 110 px above the heading would push the form below the
+ * keyboard.
+ */
+const VerticalSpacer = styled.div`
+  height: 110px;
+  @media (max-width: 640px) {
+    display: none;
+  }
+`;
 
 /**
  * L4 page — `/forgot-password`. After a successful submit, routes the user
@@ -29,6 +49,7 @@ export function ForgotPasswordPage() {
 
   return (
     <AuthShell>
+      <VerticalSpacer aria-hidden="true" />
       <AuthForm mode="forgot" onForgotSubmitted={handleSubmitted} onSwitchMode={handleSwitch} />
     </AuthShell>
   );

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/AppRoutes.gdrive-oauth-callback.test.tsx
@@ -34,6 +34,7 @@ vi.mock('../../providers/AuthProvider', async () => {
       signUpWithPassword: vi.fn(),
       signInWithGoogle: vi.fn(),
       resetPassword: vi.fn(),
+      resendSignUpConfirmation: vi.fn(),
       signOut: vi.fn(),
       enterGuestMode: vi.fn(),
       exitGuestMode: vi.fn(),

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.test.tsx
@@ -155,4 +155,40 @@ describe('GDriveOAuthCallbackPage (Bug G + Bug I)', () => {
     expect(await screen.findByText(/drive connected|connecting drive/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /SHOULD NOT REACH/i })).not.toBeInTheDocument();
   });
+
+  // Audit C: GDriveOAuthCallback #7 — replace raw inline hex / font with
+  // theme-driven styled-components inside a local ThemeProvider.
+  it('does not bake raw hex colors into inline style attributes', () => {
+    Object.defineProperty(window, 'opener', { value: null, writable: true, configurable: true });
+    const { container } = render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    const styled = container.querySelectorAll('[style]');
+    for (const el of Array.from(styled)) {
+      const style = el.getAttribute('style') ?? '';
+      // No literal hex color hard-coded in `style` (styled-components
+      // emit classes, not inline color attributes).
+      expect(/#[0-9a-fA-F]{3,8}/.test(style)).toBe(false);
+    }
+  });
+
+  // Audit C: GDriveOAuthCallback #16 — popup-blocker recovery Close button.
+  it('renders a Close button that invokes window.close() on click', async () => {
+    Object.defineProperty(window, 'opener', { value: null, writable: true, configurable: true });
+    render(
+      <MemoryRouter initialEntries={['/oauth/gdrive/callback?connected=1']}>
+        <Routes>
+          <Route path="/oauth/gdrive/callback" element={<GDriveOAuthCallbackPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    closeSpy.mockClear();
+    const close = await screen.findByRole('button', { name: /^close$/i });
+    close.click();
+    expect(closeSpy).toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
+++ b/apps/web/src/pages/GDriveOAuthCallbackPage/GDriveOAuthCallbackPage.tsx
@@ -1,8 +1,10 @@
-import { useEffect, type ReactElement } from 'react';
+import { useCallback, useEffect, type ReactElement } from 'react';
+import styled, { ThemeProvider } from 'styled-components';
 import {
   GDRIVE_OAUTH_BROADCAST_CHANNEL,
   GDRIVE_OAUTH_COMPLETE_MESSAGE,
 } from '@/routes/settings/integrations/useGDriveAccounts';
+import { seald } from '@/styles/theme';
 
 /**
  * Dedicated OAuth-callback bridge for the Google Drive popup. Mounted
@@ -81,24 +83,67 @@ export function GDriveOAuthCallbackPage(): ReactElement {
     };
   }, []);
 
+  // Audit C: GDriveOAuthCallback #16 — popup-blocked recovery. Some
+  // browsers refuse `window.close()` on windows that weren't opened by
+  // a script (or via a non-user gesture); render an explicit Close
+  // button so the user can dismiss the page when the effect's
+  // `window.close()` is silently denied.
+  const handleClose = useCallback((): void => {
+    window.close();
+  }, []);
+
   // Static surface — never <Navigate>. If the popup-blocker collapsed
   // the popup into the parent tab, the parent's BroadcastChannel
   // listener still picks up the signal; the user is left on a tiny
   // confirmation screen rather than getting bounced to /m/send by
-  // AppShell's mobile-viewport guard.
+  // AppShell's mobile-viewport guard. The page is mounted outside the
+  // main app shell (no global ThemeProvider in scope) so we wrap with
+  // a local one — audit C: GDriveOAuthCallback #7.
   return (
-    <div
-      role="status"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100vh',
-        fontFamily: 'system-ui, -apple-system, sans-serif',
-        color: '#1f2937',
-      }}
-    >
-      <p>Drive connected — you can close this window.</p>
-    </div>
+    <ThemeProvider theme={seald}>
+      <Wrap role="status">
+        <p>Drive connected — you can close this window.</p>
+        <CloseButton type="button" onClick={handleClose}>
+          Close
+        </CloseButton>
+      </Wrap>
+    </ThemeProvider>
   );
 }
+
+/**
+ * Theme-aware page surface for the OAuth bridge. Replaces an inline
+ * `style={{ color: '#1f2937', fontFamily: 'system-ui...' }}` that
+ * bypassed the design system. `ink[700]` is the closest token to the
+ * previous hex (`#1F2937` per `apps/web/src/styles/theme.ts`).
+ */
+const Wrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${({ theme }) => theme.space[4]};
+  min-height: 100dvh;
+  background: ${({ theme }) => theme.color.ink[50]};
+  font-family: ${({ theme }) => theme.font.sans};
+  color: ${({ theme }) => theme.color.ink[700]};
+  padding: ${({ theme }) => theme.space[6]};
+  text-align: center;
+`;
+
+const CloseButton = styled.button`
+  min-height: 44px;
+  padding: ${({ theme }) => theme.space[3]} ${({ theme }) => theme.space[5]};
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid ${({ theme }) => theme.color.border[2]};
+  background: ${({ theme }) => theme.color.paper};
+  font-family: inherit;
+  font-size: ${({ theme }) => theme.font.size.bodySm};
+  font-weight: ${({ theme }) => theme.font.weight.semibold};
+  color: ${({ theme }) => theme.color.ink[700]};
+  cursor: pointer;
+  &:focus-visible {
+    outline: none;
+    box-shadow: ${({ theme }) => theme.shadow.focus};
+  }
+`;

--- a/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
+++ b/apps/web/src/pages/SentConfirmationPage/SentConfirmationPage.stories.tsx
@@ -26,6 +26,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.stories.tsx
@@ -24,6 +24,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/SignInPage/SignInPage.test.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.test.tsx
@@ -30,4 +30,16 @@ describe('SignInPage', () => {
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent(/google sign-in/i);
   });
+
+  // Audit C: SignIn #1 — the OAuth/guest banner is icon-led so it doesn't
+  // look like a plain text strip behind the cookie banner.
+  it('renders an AlertTriangle icon inside the OAuth error banner', () => {
+    renderAt('/signin?error=oauth');
+    const alert = screen.getByRole('alert');
+    // lucide-react renders an inline <svg>. We assert by tagName instead
+    // of testid so the rule "test by accessible role/name" still applies
+    // (the icon itself is decorative — aria-hidden — so role is correct).
+    const svg = alert.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
 });

--- a/apps/web/src/pages/SignInPage/SignInPage.tsx
+++ b/apps/web/src/pages/SignInPage/SignInPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { ErrorBanner as SharedErrorBanner } from '@/components/shared/ErrorBanner';
+import { AlertTriangle } from 'lucide-react';
 import { AuthShell } from '@/components/AuthShell';
 import { AuthForm } from '@/components/AuthForm';
 import type { AuthFormMode } from '@/components/AuthForm/AuthForm.types';
@@ -9,12 +9,29 @@ import { pathForAuthMode } from '@/layout/authPaths';
 import { useAuth } from '@/providers/AuthProvider';
 import { useIsMobileViewport } from '@/hooks/useIsMobileViewport';
 
-const ErrorBanner = styled(SharedErrorBanner)`
+/**
+ * Icon-led error banner mirroring `DisconnectModal.tsx` `ErrorRow`
+ * (`apps/web/src/routes/settings/integrations/DisconnectModal.tsx:106-117`).
+ * Adds an `<AlertTriangle>` glyph so the OAuth/guest error is visually
+ * distinct from the cookie banner overlay (audit C: SignIn #1).
+ */
+const ErrorBanner = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
   margin: 0 0 ${({ theme }) => theme.space[4]};
+  padding: 12px 14px;
+  border: 1px solid ${({ theme }) => theme.color.danger[500]};
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.color.danger[50]};
+  color: ${({ theme }) => theme.color.danger[700]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
 `;
 
 const ERROR_COPY: Record<string, string> = {
   oauth: "We couldn't complete the Google sign-in. Please try again.",
+  oauth_timeout: 'The sign-in took too long. Please try again.',
   guest: "We couldn't start a guest session. Please sign up to continue.",
 };
 
@@ -72,7 +89,8 @@ export function SignInPage() {
     <AuthShell>
       {errorKey ? (
         <ErrorBanner role="alert">
-          {ERROR_COPY[errorKey] ?? 'Something went wrong. Please try again.'}
+          <AlertTriangle width={16} height={16} strokeWidth={1.75} aria-hidden />
+          <span>{ERROR_COPY[errorKey] ?? 'Something went wrong. Please try again.'}</span>
         </ErrorBanner>
       ) : null}
       <AuthForm

--- a/apps/web/src/pages/SignUpPage/SignUpPage.mobile-authed-redirect.test.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.mobile-authed-redirect.test.tsx
@@ -39,8 +39,8 @@ async function submitSignUp(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByLabelText(/full name/i), 'Ada Lovelace');
   await user.type(screen.getByLabelText(/email/i), 'ada@example.com');
   await user.type(screen.getByLabelText(/^password$/i), 'hunter2hunter');
-  await user.click(screen.getByLabelText(/legal age/i));
-  await user.click(screen.getByLabelText(/terms of service and privacy policy/i));
+  // Combined ESIGN attestation (audit C: SignUp #10).
+  await user.click(screen.getByLabelText(/legal age and agree/i));
   await user.click(screen.getByRole('button', { name: /create account/i }));
 }
 

--- a/apps/web/src/pages/SignUpPage/SignUpPage.mobile-redirect.test.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.mobile-redirect.test.tsx
@@ -35,11 +35,10 @@ function renderAt() {
 }
 
 // Signup gates Skip behind ESIGN affirmative consent (T-24/T-25): the user
-// must tick "agree to terms" + "legal age" before the Skip button enables.
+// must tick the combined attestation before the Skip button enables.
 // Encapsulated here so the assertion is self-contained.
 async function tickSignupConsents(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByLabelText(/agree to terms/i));
-  await user.click(screen.getByLabelText(/legal age/i));
+  await user.click(screen.getByLabelText(/legal age and agree/i));
 }
 
 describe('SignUpPage — mobile-aware Skip routing', () => {

--- a/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.stories.tsx
@@ -24,6 +24,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/SignUpPage/SignUpPage.test.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.test.tsx
@@ -54,8 +54,8 @@ describe('SignUpPage', () => {
 
     // Consent gates Skip in signup mode (commit 5a3f252) — tick both first so
     // the skip handler actually runs through the page-level navigation.
-    await user.click(screen.getByLabelText(/legal age/i));
-    await user.click(screen.getByLabelText(/terms of service and privacy policy/i));
+    // Combined ESIGN attestation (audit C: SignUp #10).
+    await user.click(screen.getByLabelText(/legal age and agree/i));
 
     await user.click(screen.getByRole('button', { name: /skip/i }));
 
@@ -81,8 +81,8 @@ describe('SignUpPage', () => {
     await user.type(screen.getByLabelText(/full name/i), 'Ada Lovelace');
     await user.type(screen.getByLabelText(/email/i), 'ada@example.com');
     await user.type(screen.getByLabelText(/^password$/i), 'hunter2hunter');
-    await user.click(screen.getByLabelText(/legal age/i));
-    await user.click(screen.getByLabelText(/terms of service and privacy policy/i));
+    // Combined ESIGN attestation (audit C: SignUp #10).
+    await user.click(screen.getByLabelText(/legal age and agree/i));
 
     await user.click(screen.getByRole('button', { name: /create account/i }));
 
@@ -95,6 +95,22 @@ describe('SignUpPage', () => {
     expect(await screen.findByRole('heading', { name: /check your email/i })).toBeInTheDocument();
   });
 
+  // Audit C: SignUp #2 — clicking the inner /legal/terms or /legal/privacy
+  // anchor inside the <label> consent row previously toggled the checkbox
+  // (a WCAG antipattern that on mobile silently un-toggled affirmative
+  // consent on the tap target). The anchors stopPropagation so the
+  // checkbox state is preserved.
+  it('clicking the inner Terms/Privacy anchors does NOT toggle the consent checkbox', async () => {
+    const user = userEvent.setup();
+    renderSignUp({});
+    const checkbox = screen.getByLabelText(/legal age and agree/i) as HTMLInputElement;
+    expect(checkbox.checked).toBe(false);
+    await user.click(screen.getByRole('link', { name: /terms of service/i }));
+    expect(checkbox.checked).toBe(false);
+    await user.click(screen.getByRole('link', { name: /privacy policy/i }));
+    expect(checkbox.checked).toBe(false);
+  });
+
   it('navigates to /documents when signup yields an immediate session', async () => {
     const user = userEvent.setup();
     const signUpWithPassword = vi.fn(async () => ({ needsEmailConfirmation: false }));
@@ -103,8 +119,8 @@ describe('SignUpPage', () => {
     await user.type(screen.getByLabelText(/full name/i), 'Ada Lovelace');
     await user.type(screen.getByLabelText(/email/i), 'ada@example.com');
     await user.type(screen.getByLabelText(/^password$/i), 'hunter2hunter');
-    await user.click(screen.getByLabelText(/legal age/i));
-    await user.click(screen.getByLabelText(/terms of service and privacy policy/i));
+    // Combined ESIGN attestation (audit C: SignUp #10).
+    await user.click(screen.getByLabelText(/legal age and agree/i));
 
     await user.click(screen.getByRole('button', { name: /create account/i }));
 

--- a/apps/web/src/pages/SignUpPage/SignUpPage.tsx
+++ b/apps/web/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
-import { ErrorBanner as SharedErrorBanner } from '@/components/shared/ErrorBanner';
+import { AlertTriangle } from 'lucide-react';
 import { AuthShell } from '@/components/AuthShell';
 import { AuthForm } from '@/components/AuthForm';
 import type { AuthFormMode } from '@/components/AuthForm/AuthForm.types';
@@ -9,8 +9,22 @@ import { pathForAuthMode } from '@/layout/authPaths';
 import { useAuth } from '@/providers/AuthProvider';
 import { useIsMobileViewport } from '@/hooks/useIsMobileViewport';
 
-const ErrorBanner = styled(SharedErrorBanner)`
+/**
+ * Icon-led error banner mirroring `DisconnectModal.tsx` `ErrorRow`
+ * (audit C: SignIn #1; the SignUp guest path uses the same affordance).
+ */
+const ErrorBanner = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
   margin: 0 0 ${({ theme }) => theme.space[4]};
+  padding: 12px 14px;
+  border: 1px solid ${({ theme }) => theme.color.danger[500]};
+  border-radius: ${({ theme }) => theme.radius.md};
+  background: ${({ theme }) => theme.color.danger[50]};
+  color: ${({ theme }) => theme.color.danger[700]};
+  font-size: ${({ theme }) => theme.font.size.caption};
+  line-height: ${({ theme }) => theme.font.lineHeight.normal};
 `;
 
 /**
@@ -61,7 +75,12 @@ export function SignUpPage() {
 
   return (
     <AuthShell>
-      {guestError ? <ErrorBanner role="alert">{guestError}</ErrorBanner> : null}
+      {guestError ? (
+        <ErrorBanner role="alert">
+          <AlertTriangle width={16} height={16} strokeWidth={1.75} aria-hidden />
+          <span>{guestError}</span>
+        </ErrorBanner>
+      ) : null}
       <AuthForm
         mode="signup"
         onSkip={handleSkip}

--- a/apps/web/src/pages/TemplatesListPage/TemplatesListPage.stories.tsx
+++ b/apps/web/src/pages/TemplatesListPage/TemplatesListPage.stories.tsx
@@ -41,6 +41,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/UseTemplatePage/UseTemplatePage.stories.tsx
+++ b/apps/web/src/pages/UseTemplatePage/UseTemplatePage.stories.tsx
@@ -33,6 +33,7 @@ const STORY_AUTH: AuthContextValue = {
   signUpWithPassword: asyncSignUp,
   signInWithGoogle: asyncNoop,
   resetPassword: asyncNoop,
+  resendSignUpConfirmation: asyncNoop,
   signOut: asyncNoop,
   enterGuestMode: asyncNoop,
   exitGuestMode: noop,

--- a/apps/web/src/pages/VerifyPage/VerifyPage.test.tsx
+++ b/apps/web/src/pages/VerifyPage/VerifyPage.test.tsx
@@ -845,10 +845,17 @@ describe('VerifyPage', () => {
   // Two long-running keyframe animations: the verdict mark's pulsing ring
   // (`pulse`) and the loading skeleton (`skeleton-shimmer`). Both must be
   // disabled inside `@media (prefers-reduced-motion: reduce)`.
+  // styled-components only injects a styled component's rules once the
+  // component mounts. The loading branch mounts SkeletonBlock; the success
+  // branch mounts VerdictMark. Resolving the query exercises both code paths
+  // (the loading skeleton flashes in render #1 before the success view in
+  // render #2), so a single render after success has both rule blocks in the
+  // global stylesheet.
   it('disables the verdict pulse + skeleton shimmer animations under prefers-reduced-motion', async () => {
-    get.mockReturnValue(new Promise(() => {}));
+    get.mockResolvedValueOnce({ data: SIGNED_PAYLOAD });
     const Wrapper = wrap('/verify/u82ZmvdxwG3CU');
     render(<VerifyPage />, { wrapper: Wrapper });
+    await screen.findByRole('heading', { level: 1, name: /sealed and intact/i });
 
     // styled-components serialises every <style> block it has injected.
     const collected = Array.from(document.querySelectorAll('style'))

--- a/apps/web/src/providers/AppStateProvider.test.tsx
+++ b/apps/web/src/providers/AppStateProvider.test.tsx
@@ -25,6 +25,7 @@ const guestAuth: AuthContextValue = {
   signUpWithPassword: async () => ({ needsEmailConfirmation: false }),
   signInWithGoogle: async () => {},
   resetPassword: async () => {},
+  resendSignUpConfirmation: async () => {},
   signOut: async () => {},
   enterGuestMode: async () => {},
   exitGuestMode: () => {},

--- a/apps/web/src/providers/AuthProvider.tsx
+++ b/apps/web/src/providers/AuthProvider.tsx
@@ -28,6 +28,12 @@ export interface AuthContextValue {
   ) => Promise<SignUpOutcome>;
   readonly signInWithGoogle: () => Promise<void>;
   readonly resetPassword: (email: string) => Promise<void>;
+  /**
+   * Resends the signup-confirmation email for an existing pending-confirm
+   * account (audit C: CheckEmail #14). Surfaced by `CheckEmailPage` in
+   * `mode=signup` so users can self-recover from a lost / delayed email.
+   */
+  readonly resendSignUpConfirmation: (email: string) => Promise<void>;
   readonly signOut: () => Promise<void>;
   readonly enterGuestMode: () => Promise<void>;
   readonly exitGuestMode: () => void;
@@ -216,6 +222,15 @@ export function AuthProvider(props: AuthProviderProps) {
     if (error) throw error;
   }, []);
 
+  const resendSignUpConfirmation = useCallback(async (email: string): Promise<void> => {
+    const redirectTo =
+      typeof window !== 'undefined' ? `${window.location.origin}/auth/callback` : undefined;
+    const options: { emailRedirectTo?: string } = {};
+    if (redirectTo) options.emailRedirectTo = redirectTo;
+    const { error } = await supabase.auth.resend({ type: 'signup', email, options });
+    if (error) throw error;
+  }, []);
+
   const signOut = useCallback(async (): Promise<void> => {
     const { error } = await supabase.auth.signOut();
     if (error) throw error;
@@ -291,6 +306,7 @@ export function AuthProvider(props: AuthProviderProps) {
       signUpWithPassword,
       signInWithGoogle,
       resetPassword,
+      resendSignUpConfirmation,
       signOut,
       enterGuestMode,
       exitGuestMode,
@@ -304,6 +320,7 @@ export function AuthProvider(props: AuthProviderProps) {
       signUpWithPassword,
       signInWithGoogle,
       resetPassword,
+      resendSignUpConfirmation,
       signOut,
       enterGuestMode,
       exitGuestMode,

--- a/apps/web/src/routes/DocumentRoute.test.tsx
+++ b/apps/web/src/routes/DocumentRoute.test.tsx
@@ -43,6 +43,7 @@ function buildAuth(): AuthContextValue {
     signUpWithPassword: () => Promise.resolve({ needsEmailConfirmation: false }),
     signInWithGoogle: () => Promise.resolve(),
     resetPassword: () => Promise.resolve(),
+    resendSignUpConfirmation: () => Promise.resolve(),
     signOut: () => Promise.resolve(),
     enterGuestMode: () => Promise.resolve(),
     exitGuestMode: () => undefined,

--- a/apps/web/src/test/renderWithProviders.tsx
+++ b/apps/web/src/test/renderWithProviders.tsx
@@ -33,6 +33,7 @@ function buildContext(override: Partial<AuthContextValue>): AuthContextValue {
     signUpWithPassword: asyncSignUp,
     signInWithGoogle: asyncNoop,
     resetPassword: asyncNoop,
+    resendSignUpConfirmation: asyncNoop,
     signOut: asyncNoop,
     enterGuestMode: asyncNoop,
     exitGuestMode: noop,


### PR DESCRIPTION
## Summary
Implements every HIGH/MEDIUM/LOW item from the Slice-C audit's auth surfaces (SignIn / SignUp / ForgotPassword / CheckEmail / AuthCallback / DebugAuth / GDriveOAuthCallback) plus the Slice-D mobile-AuthShell items. **47 files changed, 904 insertions / 139 deletions.** Each behavioral fix lands with a regression test that was RED before the fix.

### Highest-impact
- **SignUp consent click-through bug** — anchors moved OUTSIDE `<label>` (Option A); `TosRow` is now `<div>` + nested `<label htmlFor>`. Test asserts clicking the inner `/legal/*` links does not toggle the checkbox.
- **SignUp validation feedback** — Submit no longer disabled while invalid; `collectSignupErrors` paints inline errors via `TextField error="…"` + focuses the first failing field. Disabled affordance reserved for `busy`.
- **SignIn / SignUp error banner with icon** — `AlertTriangle` + `danger[50/500/700]` tokens mirroring `DisconnectModal.ErrorRow`. Same pattern applied to SignUp guest-error.
- **DebugAuthPage prod gate** — route wrapped in `import.meta.env.DEV`; dedicated test uses `vi.stubEnv`.

### Mobile auth (from Slice D)
- **AuthBrandPanel mobile header** — new `<AuthMobileHeader>` (`display: inline-flex @media (max-width: 960px)`) renders the wordmark above the form on tablets/foldables. Logo-less form bug fixed.
- **SkipButton 44 px** — `min-height: 44px; padding: 12px 16px`.
- **FormSide keyboard scroll** — Root `min-height: 100dvh`; FormSide `flex-start + padding-top: 64px` on `≤640px`.
- **AuthForm Title 28 px on `≤640px`** — wraps cleanly on iPhone SE.
- **FootRow `margin-top: 24px` mobile.**

### Other items
- **CheckEmailPage** — tokens (`font.size.h2`, `tracking.tight`, `lineHeight.relaxed`), centered `text-align`, 48 px buttons, mobile-stack `column-reverse`, signup "Resend confirmation email" via new `resendSignUpConfirmation` on `AuthProvider`.
- **GDriveOAuthCallback** — `ThemeProvider`-wrapped styled-components; tokens `ink[700]` + `font.sans`; `<CloseButton>` for popup-blocked recovery.
- **SignIn `LabelLink`** — extracted styled-component with `indigo[600]` + `shadow.focus`.
- **PasswordStrengthMeter aria-live** — wrapper `<div role="status" aria-live="polite" aria-atomic="true">`.
- **TosRow combined attestation** — single ESIGN-valid checkbox "I confirm I'm of legal age and agree to Seald's Terms and Privacy Policy."
- **ForgotPassword label** — "Email address" (was "Your work email"); `VerticalSpacer` 110 px above heading on desktop only.
- **AuthCallback watchdog** — 10 s timeout redirecting to `/signin?error=oauth_timeout`; `ERROR_COPY` extended.
- **DebugAuth dev banner** — `warn[50/500/700]` "Developer-only diagnostic page. Not intended for end users."
- **SignIn microcopy** — "Documents you create as a guest stay on this device. Sign up to access them anywhere."
- **SignIn signup placeholder** — "Enter your password".
- **AuthForm name validation `>= 2`.**
- **`index.html` `<meta name="theme-color" content="#F8FAFC">`** — polish for Safari URL bar; existing `<link>` block + cookie-consent script preserved verbatim so PR-6's font `<link>` already merged cleanly.

## Test plan
- [x] `pnpm -r typecheck` / `pnpm --filter web lint` / `pnpm lint:spelling` green
- [x] `pnpm --filter web exec vitest run` — **1615/1615** across 201 files
- [x] React PR review — zero MUST-FIX
- [ ] Post-deploy: SignUp — try clicking the Terms link inside the consent row, confirm it doesn't toggle the checkbox; try Create-account with empty consent, confirm inline error + focus on first failing field; OAuth error → check the banner shows the AlertTriangle icon; `/debug/auth` → 404 / redirect in prod; sign-in flow on a 720-px tablet → wordmark renders at top of form column.

## Coordination
- `apps/web/index.html` touched in two PRs (this one and PR-6 / MOBILE-SEND #259 for the Caveat font `<link>`). PR-6 merged first; this PR's `<meta>` change targets a different line and merges cleanly.
- `AuthProvider` gained `resendSignUpConfirmation`. 14 test files updated to provide a default stub via `renderWithProviders`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)