### PR TITLE
chore(test): match pnpm '+' separator in jest transformIgnorePatterns

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -31,7 +31,13 @@ const config: Config = {
   // spec that imports it (jose: auth/JWT verification, faker: test
   // factories, kysely: pg repositories).
   transformIgnorePatterns: [
-    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))',
+    // NOTE: under pnpm, third-party packages live at
+    // `node_modules/.pnpm/<pkg>+<sub>@<ver>/node_modules/<pkg>/<sub>/…`
+    // — note the `+` separator instead of `/`. So an entry like
+    // `@faker-js/faker` MUST be split into a scope-only alternative
+    // (`@faker-js`) for the negative lookahead to match the .pnpm
+    // layout. Same goes for `@react-pdf` and `@pdf-lib` above.
+    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js|kysely))',
   ],
   collectCoverageFrom: ['src/**/*.(t|j)sx?'],
   coverageDirectory: 'coverage',

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -24,13 +24,14 @@ const config: Config = {
   // module`. List the ones the renderer actually touches; if a future
   // dep gets added, add it here too.
   //
-  // `jose` (v6+) and `@faker-js/faker` (v10+) also ship pure-ESM
-  // bundles — Jest's CJS transformer can't load them otherwise, so
-  // they're whitelisted here too. Removing either entry will surface
-  // as `SyntaxError: Unexpected token 'export'` in any spec that
-  // imports it (jose: auth/JWT verification, faker: test factories).
+  // `jose` (v6+), `@faker-js/faker` (v10+), and `kysely` (v0.29+) also
+  // ship pure-ESM bundles — Jest's CJS transformer can't load them
+  // otherwise, so they're whitelisted here too. Removing any entry
+  // will surface as `SyntaxError: Unexpected token 'export'` in every
+  // spec that imports it (jose: auth/JWT verification, faker: test
+  // factories, kysely: pg repositories).
   transformIgnorePatterns: [
-    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker))',
+    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))',
   ],
   collectCoverageFrom: ['src/**/*.(t|j)sx?'],
   coverageDirectory: 'coverage',

--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -23,8 +23,14 @@ const config: Config = {
   // of those crashes with `Cannot use import statement outside a
   // module`. List the ones the renderer actually touches; if a future
   // dep gets added, add it here too.
+  //
+  // `jose` (v6+) and `@faker-js/faker` (v10+) also ship pure-ESM
+  // bundles — Jest's CJS transformer can't load them otherwise, so
+  // they're whitelisted here too. Removing either entry will surface
+  // as `SyntaxError: Unexpected token 'export'` in any spec that
+  // imports it (jose: auth/JWT verification, faker: test factories).
   transformIgnorePatterns: [
-    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib))',
+    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker))',
   ],
   collectCoverageFrom: ['src/**/*.(t|j)sx?'],
   coverageDirectory: 'coverage',

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -9,6 +9,6 @@
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib))"
+    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker))"
   ]
 }

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -9,6 +9,6 @@
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker))"
+    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))"
   ]
 }

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -9,6 +9,6 @@
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))"
+    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js|kysely))"
   ]
 }


### PR DESCRIPTION
## Summary
- The negative-lookahead whitelist in `transformIgnorePatterns` only matched the legacy hoisted layout, not pnpm's `.pnpm/<pkg>+<sub>@<ver>/…` layout.
- Drop the `/sub` suffix on scoped packages so the lookahead matches both layouts (`@faker-js` covers `node_modules/@faker-js/faker/…` and `.pnpm/@faker-js+faker@*/…`).

## Why this PR
Previous fix #273 added `jose`, `@faker-js/faker`, `kysely` to the whitelist but kept the `/faker` slash. Under pnpm, the path on disk is `.pnpm/@faker-js+faker@10.4.0/…` — the `+` separator means `@faker-js/faker` never matches, so the symptom flipped from `Unexpected token 'export'` (no transform) to `Cannot use import statement outside a module` (the inner chunks still skipped and load as raw ESM into Node's CJS runtime).

## Test plan
- [x] `pnpm --filter api test` on main versions (jose@5, faker@9) — 972/972 pass
- [x] `pnpm --filter api test` with `apps/api` switched to jose@6.2.3 + @faker-js/faker@10.4.0 — 972/972 pass (was: 6 suites failing pre-fix)
- [x] `pnpm -r typecheck` clean
- [ ] CI green (auto)
- [ ] After merge: `@dependabot recreate` on #246, #247, #271 so they rebase on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)