### PR TITLE
chore(test): match pnpm '+' separator for @faker-js in jest transformIgnorePatterns

### DIFF
--- a/apps/api/jest.config.ts
+++ b/apps/api/jest.config.ts
@@ -31,7 +31,14 @@ const config: Config = {
   // spec that imports it (jose: auth/JWT verification, faker: test
   // factories, kysely: pg repositories).
   transformIgnorePatterns: [
-    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))',
+    // NOTE: under pnpm, scoped third-party packages live at
+    // `node_modules/.pnpm/<scope>+<name>@<ver>/node_modules/<scope>/<name>/…`
+    // — note the `+` separator between scope and name. So an entry
+    // like `@faker-js/faker` MUST be reduced to the scope-only
+    // `@faker-js` for the negative lookahead to match the .pnpm
+    // layout as well as the hoisted `node_modules/@faker-js/faker`.
+    // Same trick already in use for `@react-pdf` / `@pdf-lib` above.
+    'node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js|kysely))',
   ],
   collectCoverageFrom: ['src/**/*.(t|j)sx?'],
   coverageDirectory: 'coverage',

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -9,6 +9,6 @@
     "^.+\\.(t|j)sx?$": "ts-jest"
   },
   "transformIgnorePatterns": [
-    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js/faker|kysely))"
+    "node_modules/(?!(?:\\.pnpm/)?(?:@react-pdf|yoga-layout|restructure|@babel/runtime|color-name|color-string|simple-swizzle|is-arrayish|hyphen|hyphenation|pdfkit|fontkit|emoji-regex|@pdf-lib|jose|@faker-js|kysely))"
   ]
 }


### PR DESCRIPTION
## Summary
- Under pnpm, scoped third-party packages live at `node_modules/.pnpm/<scope>+<name>@<ver>/…` — note the `+` separator (not `/`).
- Previous fix #273 added `@faker-js/faker` to `transformIgnorePatterns` but the `/faker` slash never matched the .pnpm layout, so the inner ESM `dist/index.js` was still skipped by Jest's transformer.
- Reduce to scope-only `@faker-js` so the negative lookahead matches both layouts. Same shape already used for `@react-pdf` and `@pdf-lib`.

## Why this PR
Dependabot PR #246 (`@faker-js/faker` 9.9.0 → 10.4.0) was failing API unit tests with `SyntaxError: Cannot use import statement outside a module` even after #273. Root cause: the regex matched `node_modules/@faker-js/faker` but not the .pnpm layout where these packages actually live.

This also covers PR #271 (root-prod group) which bumps kysely 0.28→0.29 inside the same group — kysely's `kysely` is already scope-less so it matched before, but the noted approach future-proofs every scoped ESM package.

## Test plan
- [x] `pnpm --filter api test` on main versions (jose@5, faker@9) — 972/972 pass
- [x] `pnpm --filter api test` with apps/api switched to @faker-js/faker@10.4.0 + jose@6.2.3 — 972/972 pass (was: 6 suites failing pre-fix)
- [x] `pnpm -r typecheck` clean
- [ ] CI green (auto)
- [ ] After merge: `@dependabot recreate` on #246 so it rebases on top

🤖 Generated with [Claude Code](https://claude.com/claude-code)