### PR TITLE
ops(prod-restore): pin APP_PUBLIC_URL + CORS_ORIGIN to canonical prod origin

### DIFF
--- a/.github/workflows/prod-restore.yml
+++ b/.github/workflows/prod-restore.yml
@@ -73,9 +73,31 @@ jobs:
             # (one-time, see PR #feat/aws-secrets-manager runbook).
             printf 'SEALD_API_SECRET_ID=seald-api-prod\n' \
               | sudo tee -a /opt/seald/apps/api/.env >/dev/null
+            # Pin APP_PUBLIC_URL + CORS_ORIGIN to the canonical prod
+            # origin AFTER the secret-write. Mirrors the idempotent
+            # strip-and-re-append from set-app-public-url.yml so a
+            # stale value in the PROD_API_ENV secret (e.g. the
+            # localhost:5173 default from .env.example) can't quietly
+            # bake `http://localhost:5173` into every signing
+            # invitation email + verify QR + audit-trail PDF until an
+            # operator runs the one-shot fix workflow.
+            # Discovered 2026-05-14 chasing localhost links in
+            # prod-sent emails — pre-state showed both keys were
+            # present in `.env` but with wrong values from the secret.
+            sudo grep -vE '^(APP_PUBLIC_URL|CORS_ORIGIN)=' \
+              /opt/seald/apps/api/.env > /tmp/.env.new
+            sudo install -m 0600 /tmp/.env.new /opt/seald/apps/api/.env
+            rm -f /tmp/.env.new
+            {
+              printf 'APP_PUBLIC_URL=https://seald.nromomentum.com\n'
+              printf 'CORS_ORIGIN=https://seald.nromomentum.com\n'
+            } | sudo tee -a /opt/seald/apps/api/.env >/dev/null
             sudo chmod 0600 /opt/seald/apps/api/.env
             sudo wc -c /opt/seald/apps/api/.env
-            # Sanity-check critical keys are present (no values printed).
+            # Sanity-check critical keys are present (no values
+            # printed). APP_PUBLIC_URL + CORS_ORIGIN are pinned above
+            # so they're guaranteed present — listed here only to keep
+            # the contract explicit for future operators.
             for k in DATABASE_URL SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY \
                      PDF_SIGNING_PROVIDER PDF_SIGNING_KMS_KEY_ID \
                      PDF_SIGNING_KMS_REGION PDF_SIGNING_KMS_CERT_PEM_PATH \


### PR DESCRIPTION
## Summary
Adds an idempotent strip-and-re-append of `APP_PUBLIC_URL` and `CORS_ORIGIN` to `prod-restore.yml`, right after the `PROD_API_ENV` secret is written to `/opt/seald/apps/api/.env`. The canonical `https://seald.nromomentum.com` value wins regardless of what's in the secret.

## Why
2026-05-14: a prod-sent email surfaced a localhost link. Trace:
- `prod-restore.yml` last ran 2026-05-10 — wrote `.env` from `PROD_API_ENV` (secret apparently still has the `.env.example` default `APP_PUBLIC_URL=http://localhost:5173`).
- Existing sanity loop only checks the key is *present*, not that the value points at the public origin → bad value silently overwrote the previous `set-app-public-url.yml` fix.
- API was running for 4 days with `APP_PUBLIC_URL=http://localhost:5173`, baking that into every signing-invite email + verify QR + audit-trail PDF generated during that window.

Today's stop-gap was re-running `set-app-public-url.yml` (run 25853047976 — strips + writes the right value, force-recreates the api container; verified healthy at 09:39 UTC). This PR ensures the next `prod-restore` doesn't undo that.

## Test plan
- [x] `actionlint` will run on this YAML change as part of CI
- [ ] Next time `prod-restore.yml` is dispatched, the post-state should show `APP_PUBLIC_URL=https://seald.nromomentum.com` in `/opt/seald/apps/api/.env` regardless of the secret content. Operator can verify with the `wc -c` line + a one-off `sudo grep ^APP_PUBLIC_URL /opt/seald/apps/api/.env`.

## Notes
- The `PROD_API_ENV` secret should still be cleaned up at some point (drop the stale `APP_PUBLIC_URL` / `CORS_ORIGIN` lines from it) — purely belt-and-suspenders, no behavior delta.
- Documents in the audit trail that were sealed during the localhost window have the wrong URL baked into the PDF; only the embedded link is broken — the verify page at `https://seald.nromomentum.com/verify/<short_code>` still works directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)