### PR TITLE
test(web): widen SigningDeclinedPage POM to accept all 3 decline-reason headings

### DIFF
--- a/apps/web/e2e/pages/SigningDeclinedPage.ts
+++ b/apps/web/e2e/pages/SigningDeclinedPage.ts
@@ -4,6 +4,17 @@ export class SigningDeclinedPage {
   constructor(private readonly page: Page) {}
 
   async expectVisible(): Promise<void> {
-    await expect(this.page.getByRole('heading', { name: /declined/i })).toBeVisible();
+    // PR-4 (signer-flow audit, #260) branches the H1 on `decline_reason`:
+    //   - default            → "You declined this request."
+    //   - consent-withdrawn  → "You withdrew consent to sign electronically."
+    //   - not-the-recipient  → "Thanks — we marked this link as the wrong recipient."
+    // Match the URL (invariant for the page) and any of the three known
+    // headings — the H1 in any variant must be visible.
+    await expect(this.page).toHaveURL(/\/sign\/[^/]+\/declined/);
+    await expect(
+      this.page.getByRole('heading', {
+        name: /declined this request|withdrew consent|wrong recipient/i,
+      }),
+    ).toBeVisible();
   }
 }


### PR DESCRIPTION
## Summary
PR-4 (#260) branched the declined-page H1 on `snap.decline_reason`:
- default → "You **declined** this request."
- `consent-withdrawn` → "You **withdrew** consent to sign electronically."
- `not-the-recipient` → "Thanks — we marked this link as the wrong recipient."

The POM still asserted `/declined/i`, which matches only the default branch. The `signer-not-me.feature: Confirming Not me declines and routes to the declined page` scenario goes through the `not-the-recipient` path → heading times out → BDD job red.

Fix: assert the URL (`/sign/:id/declined`, invariant across all three reasons) and an H1 matching any of the three known headings. Production code untouched.

## Test plan
- [x] Local typecheck clean
- [ ] CI: `BDD e2e (web)` should go green on this branch