### PR TITLE
test(web): open opt-out <details> before Decline in SigningPrepPage POM (unblocks main CI)

### DIFF
--- a/apps/web/e2e/pages/SigningPrepPage.ts
+++ b/apps/web/e2e/pages/SigningPrepPage.ts
@@ -19,9 +19,12 @@ export class SigningPrepPage {
   }
 
   async decline(): Promise<void> {
-    // Decline link triggers a native window.confirm() — Playwright
-    // auto-accepts when we register a one-shot dialog handler before
-    // clicking.
+    // PR-4 audit (item 5) moved the destructive opt-out actions into a
+    // collapsed <details> "Need to opt out?" disclosure below the AES
+    // disclosure. Open the disclosure first, then click the actual
+    // decline link — which still triggers a native window.confirm()
+    // (PR-4 only promoted withdraw-consent to a styled dialog).
+    await this.page.getByRole('button', { name: /need to opt out/i }).click();
     this.page.once('dialog', (d) => {
       void d.accept();
     });


### PR DESCRIPTION
## Summary
Main is red on every push: `BDD e2e (web)` + `Playwright Success` fail because two BDD scenarios time out clicking `getByRole('button', { name: /decline this request/i })`. PR-4 (signer-flow audit, #260) moved the Decline / Wrong-recipient / Withdraw-consent buttons into a collapsed `<details>` "Need to opt out?" disclosure on `SigningPrepPage`. The watcher updated `signer-not-me.steps.ts` then but missed the parallel **POM** `SigningPrepPage.decline()` that `signer-decline.steps.ts` consumes.

This patch opens the `<details>` first in the POM, mirroring `signer-not-me.steps.ts`. No production code change.

## Test plan
- [x] Local typecheck clean
- [ ] CI: BDD e2e + Playwright Success → green on this PR (the two regressed scenarios were `signer-decline.feature: Recipient declines from the prep page` and `signer-not-me.feature: Confirming Not me declines and routes to the declined page` — the first uses this POM, the second uses the step file already fixed; this PR closes the gap).

## Why this matters now
Unblocks the 16 open Dependabot PRs — they all run against this baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)