### PR TITLE
fix(web): render signing PDF at devicePixelRatio for retina sharpness

### DIFF
--- a/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.test.tsx
+++ b/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.test.tsx
@@ -1,7 +1,30 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { waitFor } from '@testing-library/react';
 import { axe } from 'vitest-axe';
 import { renderWithTheme } from '../../test/renderWithTheme';
 import { DocumentPageCanvas } from './DocumentPageCanvas';
+
+const pdfMock = vi.hoisted(() => {
+  type Viewport = { width: number; height: number };
+  const render = vi.fn().mockReturnValue({ promise: Promise.resolve() });
+  const getViewport = vi.fn(
+    ({ scale }: { scale: number }): Viewport => ({
+      width: 800 * scale,
+      height: 1000 * scale,
+    }),
+  );
+  const getPage = vi.fn().mockResolvedValue({ getViewport, render });
+  return {
+    render,
+    getViewport,
+    getPage,
+    useResult: { doc: { getPage }, numPages: 1, loading: false, error: null },
+  };
+});
+
+vi.mock('@/lib/pdf', () => ({
+  usePdfDocument: () => pdfMock.useResult,
+}));
 
 describe('DocumentPageCanvas', () => {
   it('renders the title and page tag', () => {
@@ -53,5 +76,74 @@ describe('DocumentPageCanvas', () => {
     const { container } = renderWithTheme(<DocumentPageCanvas pageNum={1} totalPages={1} />);
     const page = container.querySelector('[data-r-page="1"]');
     expect(page?.getAttribute('data-pdf-mode')).toBe('false');
+  });
+
+  // Regression: on retina (dpr ≥ 2) the canvas backing store was sized at
+  // CSS pixels, so the browser upscaled the rasterised page and signing
+  // text rendered blurry. The fix scales the viewport by devicePixelRatio
+  // (capped at 2) so the bitmap is 1:1 with device pixels.
+  describe('retina-sharp render', () => {
+    const originalDpr = window.devicePixelRatio;
+
+    beforeEach(() => {
+      pdfMock.getPage.mockClear();
+      pdfMock.getViewport.mockClear();
+      pdfMock.render.mockClear();
+    });
+
+    afterEach(() => {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        value: originalDpr,
+        configurable: true,
+      });
+    });
+
+    function setDpr(value: number): void {
+      Object.defineProperty(window, 'devicePixelRatio', {
+        value,
+        configurable: true,
+      });
+    }
+
+    it('renders at scale × dpr on a 2× display', async () => {
+      setDpr(2);
+      const { container } = renderWithTheme(
+        <DocumentPageCanvas pageNum={1} totalPages={1} pdfSrc="x.pdf" width={560} />,
+      );
+      await waitFor(() => expect(pdfMock.render).toHaveBeenCalled());
+
+      const canvas = container.querySelector('canvas');
+      expect(canvas).not.toBeNull();
+      // baseScale = 560 / 800 = 0.7; with dpr=2 the canvas bitmap is 0.7×2×800 = 1120
+      expect(canvas?.width).toBe(1120);
+      expect(canvas?.height).toBe(1400);
+
+      const lastCall = pdfMock.getViewport.mock.calls.at(-1)?.[0];
+      expect(lastCall?.scale).toBeCloseTo(1.4, 5);
+    });
+
+    it('caps dpr at 2 even on a 3× display', async () => {
+      setDpr(3);
+      const { container } = renderWithTheme(
+        <DocumentPageCanvas pageNum={1} totalPages={1} pdfSrc="x.pdf" width={560} />,
+      );
+      await waitFor(() => expect(pdfMock.render).toHaveBeenCalled());
+
+      const canvas = container.querySelector('canvas');
+      expect(canvas?.width).toBe(1120);
+      expect(canvas?.height).toBe(1400);
+    });
+
+    it('falls back to scale × 1 on a non-retina display', async () => {
+      setDpr(1);
+      const { container } = renderWithTheme(
+        <DocumentPageCanvas pageNum={1} totalPages={1} pdfSrc="x.pdf" width={560} />,
+      );
+      await waitFor(() => expect(pdfMock.render).toHaveBeenCalled());
+
+      const canvas = container.querySelector('canvas');
+      expect(canvas?.width).toBe(560);
+      expect(canvas?.height).toBe(700);
+    });
   });
 });

--- a/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.test.tsx
+++ b/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.test.tsx
@@ -84,14 +84,20 @@ describe('DocumentPageCanvas', () => {
   // (capped at 2) so the bitmap is 1:1 with device pixels.
   describe('retina-sharp render', () => {
     const originalDpr = window.devicePixelRatio;
+    // jsdom returns null from canvas.getContext('2d') by default, which makes
+    // the component bail before calling page.render(). Stub it with a no-op
+    // 2D context so the render path actually runs.
+    const fakeCtx = {} as CanvasRenderingContext2D;
 
     beforeEach(() => {
       pdfMock.getPage.mockClear();
       pdfMock.getViewport.mockClear();
       pdfMock.render.mockClear();
+      vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation(() => fakeCtx);
     });
 
     afterEach(() => {
+      vi.restoreAllMocks();
       Object.defineProperty(window, 'devicePixelRatio', {
         value: originalDpr,
         configurable: true,

--- a/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.tsx
+++ b/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.tsx
@@ -64,7 +64,7 @@ export const DocumentPageCanvas = forwardRef<HTMLDivElement, DocumentPageCanvasP
           const page = await doc.getPage(pageNum);
           if (cancelled) return;
           // Retina-sharp render: backing store at CSS px × devicePixelRatio
-          // so a 560 CSS-px canvas rasterizes at 1120 device px on a 2×
+          // so a 560 CSS-px canvas renders at 1120 device px on a 2×
           // display instead of being browser-upscaled (which produced the
           // soft-text we shipped before this fix). Cap dpr at 2 — 3× phones
           // pay 9× memory + render cost for ~no perceived quality gain.

--- a/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.tsx
+++ b/apps/web/src/components/DocumentPageCanvas/DocumentPageCanvas.tsx
@@ -63,8 +63,17 @@ export const DocumentPageCanvas = forwardRef<HTMLDivElement, DocumentPageCanvasP
         try {
           const page = await doc.getPage(pageNum);
           if (cancelled) return;
-          const scale = width / page.getViewport({ scale: 1 }).width;
-          const viewport = page.getViewport({ scale });
+          // Retina-sharp render: backing store at CSS px × devicePixelRatio
+          // so a 560 CSS-px canvas rasterizes at 1120 device px on a 2×
+          // display instead of being browser-upscaled (which produced the
+          // soft-text we shipped before this fix). Cap dpr at 2 — 3× phones
+          // pay 9× memory + render cost for ~no perceived quality gain.
+          // The `width: 100%; height: auto` rule on `PdfCanvas` (see
+          // .styles.ts) keeps the CSS box at `width` px wide and lets the
+          // browser downscale the larger backing store to fit.
+          const dpr = Math.min(typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1, 2);
+          const baseScale = width / page.getViewport({ scale: 1 }).width;
+          const viewport = page.getViewport({ scale: baseScale * dpr });
           const canvas = canvasRef.current;
           if (!canvas) return;
           const ctx = canvas.getContext('2d');


### PR DESCRIPTION
## Summary

The signing fill page rendered the PDF page at a CSS-pixel-sized canvas
backing store, so on retina displays (dpr ≥ 2) the browser upscaled the
rasterised bitmap to physical pixels and signing text rendered visibly
soft / pixelated.

- Scale pdfjs's viewport by \`devicePixelRatio\` (capped at 2 so 3× phones
  don't pay 9× memory + render cost) so the canvas bitmap is 1:1 with
  device pixels.
- The existing \`width: 100%; height: auto\` CSS on \`PdfCanvas\` keeps the
  CSS box at \`width\` px wide and lets the browser downscale the larger
  backing store cleanly — no styles change needed.
- Regression tests assert \`canvas.width === cssWidth × dpr\` for dpr=1/2/3
  (verified RED on pre-fix code, GREEN after).

## Test plan

- [x] \`pnpm --filter web typecheck\` green
- [x] \`pnpm --filter web lint\` green (scoped to changed files)
- [x] \`pnpm --filter web test\` 1714/1714 green, incl. 3 new retina-render specs
- [x] New regression assertions confirmed RED on pre-fix code
- [ ] Post-deploy: re-verify on https://seald.nromomentum.com on a 2× display — sign-fill page text should appear crisp at 100% zoom