### PR TITLE
fix(landing): hide the mobile-nav drawer by default (was always-visible on desktop)

### DIFF
--- a/apps/landing/src/styles/globals.css
+++ b/apps/landing/src/styles/globals.css
@@ -267,9 +267,13 @@ body {
   transition: transform 160ms var(--ease-standard);
 }
 
-/* Mobile drawer — slides out below the nav. Hidden by default; the
-   JS removes the `hidden` attribute and adds `.open` to animate in. */
+/* Mobile drawer — slides out below the nav. Hidden by default at every
+   viewport; the JS removes the `hidden` attribute and adds `.open`
+   which flips display to `flex`. The HTML `hidden` attribute alone
+   isn't enough because the layout rules below would override it; the
+   explicit `display: none` is what actually hides it. */
 .nav-mobile-drawer {
+  display: none;
   position: absolute;
   top: 100%;
   left: 0;
@@ -277,11 +281,13 @@ body {
   background: var(--paper);
   border-bottom: 1px solid var(--border-1);
   box-shadow: var(--shadow-md);
-  display: flex;
   flex-direction: column;
   padding: 12px 20px 20px;
   gap: 4px;
   z-index: 49;
+}
+.nav-mobile-drawer.open {
+  display: flex;
 }
 .nav-mobile-drawer a {
   padding: 14px 8px;


### PR DESCRIPTION
## Summary
The landing-page mobile nav drawer was rendering at every viewport because `.nav-mobile-drawer` shipped with `display: flex` and no `display: none` fallback — the HTML `hidden` attribute loses to any explicit `display:` rule. The hamburger toggle correctly hides ≥980px, so desktop visitors saw a full mobile menu stacked below the nav with no way to close it.

Fix: default the drawer to `display: none`; the `.open` class (toggled by `landing.js` on hamburger click) flips it to `display: flex`. Toggle still only renders ≤980px.

## Test plan
- [x] `pnpm --filter landing build` clean
- [ ] Post-deploy: open https://seald.nromomentum.com on desktop — no drawer; resize to ≤980px — hamburger appears, click → drawer opens, click link → drawer closes
EOF
)